### PR TITLE
Use IndexWriter.getDocStats() instead of IndexWriter.maxDoc()

### DIFF
--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -336,7 +336,7 @@ public class SearchPerfTest {
         });
       
       writer = new IndexWriter(dir, iwc);
-      System.out.println("Initial writer.maxDoc()=" + writer.maxDoc());
+      System.out.println("Initial writer.maxDoc=" + writer.getDocStats().maxDoc);
 
       // TODO: add -nrtBodyPostingsOffsets instead of
       // hardwired false:
@@ -378,18 +378,18 @@ public class SearchPerfTest {
                 IndexSearcher s = mgr.acquire();
                 try {
                   if (ramDir != null) {
-                    System.out.println(String.format(Locale.ENGLISH, "%.1fs: index: %d bytes in RAMDir; writer.maxDoc()=%d; searcher.maxDoc()=%d; searcher.numDocs()=%d",
+                    System.out.println(String.format(Locale.ENGLISH, "%.1fs: index: %d bytes in RAMDir; writer.maxDoc=%d; searcher.maxDoc()=%d; searcher.numDocs()=%d",
                                                      (System.currentTimeMillis() - startMS)/1000.0, ramDir.ramBytesUsed(),
-                                                     writer.maxDoc(), s.getIndexReader().maxDoc(), s.getIndexReader().numDocs()));
+                                                     writer.getDocStats().maxDoc, s.getIndexReader().maxDoc(), s.getIndexReader().numDocs()));
                     //String[] l = ramDir.listAll();
                     //Arrays.sort(l);
                     //for(String f : l) {
                     //System.out.println("  " + f + ": " + ramDir.fileLength(f));
                     //}
                   } else {
-                    System.out.println(String.format(Locale.ENGLISH, "%.1fs: done reopen; writer.maxDoc()=%d; searcher.maxDoc()=%d; searcher.numDocs()=%d",
+                    System.out.println(String.format(Locale.ENGLISH, "%.1fs: done reopen; writer.maxDoc=%d; searcher.maxDoc()=%d; searcher.numDocs()=%d",
                                                      (System.currentTimeMillis() - startMS)/1000.0,
-                                                     writer.maxDoc(), s.getIndexReader().maxDoc(),
+                                                     writer.getDocStats().maxDoc, s.getIndexReader().maxDoc(),
                                                      s.getIndexReader().numDocs()));
                   }
                 } finally {


### PR DESCRIPTION
IndexWriter.maxDoc() has been deprecated in 7.7 and remove in master(8.0)
Instead getDocStats should be used.