### PR TITLE
Introduce Analytical Benchmarking and Metrics

### DIFF
--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -207,6 +207,7 @@ class Competitor(object):
                hiliteImpl = 'FastVectorHighlighter',
                pk = True,
                loadStoredFields = False,
+               concurrentSegReads = False,
                javacCommand = constants.JAVAC_EXE):
     self.name = name
     self.checkout = checkout
@@ -227,6 +228,7 @@ class Competitor(object):
     self.pk = pk
     self.loadStoredFields = loadStoredFields
     self.javacCommand = javacCommand
+    self.concurrentSegReads = concurrentSegReads
 
   def compile(self, cp):
     root = benchUtil.checkoutToUtilPath(self.checkout)

--- a/src/python/example.py
+++ b/src/python/example.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import competition
+import sys
 
 # simple example that runs benchmark with WIKI_MEDIUM source and taks files 
 # Baseline here is ../trunk versus ../patch
@@ -24,16 +25,24 @@ if __name__ == '__main__':
   comp =  competition.Competition()
 
   index = comp.newIndex('trunk', sourceData)
+
+  // Warning -- Do not break the order of arguments
+  // TODO -- Fix the following by using argparser
+  if len(sys.argv) > 3 and sys.argv[3] == '-concurrentSegReads':
+    concurrentSegmentReads = True
+  else:
+    concurrentSegmentReads = False
+
   # create a competitor named baseline with sources in the ../trunk folder
   comp.competitor('baseline', 'trunk',
-                  index = index)
+                  index = index, concurrentSegReads = concurrentSegmentReads)
 
   # use the same index here
   # create a competitor named my_modified_version with sources in the ../patch folder
   # note that we haven't specified an index here, luceneutil will automatically use the index from the base competitor for searching 
   # while the codec that is used for running this competitor is taken from this competitor.
   comp.competitor('my_modified_version', 'patch',
-                  index = index)
+                  index = index, concurrentSegReads = concurrentSegmentReads)
 
   # start the benchmark - this can take long depending on your index and machines
   comp.benchmark("trunk_vs_patch")

--- a/src/python/sendTasks.py
+++ b/src/python/sendTasks.py
@@ -139,6 +139,7 @@ class SendTasks:
     queueTimeStats = RollingStats(100)
     totalTimeStats = RollingStats(100)
     actualQPSStats = RollingStats(5)
+    latenciesInMS = []
     
     while True:
       result = ''
@@ -167,6 +168,7 @@ class SendTasks:
       latencyMS = (endTime-taskStartTime)*1000
       queueTimeStats.add(queueTimeMS)
       totalTimeStats.add(latencyMS)
+      latenciesInMS.append(latencyMS)
       self.results.add(taskString.strip(),
                        totalHitCount,
                        taskStartTime-startTime,
@@ -178,6 +180,14 @@ class SendTasks:
         pctDone = 100.0*(now - startTime) / self.runTimeSec
         if pctDone > 100.0:
           pctDone = 100.0
+
+        latenciesInMS.sort()
+
+        self.out.write('p0: ' + str(latenciesInMS[0]))
+        self.out.write('p50: ' + str(latenciesInMS[(len(latenciesInMS)-1)/2]))
+        self.out.write('p90: ' + str(times[int((len(latenciesInMS)-1)*0.9)]))
+        self.out.write('p100: ' + str(times[len(latenciesInMS)-1]))
+
         self.out.write('%6.1f s: %5.1f%%: %5.1f qps in; %5.1f qps out; %6.1f/%6.1f ms [%d, %d]\n' % \
                        (now - startTime, pctDone,
                         self.taskID/(now-startTime),


### PR DESCRIPTION
We do not have functionality to control and run concurrent reads
functionality within Lucene today, and with the ongoing effort
to extend that functionality, it is important to have a generic
benchmark which enabled this benchmarking. Also, we do not calculate
P50, P90 and P100 metrics which are useful for analytical queries.
This commit introduces these functionalities