### PR TITLE
Group tasks by category when search threads > 1

### DIFF
--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -518,7 +518,8 @@ public class SearchPerfTest {
       // Load the tasks from a file:
       final int taskRepeatCount = args.getInt("-taskRepeatCount");
       final int numTaskPerCat = args.getInt("-tasksPerCat");
-      tasks = new LocalTaskSource(indexState, taskParser, tasksFile, staticRandom, random, numTaskPerCat, taskRepeatCount, doPKLookup);
+      boolean groupByCat = searchThreadCount > 1;
+      tasks = new LocalTaskSource(indexState, taskParser, tasksFile, staticRandom, random, numTaskPerCat, taskRepeatCount, doPKLookup, groupByCat);
       System.out.println("Task repeat count " + taskRepeatCount);
       System.out.println("Tasks file " + tasksFile);
       System.out.println("Num task per cat " + numTaskPerCat);


### PR DESCRIPTION
I found that when running with SEARCH_TASKS > 1, "expensive" tasks were stealing threads from "cheap" tasks making results meaningless; basically all tasks would appear to have the same QPS. This change groups the (shuffled, repeated) tasks by category before executing them. There would probably still be a little bit of overlap at the boundaries between one run of tasks and the next, but I see dramatically more repeatable results now