### PR TITLE
Index points to benchmark sort optimization

### DIFF
--- a/src/main/perf/LineFileDocs.java
+++ b/src/main/perf/LineFileDocs.java
@@ -1,3 +1,4 @@
+
 package perf;
 
 /**
@@ -299,8 +300,10 @@ public class LineFileDocs implements Closeable {
     final Field titleDV;
     final Field monthDV;
     final Field dayOfYearDV;
+    final IntPoint dayOfYearIP;
     final BinaryDocValuesField titleBDV;
     final NumericDocValuesField lastModNDV; 
+    final LongPoint lastModLP;
     final Field body;
     final Field id;
     final Field idPoint;
@@ -333,18 +336,24 @@ public class LineFileDocs implements Closeable {
 
       	lastModNDV = new NumericDocValuesField("lastModNDV", -1);
       	doc.add(lastModNDV);
+	lastModLP = new LongPoint("lastModNDV", -1); //points field must have the same name and value as DV field
+	doc.add(lastModLP);
 
         monthDV = new SortedDocValuesField("monthSortedDV", new BytesRef(""));
       	doc.add(monthDV);
-        
-        dayOfYearDV = new NumericDocValuesField("dayOfYearNumericDV", 0);
-      	doc.add(dayOfYearDV);
+	
+	dayOfYearDV = new NumericDocValuesField("dayOfYearNumericDV", 0);
+	doc.add(dayOfYearDV);
+	dayOfYearIP = new IntPoint("dayOfYearNumericDV", 0); //points field must have the same name and value as DV field
+	doc.add(dayOfYearIP);
       } else {
       	titleDV = null;
         titleBDV = null;
       	lastModNDV = null;
+	lastModLP = null;
         monthDV = null;
         dayOfYearDV = null;
+	dayOfYearIP = null;
       }
       
       titleTokenized = new Field("titleTokenized", "", TextField.TYPE_STORED);
@@ -533,6 +542,7 @@ public class LineFileDocs implements Closeable {
       doc.titleTokenized.setStringValue(title);
       doc.monthDV.setBytesValue(new BytesRef(months[doc.dateCal.get(Calendar.MONTH)]));
       doc.dayOfYearDV.setLongValue(doc.dateCal.get(Calendar.DAY_OF_YEAR));
+      doc.dayOfYearIP.setIntValue(doc.dateCal.get(Calendar.DAY_OF_YEAR));
     }
     doc.id.setStringValue(intToID(myID));
 
@@ -540,6 +550,7 @@ public class LineFileDocs implements Closeable {
 
     if (addDVFields) {
       doc.lastModNDV.setLongValue(msecSinceEpoch);
+      doc.lastModLP.setLongValue(msecSinceEpoch);
     }
 
     doc.timeSec.setIntValue(timeSec);

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -168,7 +168,7 @@ class SearchTask:
           print('WARNING: expandedTermCounts differ for %s: %s vs %s' % (self, self.expandedTermCount, other.expandedTermCount))
           # self.fail('wrong expandedTermCount: %s vs %s' % (self.expandedTermCount, other.expandedTermCount))
 
-      if False and self.hitCount != other.hitCount:
+      if verifyCounts and self.hitCount != other.hitCount:
         self.fail('wrong hitCount: %s vs %s' % (self.hitCount, other.hitCount))
 
       if len(self.hits) != len(other.hits):

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -140,7 +140,7 @@ class SearchTask:
           print 'WARNING: expandedTermCounts differ for %s: %s vs %s' % (self, self.expandedTermCount, other.expandedTermCount)
           # self.fail('wrong expandedTermCount: %s vs %s' % (self.expandedTermCount, other.expandedTermCount))
 
-      if verifyCounts and self.hitCount != other.hitCount:
+      if False and self.hitCount != other.hitCount:
         self.fail('wrong hitCount: %s vs %s' % (self.hitCount, other.hitCount))
 
       if len(self.hits) != len(other.hits):

--- a/tasks/wikimedium.10M.nostopwords.tasks
+++ b/tasks/wikimedium.10M.nostopwords.tasks
@@ -13647,6 +13647,13 @@ HighTermDayOfYearSort: dayofyeardvsort//government # freq=384004
 HighTermDayOfYearSort: dayofyeardvsort//27 # freq=383042
 HighTermDayOfYearSort: dayofyeardvsort//old # freq=381809
 
+
+TermDateTimeSort: lastmodndvsort//0 # freq=708472
+TermDateTimeSort: lastmodndvsort//names # freq=402762
+TermDateTimeSort: lastmodndvsort//nbsp # freq=492778
+TermDateTimeSort: lastmodndvsort//part # freq=588644
+TermDateTimeSort: lastmodndvsort//st # freq=306811
+
 HighTermMonthSort: monthdvsort//ref # freq=3793973
 HighTermMonthSort: monthdvsort//http # freq=3493581
 HighTermMonthSort: monthdvsort//from # freq=3224339


### PR DESCRIPTION
Sort optimization introduced in https://github.com/apache/lucene-solr/pull/1351
depends on numeric fields being indexed both as doc_values and points.

This PR does the following:
- add a LongPoint field – lastModLP, last modified timestamp
- add an IntPoint field – dayOfYearIP, day of the year of the last modified timestamp
- add sort on the last modified timestamp to wikimedium.10M.nostopwords.tasks
- don't fail a task if hitCounts don't match in benchUtil.py. As we
don't collect all hits in the optimized runs, we don't expect hits total
to match.