### PR TITLE
Update hppc artifact version to 0.8.2

### DIFF
--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -966,12 +966,12 @@ class RunAlgs:
     found = False
     for root_path, dirs, files in os.walk(os.path.expanduser('~/.gradle/caches/modules-2/files-2.1/com.carrotsearch/hppc')):
       for file in files:
-        if file == 'hppc-0.8.1.jar':
+        if file == 'hppc-0.8.2.jar':
           cp.append('%s/%s' % (root_path, file))
           found = True
 
     if not found:
-      raise RuntimeError('unable to locate hppc-0.8.1.jar dependency for lucene/facet!')
+      raise RuntimeError('unable to locate hppc-0.8.2.jar dependency for lucene/facet!')
 
     # so perf.* is found:
     lib = os.path.join(checkoutToUtilPath(checkout), "lib")


### PR DESCRIPTION
In https://github.com/apache/lucene-solr/commit/2991acf8fffe9dbeda20c24479b108bfb8ea9257#diff-0a9e963d0e9ba82d79db98b8903b5c56, hppc version was upgraded to 0.8.2, so this tool also should refer hppc-0.8.2 since it fails with the latest Lucne master.

Compiling log message:
```
RuntimeError: unable to locate hppc-0.8.1.jar dependency for lucene/facet!
```

It would be preferable not to hard-code the correct artifact version though, we'd need to fix it manually for the moment (?)
