### PR TITLE
Fix a bug benchUtil.run() method 

### DIFF
--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -726,7 +726,7 @@ def run(cmd, logFile=None, indent='    '):
     out = open(logFile, 'wb')
   else:
     out = subprocess.STDOUT
-  p = subprocess.Popen(shlex.split(cmd), shell=False, stdout=out, stdin=subprocess.PIPE, stderr=out)
+  p = subprocess.Popen(shlex.split(cmd), shell=False, stdout=out, stderr=out, close_fds=True)
   if p.wait():
     if logFile is not None and os.path.getsize(logFile) < 50*1024:
       print(open(logFile).read())

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -34,6 +34,7 @@ import signal
 import QPSChart
 import IndexChart
 import subprocess
+import shlex
 
 PYTHON_MAJOR_VER = sys.version_info.major
 
@@ -725,7 +726,7 @@ def run(cmd, logFile=None, indent='    '):
     out = open(logFile, 'wb')
   else:
     out = subprocess.STDOUT
-  p = subprocess.Popen(cmd.split(), shell=False, stdout=out, stderr=out, close_fds=True)
+  p = subprocess.Popen(shlex.split(cmd), shell=False, stdout=out, stdin=subprocess.PIPE, stderr=out)
   if p.wait():
     if logFile is not None and os.path.getsize(logFile) < 50*1024:
       print(open(logFile).read())


### PR DESCRIPTION
@mikemccand I'm sorry I broke `benchUtil.py` with #72 !

`shlex.split()` should be used instead of `str.split()` when passing the command to Popen, otherwise some commands (e.g. invoking `javac`) will fail.