### PR TITLE
Add tool to download and create the ja-wiki-2020620 line docs file

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This one is different and self-contained. Read the command-line examples at the 
 
 # Creating line doc file from an arbitrary Wikimedia dump data
 
-You can create your own line doc file from an arbitrary Wikimedia dump by following steps.
+You can create your own line doc file from an arbitrary Wikimedia dump by following steps.  Note that the `src/python/createJapaneseWikipediaLineDocsFile.py` helper tool does these steps:
 
 1. Download Wikimedia dump (XML) from https://dumps.wikimedia.org/ and decompress it on `$YOUR_DATA_DIR`.
 
@@ -98,14 +98,21 @@ You can create your own line doc file from an arbitrary Wikimedia dump by follow
     cat /data/jawiki/jawiki-20200620-pages-articles-multistream.xml | python -u src/python/WikipediaExtractor.py -b102400m -o /data/jawiki
     ```
 
-4. Combine the outputs of 2. and 3. by running `src/python/combineWikiFiles.py`.
+4a. Combine the outputs of 2. and 3. by running `src/python/combineWikiFiles.py`.
 
     e.g.:
     ```
     python src/python/combineWikiFiles.py /data/jawiki/jawiki-20200620-text.txt /data/jawiki/AA/wiki_00 /data/jawiki/jawiki-20200620-lines.txt
     ```
 
-5. (Optional) You may want to extract text attributes only.
+4b. (Optional) If you want to strip all but the last three columns from the combined file, pass the `-only-three-columns` to combineWikiFiles.py:
+
+    e.g.:
+    ```
+    python src/python/combineWikiFiles.py /data/jawiki/jawiki-20200620-text.txt /data/jawiki/AA/wiki_00 /data/jawiki/jawiki-20200620-lines.txt -only-three-columns
+    ```
+
+    Alternatively, use the Unix `cut` tool:
 
     ```
     # extract titie, timestamp and body text

--- a/src/python/WikipediaExtractor.py
+++ b/src/python/WikipediaExtractor.py
@@ -343,6 +343,7 @@ def clean(text):
 
     # Expand links
     text = wikiLink.sub(make_anchor_tag, text)
+
     # Drop all remaining ones
     text = parametrizedLink.sub('', text)
 
@@ -409,6 +410,7 @@ def clean(text):
     text = re.sub(u'(\[\(Â«) ', r'\1', text)
     text = re.sub(r'\n\W+?\n', '\n', text) # lines with only punctuations
     text = text.replace(',,', ',').replace(',.', '.')
+
     return text
 
 section = re.compile(r'(==+)\s*(.*?)\s*\1')
@@ -647,8 +649,9 @@ def main():
             print >> sys.stderr, 'Could not create: ', output_dir
             return
 
-    output_splitter = OutputSplitter(compress, sys.maxint, file_size, output_dir)
-    process_data(sys.stdin, output_splitter)
+    output_splitter = OutputSplitter(compress, file_size, output_dir)
+    # use sys.stdin.buffer to get binary (utf-8) reads:
+    process_data(sys.stdin.buffer, output_splitter)
     output_splitter.close()
 
 if __name__ == '__main__':

--- a/src/python/combineWikiFiles.py
+++ b/src/python/combineWikiFiles.py
@@ -1,5 +1,6 @@
 import sys
 import re
+import string
 
 # Takes plain text output from WikipediaExtractor, and a previously
 # created line file, and just replaces body text with the clean
@@ -20,7 +21,7 @@ f2 = open(sys.argv[2], 'r')
 fOut = open(sys.argv[3], 'w')
 
 if onlyThreeColumns:
-  tup = line.strip().split('\t')
+  tup = line.strip(string.whitespace).split('\t')
   tup = tup[:3]
   line = '\t'.join(tup) + '\n'
 
@@ -36,10 +37,10 @@ while True:
   if l1 == '':
     break
 
-  tup = l1.strip().split('\t')
+  tup = l1.strip(string.whitespace).split('\t')
   #print tup[0]
   
-  l2 = f2.readline().strip()
+  l2 = f2.readline().strip(string.whitespace)
   if not l2.startswith('<doc id'):
     raise RuntimeError('unexpected line: %s' % l2)
 
@@ -60,7 +61,8 @@ while True:
     l2 = f2.readline()
     if l2.startswith('</doc>'):
       break
-    l.append(l2.strip())
+    # strip only ascii whitespace:
+    l.append(l2.strip(string.whitespace))
 
   text = ' '.join(l)
 
@@ -100,7 +102,7 @@ while True:
   prefix = title + ' ' + PARAGRAPH_SEP
   if text.startswith(prefix):
     #print 'strip...'
-    text = text[len(prefix):].strip()
+    text = text[len(prefix):].strip(string.whitespace)
     tup[2] = text
 
   if onlyThreeColumns:

--- a/src/python/runAnalyzerPerf.py
+++ b/src/python/runAnalyzerPerf.py
@@ -21,6 +21,10 @@ LUCENE_ROOT = '/l/trunk.analyzers.nightly/lucene'
 LOGS_ROOT = os.path.join(constants.LOGS_DIR, 'analyzers')
 LOGS_JA_ROOT = os.path.join(constants.LOGS_DIR, 'analyzers_ja')
 
+for path in (LOGS_ROOT, LOGS_JA_ROOT):
+  if not os.path.exists(path):
+    os.makedirs(path)
+
 def run(cmd):
   print('RUN: %s' % cmd)
   if os.system(cmd):
@@ -38,7 +42,7 @@ print('\n%s' % ymd)
 run('git clean -xfd')
 run('git pull origin master')
 print('Compile...')
-run('ant clean compile > compile.log 2>&1')
+run('../gradlew clean compileJava > compile.log 2>&1')
 
 logFile = '%s/%s.log' % (LOGS_ROOT, ymd)
 logFileJa = '%s/%s.log' % (LOGS_JA_ROOT, ymd)
@@ -59,14 +63,14 @@ with open(logFileJa + '.tmp', 'w') as lf:
   lf.write('java version: %s\n' % os.popen('java -fullversion 2>&1').read().strip())
   os.chdir(LUCENE_ROOT)
 
-run('javac -d %s/build -cp build/core/classes/java:build/analysis/common/classes/java:build/analysis/kuromoji/classes/java %s/src/main/perf/TestAnalyzerPerf.java' % (constants.BENCH_BASE_DIR, constants.BENCH_BASE_DIR))
+run('javac -d %s/build -cp core/build/classes/java/main:analysis/common/build/classes/java/main:analysis/kuromoji/build/classes/java/main %s/src/main/perf/TestAnalyzerPerf.java' % (constants.BENCH_BASE_DIR, constants.BENCH_BASE_DIR))
 
 print('  now run en perf')
-run('java -XX:+UseParallelGC -cp %s/build:build/core/classes/java:build/analysis/common/classes/java:build/analysis/kuromoji/classes/java perf.TestAnalyzerPerf /l/data/enwiki-20130102-lines.txt >> %s.tmp 2>&1' % (constants.BENCH_BASE_DIR, logFile))
+run('java -XX:+UseParallelGC -cp %s/build:core/build/classes/java/main:analysis/common/build/classes/java/main:analysis/kuromoji/build/classes/java/main perf.TestAnalyzerPerf /l/data/enwiki-20130102-lines.txt >> %s.tmp 2>&1' % (constants.BENCH_BASE_DIR, logFile))
 os.rename(logFile+'.tmp', logFile)
 print('  done en ')
 
 print('  now run ja')
-run('java -XX:+UseParallelGC -cp %s/build:build/core/classes/java:build/analysis/common/classes/java:build/analysis/kuromoji/classes/java perf.TestAnalyzerPerf /l/data/jawiki-20200620-lines.txt ja >> %s.tmp 2>&1' % (constants.BENCH_BASE_DIR, logFileJa))
+run('java -XX:+UseParallelGC -cp %s/build:core/build/classes/java/main:analysis/common/build/classes/java/main:analysis/kuromoji/build/classes/java/main:analysis/kuromoji/src/resources perf.TestAnalyzerPerf /l/data/jawiki-20200620-lines.txt ja >> %s.tmp 2>&1' % (constants.BENCH_BASE_DIR, logFileJa))
 os.rename(logFileJa+'.tmp', logFileJa)
 print('  done ja')

--- a/src/python/wikiXMLToText.py
+++ b/src/python/wikiXMLToText.py
@@ -12,7 +12,6 @@ import random
 
 # Removes lines like [[wa:Finlande]]
 #reOtherLangs = re.compile(r'^\[\[.*?:.*?\]\]$', re.MULTILINE)
-utf8Encoder = codecs.getencoder('UTF8')
 
 reCategory = re.compile(r'\[\[Category:(.*?)\]\]')
 reFile = re.compile(r'\[\[File:(.*?)\]\]')
@@ -20,9 +19,6 @@ reSection = re.compile('^==([^=]*?)==$', re.MULTILINE)
 reSubSection = re.compile('^===([^=]*?)===$', re.MULTILINE)
 reSubSubSection = re.compile('^====([^=]*?)====$', re.MULTILINE)
 reRef = re.compile('<ref>.*?</ref>')
-
-def toUTF8(s):
-  return utf8Encoder(s)[0]
 
 def extractAttrs(text, attrs):
   attrs['characterCount'] = str(len(text))
@@ -39,8 +35,8 @@ class AllText:
     self.allText = []
 
   def start(self, name):
-    print
-    print 'TEXT: %s' % name
+    print('')
+    print('TEXT: %s' % name)
     self.text = []
     self.name = name
     self.len = 0
@@ -54,7 +50,7 @@ class AllText:
     self.allText[-1][1].append(text)
     t = time.time()
     if t - self.lastPrintTime > 5.0:
-      print '  %.1f MB...' % (self.len/1024./1024.)
+      print('  %.1f MB...' % (self.len/1024./1024.))
       self.lastPrintTime = t
 
   def finish(self, mb):
@@ -88,7 +84,7 @@ def convert(fIn, fOut):
   context = iter(context)
 
   # get the root element
-  event, root = context.next()
+  event, root = context.__next__()
 
   isRedirect = False
   count = 0
@@ -123,16 +119,16 @@ def convert(fIn, fOut):
         fOut.write('\t'.join(atts))
         fOut.write('\n')
         if False:
-          print '%s' % attrs['title']
-          print '  username: %s' % attrs['username']
-          print '  cats: %s' % attrs['categories']
-          print '  charCount: %s' % attrs['characterCount']
-          print '  imageCount: %s' % attrs['imageCount']
-          print '  sections: %s' % attrs['sectionCount']
-          print '  refs: %s' % attrs['refCount']
+          print('%s' % attrs['title'])
+          print('  username: %s' % attrs['username'])
+          print('  cats: %s' % attrs['categories'])
+          print('  charCount: %s' % attrs['characterCount'])
+          print('  imageCount: %s' % attrs['imageCount'])
+          print('  sections: %s' % attrs['sectionCount'])
+          print('  refs: %s' % attrs['refCount'])
         count += 1
         if count % 100000 == 0:
-          print '%d...' % count
+          print('%d...' % count)
         
       attrs = newAttrs(*('timestamp', 'text', 'title', 'username'))
       isRedirect = False
@@ -153,10 +149,10 @@ def convert(fIn, fOut):
     # Else massive memory leak:
     root.clear()
 
-  print '%d articles extracted' % count
+  print('%d articles extracted' % count)
 
 def get(attrs, *names):
-  return [toUTF8(attrs[x]) for x in names]
+  return [attrs[x] for x in names]
 
 def newAttrs(*names):
   return dict((att, '') for att in names)


### PR DESCRIPTION
I worked through the tricky steps from https://github.com/mikemccand/luceneutil/pull/69 to build a new line-docs-file for the newly added Kuromoji analyzers benchmark, and got it working in a new tool, `createJapaneseWikipediaLineDocsFile.py`.

I also had to make a few more python3 fixes to the dependent tools `WikipediaExtractor.py` and `wikiXMLToText.py` to get the whole script working under python 3.8.

It works, and produces a line docs file in the end, and I'm able to `runAnalzyersPerf.py` using it, but the problem is that the file I got in the end ([copied here](http://home.apache.org/~mikemccand/new-jawiki-20200620-lines.txt.lzma) is larger (~2.9 GB) than the one from https://github.com/mikemccand/luceneutil/pull/69 (~2.5 GB, [copied here](http://home.apache.org/~mikemccand/jawiki-20200620-lines.txt.lzma)).

So I think there is a bug either in my tool, my changes here, or in how I executed the steps.

Here's the difference in the first document:

original line docs file:

```
アンパサンド    07-Jun-2020 10:25:49    アンパサンド (&、英語名：) とは並立助詞「…と…」を意味する記号である。ラテン語の の合字で、Trebuchet MSフォントでは、と表示され "et" の合字であることが容易にわかる。ampersa、すなわち "and per se and"、その意味は"and symbol which by itself and"である。 その使用は1世紀に遡ることができ、5世紀中葉から現代に至るまでの変遷がわかる。 Z に続くラテン文字アルファベットの27字目とされた時期もある。 アンパサンドと同じ役割を果たす文字に「のet」と呼ばれる、数字の「7」に似た記号があった(, U+204A)。この記号は現在もゲール文字で使われている。 記号名の「アンパサンド」は、ラテン語まじりの英語「& はそれ自身 "and" を表す」(& per se and) のくずれた形である。英語以外の言語での名称は多様である。 また同様に、「t」または「+（プラス）」に輪を重ねたような、無声歯茎側面摩擦音を示す発音記号「」のようなものが使われることもある。 プログラミング言語では、C など多数の言語で AND 演算子として用いられる。以下は C の例。 PHPでは、変数宣言記号（$）の直前に記述することで、参照渡しを行うことができる。 BASIC 系列の言語では文字列の連結演算子として使用される。codice_4 は codice_5 を返す。また、主にマイクロソフト系では整数の十六進表記に codice_6 を用い、codice_7 （十進で15）のように表現する。 SGML、XML、HTMLでは、アンパサンドを使ってSGML実体を参照する。
```

my line docs file:

```
アンパサンド    07-Jun-2020 10:25:49    アンパサンド アンパサンド (&、英語名：) とは並立助詞「…と…」を意味する記号である。ラテン語の の合字で、Trebuchet MSフォントでは、 "et" の合字であることが容易にわかる。ampersa、すなわち "and per se and"、その意味は"and symbol which by itself and"である。歴史. その使用は1世紀に遡ることができ、5世紀中葉から現代に至るまでの変遷がわかる。Z に続くラテン文字アルファベットの27字目とされた時期もある。アンパサンドと同じ役割を果たす文字に「のet」と呼ばれる、数字の「7」に似た記号があった(, U+204A)。この記号は現在もゲール文字で使われている。記号名の「アンパサンド」は、ラテン語まじりの英語「& はそれ自身 "and" を表す」(& per se and) のくずれた形である。英語以外の言語での名称は多様である。手書き. 日常的な手書きの場合、欧米でアンパサンドは「ε」に縦線を引く単純化されたものが使われることがある。また同様に、「t」または「+（プラス）」に輪を重ねたような、無声歯茎側面摩擦音を示す発音記号「」のようなものが使われることもある。プログラミング言語. プログラミング言語では、C など多数の言語で AND 演算子として用いられる。以下は C の例。PHPでは、変数宣言記号（$）の直前に記述することで、参照渡しを行うことができる。BASIC 系列の言語では文字列の連結演算子として使用される。codice_4 は codice_5 を返す。また、主にマイクロソフト系では整数の十六進表記に codice_6 を用い、codice_7 （十進で15）のように表現する。SGML、XML、HTMLでは、アンパサンドを使ってSGML実体を参\
照する。
```

So I am not yet sure where my attempt to create the line docs file went wrong ...