### PR TITLE
Switch subprocess execution to arg list instead of string

### DIFF
--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -74,7 +74,7 @@ def sourceData(key=None):
       key = sys.argv[1+sys.argv.index('-source')]
   if key in DATA:
     return DATA[key]
-  raise RuntimeError('unknown data source (valid keys: %s)' % DATA.keys())
+  raise RuntimeError('unknown data source "%s" (valid keys: %s)' % (key, DATA.keys()))
 
 class Index(object):
 
@@ -276,10 +276,12 @@ class Competitor(object):
 
     print('files %s' % files)
     
-    benchUtil.run('%s -d %s -classpath "%s" %s' % (self.javacCommand, buildDir, cp, ' '.join(files)), os.path.join(constants.LOGS_DIR, 'compile.log'))
+    cmd = [self.javacCommand, '-d', buildDir, '-classpath', cp]
+    cmd += files
+    benchUtil.run(cmd, os.path.join(constants.LOGS_DIR, 'compile.log'))
     # copy resources/META-INF
     if os.path.exists(os.path.join(perfSrc, 'resources/*')):
-      benchUtil.run('cp -r %s %s' % (os.path.join(perfSrc, 'resources/*'), buildDir.replace("\\", "/")))
+      benchUtil.run('cp', '-r', os.path.join(perfSrc, 'resources/*'), buildDir.replace("\\", "/"))
 
 class Competition(object):
 


### PR DESCRIPTION
This switches our usage of subprocess.Popen from the version that uses a string command to the one that uses a list. This is just a cleanup. I think it's better because it avoids string formatting and concatenation (which we sometimes also split), and the need to wrap some arguments in double quotes to protect them from the shell. It also just looks cleaner to me.