### PR TITLE
Add a p-value column to the report, and make it sortable

### DIFF
--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1349,15 +1349,16 @@ class RunAlgs:
         # Student's T-Test is often used for distributions with the same underlying variance and number of samples, but
         # with large number of samples, Student's T distribution approaches a normal distribution
 
-        # the "combined" std.dev. is the square root the geometric mean of the two variances
-        qpsStdDev = math.sqrt(qpsStdDevBase * qpsStdDevBase + qpsStdDevCmp * qpsStdDevCmp)
+        # the "combined" std.dev. is the square root of the average of the two variances.
+        # the factor of 2 here cancels out with one below, but is left in for clarity of nomenclature
+        qpsStdDev = math.sqrt((qpsStdDevBase * qpsStdDevBase + qpsStdDevCmp * qpsStdDevCmp) / 2)
 
         # t-value is the difference of the means normalized by the combined std.dev.
-        tValue = abs(qpsCmp - qpsBase) / math.sqrt(qpsStdDevBase * qpsStdDevBase + qpsStdDevCmp * qpsStdDevCmp / len(baseQPS))
+        tValue = abs(qpsCmp - qpsBase) / (qpsStdDev * math.sqrt(2 / len(baseQPS)))
 
         # then we have tValue = exp(-x/(2 . stddev^2)) and
         # pValue = 1 - 2 * Integral(exp(-x/(2 . stddev^2)) [0 to tValue]) as the probability of the null hypothesis (that the
-        # two means are drawn from the same distribution).
+        # two means are drawn from the same distribution, using a "two-tailed" test).
         # We have no closed form solution for the Gaussian integral, but python has erf() which is its residual
         pValue = 1 - math.erf(tValue / math.sqrt(2))
         # We pick an arbitrary  but typical confidence interval for "significance":

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -74,21 +74,37 @@ def addFiles(root):
 
 def htmlColor(v):
   if v < 0:
-    return '<font color="red">%d%%</font>' % (-v)
+    return colorFormat(-v, 'html', 'red')
   else:
-    return '<font color="green">%d%%</font>' % v
+    return colorFormat(v, 'html', 'green')
 
 def htmlColor2(v):
+  vstr = '%.1f X' % v
   if v < 1.0:
-    return '<font color="red">%.1f X</font>' % v
+    return colorFormat(vstr, 'html', 'red')
   else:
-    return '<font color="green">%.1f X</font>' % v
+    return colorFormat(vstr, 'html', 'green')
 
 def jiraColor(v):
   if v < 0:
-    return '{color:red}%d%%{color}' % (-v)
+    return colorFormat(-v, 'jira', 'red')
   else:
-    return '{color:green}%d%%{color}' % v
+    return colorFormat(v, 'jira', 'green')
+
+def pValueColor(v, form):
+  vstr = '%.3f' % v
+  if v <= 0.05:
+    return colorFormat(vstr, form, 'green')
+  else:
+    return colorFormat(vstr, form, 'red')
+
+def colorFormat(value, form, color):
+  if form == 'html':
+    return '<font color="{}">{}</font>'.format(color, value)
+  elif form == 'jira':
+    return '{{color:{}}}{}{{color}}'.format(color, value)
+  else:
+    raise RuntimeException("unknown format {}".format(form))
 
 def getArg(argName, default, hasArg=True):
   try:
@@ -1400,9 +1416,9 @@ class RunAlgs:
         w('%16s' % ('%7.1f%% (%4d%% - %4d%%)' % (psAvg, psWorst, psBest)))
 
       if jira:
-        w('|%s' % (jiraColor(pValue)))
+        w('|%s' % pValueColor(pValue, 'jira'))
       elif html:
-        w('<td>%s</td>' % htmlColor2(pValue))
+        w('<td>%s</td>' % pValueColor(pValue, 'html'))
       else:
         w('%6.3f' % pValue)
 


### PR DESCRIPTION
This adds a p-value column to luceneutil's output. The p-value is to be interpreted as the probability that the observations in the two conditions were drawn from the same underlying distribution; that is, that there is no difference. Typically p < 0.05 is treated as a statistically significant difference.

Questions: 

1. should we make this the default sort (rather than percent difference, which must be eyeballed against std.dev.)
2. should we group the results into significant/insignificant?