### PR TITLE
VectorValues test support

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+;; set up Lucene style for emacs
+((java-mode . ((c-basic-offset . 2))))
+

--- a/src/main/WikiVectors.java
+++ b/src/main/WikiVectors.java
@@ -35,7 +35,10 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Precompute per-document semantic vectors as the sum (average) of their word vectors.
+ * Precompute per-document semantic vectors as the sum (average) of their word vectors.  This tool
+ * is used to generate document vectors from wiki line documents and a downloaded word embedding
+ * dictionary, as a precursor for indexing vectors in benchmark runs. It's provided for "offline"
+ * (manual) use, and doesn't factor into benchmark execution.
  */
 public class WikiVectors {
 
@@ -145,7 +148,9 @@ public class WikiVectors {
             }
         }
         tokenCount += count;
-        vectorDiv(dvec, count);
+        if (count > 0) {
+          vectorDiv(dvec, count);
+        }
         return dvec;
     }
 

--- a/src/main/WikiVectors.java
+++ b/src/main/WikiVectors.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Precompute per-document semantic vectors as the sum (average) of their word vectors.
+ */
+public class WikiVectors {
+
+    int dimension;
+    long tokenCount;
+    long missingTokenCount;
+    Map<String, float[]> vectors = new HashMap<>();
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 3) {
+            System.err.println("usage: WikiVectors <vectorDictionary> <lineDocs> <docVectorOutput>");
+            System.exit(-1);
+        }
+        WikiVectors wv = new WikiVectors();
+        wv.loadDict(args[0]);
+        wv.computeVectors(args[1], args[2]);
+    }
+
+    int parseLine(String line) {
+        String[] parts = line.split(" ");
+        String token = parts[0];
+        float[] vector = new float[parts.length - 1];
+        for (int i = 1; i < parts.length; i++) {
+            vector[i - 1] = Float.parseFloat(parts[i]);
+        }
+        if (vectors.containsKey(token)) {
+            throw new IllegalStateException("token " + token + " seen twice");
+        }
+        vectors.put(token, vector);
+        return vector.length;
+    }
+
+    void loadDict(String filename) throws IOException {
+        // read a dictionary file where each line has a token and its n-dimensional vector as text:
+        // <word> <f1> <f2> ... <fn>
+        try (BufferedReader reader = Files.newBufferedReader(Paths.get(filename), StandardCharsets.UTF_8)) {
+            String line = reader.readLine();
+            dimension = parseLine(line);
+            while ((line = reader.readLine()) != null) {
+                int dim = parseLine(line);
+                if (dim != dimension) {
+                    String err = String.format("vector dimension %s is not the initial dimension: %s for line: %s", dim, dimension, line);
+                    throw new IllegalStateException(err);
+                }
+                if (vectors.size() % 10000 == 0) {
+                    System.out.print("loaded " + vectors.size() + "\r");
+                    System.out.flush();
+                }
+            }
+        }
+        System.out.println("loaded " + vectors.size());
+    }
+
+    void computeVectors(String lineDocFile, String outputFile) throws IOException {
+        int count = 0;
+        CharsetDecoder dec=StandardCharsets.UTF_8.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPLACE); // replace invalid input with the UTF8 replacement character
+        try (OutputStream out = Files.newOutputStream(Paths.get(outputFile));
+             Reader r = Channels.newReader(FileChannel.open(Paths.get(lineDocFile)), dec, -1);
+             BufferedReader in = new BufferedReader(r)) {
+            String lineDoc;
+            byte[] buffer = new byte[dimension * Float.BYTES];
+            ByteBuffer bbuf = ByteBuffer.wrap(buffer)
+                .order(ByteOrder.LITTLE_ENDIAN);
+            FloatBuffer fbuf = bbuf.asFloatBuffer();
+            while ((lineDoc = in.readLine()) != null) {
+                float[] dvec = computeDocVector(lineDoc);
+                fbuf.position(0);
+                fbuf.put(dvec);
+                out.write(buffer);
+                if (++count % 10000 == 0) {
+                    System.out.print("wrote " + count + "\r");
+                    System.out.flush();
+                }
+            }
+            System.out.println("wrote " + count);
+            System.out.println("Token Coverage = " + (100 * tokenCount / (tokenCount + missingTokenCount)) + "%");
+        } catch (IOException e) {
+            System.err.println("An error occurred on line " + (count + 1));
+            throw e;
+        }
+    }
+
+    void vectorAdd(float[] x, float[] y) {
+        assert x.length == y.length;
+        for (int i = 0; i < x.length; i++) {
+            x[i] += y[i];
+        }
+    }
+
+    void vectorDiv(float[] v, float x) {
+        for (int i = 0; i < v.length; i++) {
+            v[i] /= x;
+        }
+    }
+
+    float[] computeDocVector(String doc) {
+        float[] dvec = new float[dimension];
+        int count = 0;
+        for (String token : tokenize(doc)) {
+            float[] tvec = vectors.get(token);
+            if (tvec != null) {
+                vectorAdd(dvec, tvec);
+                count++;
+            } else {
+                missingTokenCount++;
+            }
+        }
+        tokenCount += count;
+        vectorDiv(dvec, count);
+        return dvec;
+    }
+
+    // tokenize on white space, most ascii punctuation, preserving -_,., then lower case.  Not very
+    // sophisticated, but enough for performance testing on English text. Should we use StandardTokenizer?
+    Iterable<String> tokenize(String document) {
+        List<String> tokens = new ArrayList<>();
+        for (String t : document.split("[\\]\\[\\\\:\"'?/<> \t~`!@#$%^&*\\(\\)+={}]+")) {
+            if (t.length() > 0) {
+                t = t.toLowerCase();
+                tokens.add(t);
+            }
+        }
+        return tokens;
+    }
+
+}

--- a/src/main/WikiVectors.java
+++ b/src/main/WikiVectors.java
@@ -35,10 +35,10 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Precompute per-document semantic vectors as the sum (average) of their word vectors.  This tool
- * is used to generate document vectors from wiki line documents and a downloaded word embedding
- * dictionary, as a precursor for indexing vectors in benchmark runs. It's provided for "offline"
- * (manual) use, and doesn't factor into benchmark execution.
+ * Precompute per-document semantic vectors as the average of their word vectors.  This tool is used
+ * to generate document vectors from wiki line documents and a downloaded word embedding dictionary,
+ * as a precursor for indexing vectors in benchmark runs. It's provided for "offline" (manual) use,
+ * and doesn't factor into benchmark execution.
  */
 public class WikiVectors {
 

--- a/src/main/perf/Indexer.java
+++ b/src/main/perf/Indexer.java
@@ -205,6 +205,15 @@ public final class Indexer {
     } 
 
     final String lineFile = args.getString("-lineDocsFile");
+    String vectorFile;
+    int vectorDimension;
+    if (args.hasArg("-vectorFile")) {
+        vectorFile = args.getString("-vectorFile");
+        vectorDimension = args.getInt("-vectorDimension");
+    } else {
+        vectorFile = null;
+        vectorDimension = 0;
+    }
 
     // -1 means all docs in the line file:
     final int docCountLimit = args.getInt("-docCountLimit");
@@ -317,6 +326,7 @@ public final class Indexer {
     System.out.println("Index path: " + dirPath);
     System.out.println("Analyzer: " + analyzer);
     System.out.println("Line file: " + lineFile);
+    System.out.println("Vector file: " + vectorFile + ", dim=" + vectorDimension);
     System.out.println("Doc count limit: " + (docCountLimit == -1 ? "all docs" : ""+docCountLimit));
     System.out.println("Threads: " + numThreads);
     System.out.println("Force merge: " + (doForceMerge ? "yes" : "no"));
@@ -428,7 +438,9 @@ public final class Indexer {
     // Fixed seed so group field values are always consistent:
     final Random random = new Random(17);
 
-    LineFileDocs lineFileDocs = new LineFileDocs(lineFile, repeatDocs, storeBody, tvsBody, bodyPostingsOffsets, false, taxoWriter, facetDimMethods, facetsConfig, addDVFields);
+    LineFileDocs lineFileDocs = new LineFileDocs(lineFile, repeatDocs, storeBody, tvsBody, bodyPostingsOffsets, false,
+                                                 taxoWriter, facetDimMethods, facetsConfig, addDVFields,
+                                                 vectorFile, vectorDimension);
 
     float docsPerSecPerThread = -1f;
     //float docsPerSecPerThread = 100f;

--- a/src/main/perf/LineFileDocs.java
+++ b/src/main/perf/LineFileDocs.java
@@ -18,7 +18,7 @@ package perf;
  * limitations under the License.
  */
 
-// FIELDS_HEADER_INDICATOR###	title	timestamp	text	username	characterCount	categories	imageCount	sectionCount	subSectionCount	subSubSectionCount	refCount
+// FIELDS_HEADER_INDICATOR###   title   timestamp   text    username    characterCount  categories  imageCount  sectionCount    subSectionCount subSubSectionCount  refCount
 
 import java.io.BufferedReader;
 import java.io.Closeable;
@@ -214,8 +214,8 @@ public class LineFileDocs implements Closeable {
       reader = new BufferedReader(new InputStreamReader(is, "UTF-8"), BUFFER_SIZE);
       String firstLine = reader.readLine();
       if (firstLine.startsWith("FIELDS_HEADER_INDICATOR")) {
-        if (!firstLine.startsWith("FIELDS_HEADER_INDICATOR###	doctitle	docdate	body") &&
-            !firstLine.startsWith("FIELDS_HEADER_INDICATOR###	title	timestamp	text")) {
+        if (!firstLine.startsWith("FIELDS_HEADER_INDICATOR###\tdoctitle\tdocdate\tbody") &&
+            !firstLine.startsWith("FIELDS_HEADER_INDICATOR###\ttitle\ttimestamp\ttext")) {
           throw new IllegalArgumentException("unrecognized header in line docs file: " + firstLine.trim());
         }
         if (facetFields.isEmpty() == false) {
@@ -359,32 +359,32 @@ public class LineFileDocs implements Closeable {
       doc.add(title);
 
       if (addDVFields) {
-      	titleDV = new SortedDocValuesField("titleDV", new BytesRef(""));
-      	doc.add(titleDV);
+        titleDV = new SortedDocValuesField("titleDV", new BytesRef(""));
+        doc.add(titleDV);
 
         titleBDV = new BinaryDocValuesField("titleBDV", new BytesRef(""));
         doc.add(titleBDV);
 
-      	lastModNDV = new NumericDocValuesField("lastModNDV", -1);
-      	doc.add(lastModNDV);
-	lastModLP = new LongPoint("lastModNDV", -1); //points field must have the same name and value as DV field
-	doc.add(lastModLP);
+        lastModNDV = new NumericDocValuesField("lastModNDV", -1);
+        doc.add(lastModNDV);
+        lastModLP = new LongPoint("lastModNDV", -1); //points field must have the same name and value as DV field
+        doc.add(lastModLP);
 
         monthDV = new SortedDocValuesField("monthSortedDV", new BytesRef(""));
-      	doc.add(monthDV);
+        doc.add(monthDV);
 
         dayOfYearDV = new NumericDocValuesField("dayOfYearNumericDV", 0);
         doc.add(dayOfYearDV);
         dayOfYearIP = new IntPoint("dayOfYearNumericDV", 0); //points field must have the same name and value as DV field
         doc.add(dayOfYearIP);
       } else {
-      	titleDV = null;
+        titleDV = null;
         titleBDV = null;
-      	lastModNDV = null;
-	lastModLP = null;
+        lastModNDV = null;
+        lastModLP = null;
         monthDV = null;
         dayOfYearDV = null;
-	dayOfYearIP = null;
+        dayOfYearIP = null;
       }
 
       titleTokenized = new Field("titleTokenized", "", TextField.TYPE_STORED);
@@ -707,4 +707,3 @@ public class LineFileDocs implements Closeable {
     }
   }
 }
-

--- a/src/main/perf/LineFileDocs.java
+++ b/src/main/perf/LineFileDocs.java
@@ -1,3 +1,4 @@
+
 package perf;
 
 /**
@@ -329,8 +330,10 @@ public class LineFileDocs implements Closeable {
     final Field titleDV;
     final Field monthDV;
     final Field dayOfYearDV;
+    final IntPoint dayOfYearIP;
     final BinaryDocValuesField titleBDV;
     final NumericDocValuesField lastModNDV;
+    final LongPoint lastModLP;
     final Field body;
     final Field id;
     final Field idPoint;
@@ -364,18 +367,24 @@ public class LineFileDocs implements Closeable {
 
       	lastModNDV = new NumericDocValuesField("lastModNDV", -1);
       	doc.add(lastModNDV);
+	lastModLP = new LongPoint("lastModNDV", -1); //points field must have the same name and value as DV field
+	doc.add(lastModLP);
 
         monthDV = new SortedDocValuesField("monthSortedDV", new BytesRef(""));
       	doc.add(monthDV);
 
         dayOfYearDV = new NumericDocValuesField("dayOfYearNumericDV", 0);
-      	doc.add(dayOfYearDV);
+        doc.add(dayOfYearDV);
+        dayOfYearIP = new IntPoint("dayOfYearNumericDV", 0); //points field must have the same name and value as DV field
+        doc.add(dayOfYearIP);
       } else {
       	titleDV = null;
         titleBDV = null;
       	lastModNDV = null;
+	lastModLP = null;
         monthDV = null;
         dayOfYearDV = null;
+	dayOfYearIP = null;
       }
 
       titleTokenized = new Field("titleTokenized", "", TextField.TYPE_STORED);
@@ -577,6 +586,7 @@ public class LineFileDocs implements Closeable {
       doc.titleTokenized.setStringValue(title);
       doc.monthDV.setBytesValue(new BytesRef(months[doc.dateCal.get(Calendar.MONTH)]));
       doc.dayOfYearDV.setLongValue(doc.dateCal.get(Calendar.DAY_OF_YEAR));
+      doc.dayOfYearIP.setIntValue(doc.dateCal.get(Calendar.DAY_OF_YEAR));
     }
     doc.id.setStringValue(intToID(myID));
 
@@ -584,6 +594,7 @@ public class LineFileDocs implements Closeable {
 
     if (addDVFields) {
       doc.lastModNDV.setLongValue(msecSinceEpoch);
+      doc.lastModLP.setLongValue(msecSinceEpoch);
     }
 
     doc.timeSec.setIntValue(timeSec);

--- a/src/main/perf/NRTPerfTest.java
+++ b/src/main/perf/NRTPerfTest.java
@@ -272,7 +272,7 @@ public class NRTPerfTest {
 		System.out.println("Max merge MB/sec = " + (mergeMaxWriteMBPerSec <= 0.0 ? "unlimited" : mergeMaxWriteMBPerSec));
 		final Random random = new Random(seed);
 
-		final LineFileDocs docs = new LineFileDocs(lineDocFile, true, false, false, false, false, null, Collections.emptyMap(), null, true);
+		final LineFileDocs docs = new LineFileDocs(lineDocFile, true, false, false, false, false, null, Collections.emptyMap(), null, true, null, 0);
 
 		final Directory dir0;
 		if (dirImpl.equals("MMapDirectory")) {
@@ -374,7 +374,7 @@ public class NRTPerfTest {
 		final DirectSpellChecker spellChecker = new DirectSpellChecker();
 		final IndexState indexState = new IndexState(manager, null, field, spellChecker, "FastVectorHighlighter", null, null);
 		final QueryParser qp = new QueryParser(field, analyzer);
-		TaskParser taskParser = new TaskParser(indexState, qp, field, 10, random, true);
+		TaskParser taskParser = new TaskParser(indexState, qp, field, 10, random, null, true);
 		final TaskSource tasks = new RandomTaskSource(taskParser, tasksFile, random) {
 			@Override
 			public void taskDone(Task task, long queueTimeNS, TotalHits toalHitCount) {

--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -262,6 +262,12 @@ public class SearchPerfTest {
 
     final boolean verifyCheckSum = !args.getFlag("-skipVerifyChecksum");
     final boolean recacheFilterDeletes = args.getFlag("-recacheFilterDeletes");
+    final String vectorField;
+    if (args.hasArg("-vectorField")) {
+      vectorField = args.getString("-vectorField");
+    } else {
+      vectorField = null;
+    }
 
     if (recacheFilterDeletes) {
       throw new UnsupportedOperationException("recacheFilterDeletes was deprecated");
@@ -347,8 +353,8 @@ public class SearchPerfTest {
       // TODO: add -nrtBodyPostingsOffsets instead of
       // hardwired false:
       boolean addDVFields = mode == Mode.BDV_UPDATE || mode == Mode.NDV_UPDATE;
-			LineFileDocs lineFileDocs = new LineFileDocs(lineDocsFile, false, storeBody, tvsBody, false, cloneDocs, null, null, null, addDVFields);
-			IndexThreads threads = new IndexThreads(new Random(17), writer, new AtomicBoolean(false), lineFileDocs, indexThreadCount, -1, false, false, mode, docsPerSecPerThread, null, -1.0, -1);
+      LineFileDocs lineFileDocs = new LineFileDocs(lineDocsFile, false, storeBody, tvsBody, false, cloneDocs, null, null, null, addDVFields, null, 0);
+      IndexThreads threads = new IndexThreads(new Random(17), writer, new AtomicBoolean(false), lineFileDocs, indexThreadCount, -1, false, false, mode, docsPerSecPerThread, null, -1.0, -1);
       threads.start();
 
       mgr = new SearcherManager(writer, new SearcherFactory() {
@@ -499,7 +505,7 @@ public class SearchPerfTest {
     final IndexState indexState = new IndexState(mgr, taxoReader, fieldName, spellChecker, hiliteImpl, facetsConfig, facetDimMethods);
 
     final QueryParser queryParser = new QueryParser("body", a);
-    TaskParser taskParser = new TaskParser(indexState, queryParser, fieldName, topN, staticRandom, doStoredLoads);
+    TaskParser taskParser = new TaskParser(indexState, queryParser, fieldName, topN, staticRandom, vectorField, doStoredLoads);
 
     final TaskSource tasks;
 

--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -263,7 +263,7 @@ public class SearchPerfTest {
     final boolean verifyCheckSum = !args.getFlag("-skipVerifyChecksum");
     final boolean recacheFilterDeletes = args.getFlag("-recacheFilterDeletes");
     final String vectorField;
-    if (args.hasArg("-vectorField")) {
+    if (args.getFlag("-vectorField")) {
       vectorField = "vector";
     } else {
       vectorField = null;

--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -264,7 +264,7 @@ public class SearchPerfTest {
     final boolean recacheFilterDeletes = args.getFlag("-recacheFilterDeletes");
     final String vectorField;
     if (args.hasArg("-vectorField")) {
-      vectorField = args.getString("-vectorField");
+      vectorField = "vector";
     } else {
       vectorField = null;
     }

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -55,6 +55,7 @@ class TaskParser {
   private final Sort lastModNDVSort;
   private final int topN;
   private final Random random;
+  private final String vectorField;
   private final boolean doStoredLoads;
   private final IndexState state;
 
@@ -63,11 +64,13 @@ class TaskParser {
                     String fieldName,
                     int topN,
                     Random random,
+                    String vectorField,
                     boolean doStoredLoads) {
     this.queryParser = queryParser;
     this.fieldName = fieldName;
     this.topN = topN;
     this.random = random;
+    this.vectorField = vectorField;
     this.doStoredLoads = doStoredLoads;
     this.state = state;
     titleDVSort = new Sort(new SortField("titleDV", SortField.Type.STRING));
@@ -387,7 +390,7 @@ class TaskParser {
         }
       */
 
-      task = new SearchTask(category, query2, sort, group, topN, doHilite, doStoredLoads, facets, doDrillSideways);
+      task = new SearchTask(category, query2, sort, group, topN, doHilite, doStoredLoads, facets, vectorField, doDrillSideways);
     }
 
     return task;

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -168,7 +168,7 @@ class SearchTask:
           print('WARNING: expandedTermCounts differ for %s: %s vs %s' % (self, self.expandedTermCount, other.expandedTermCount))
           # self.fail('wrong expandedTermCount: %s vs %s' % (self.expandedTermCount, other.expandedTermCount))
 
-      if verifyCounts and self.hitCount != other.hitCount:
+      if False and self.hitCount != other.hitCount:
         self.fail('wrong hitCount: %s vs %s' % (self.hitCount, other.hitCount))
 
       if len(self.hits) != len(other.hits):

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -168,7 +168,7 @@ class SearchTask:
           print('WARNING: expandedTermCounts differ for %s: %s vs %s' % (self, self.expandedTermCount, other.expandedTermCount))
           # self.fail('wrong expandedTermCount: %s vs %s' % (self.expandedTermCount, other.expandedTermCount))
 
-      if False and self.hitCount != other.hitCount:
+      if verifyCounts and self.hitCount != other.hitCount:
         self.fail('wrong hitCount: %s vs %s' % (self.hitCount, other.hitCount))
 
       if len(self.hits) != len(other.hits):

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1163,7 +1163,7 @@ class RunAlgs:
     if c.loadStoredFields:
       w('-loadStoredFields')
     if c.vectorField:
-      w('-vectorField', c.vectorField)
+      w('-vectorField')
 
     if False:
       command = '%s -classpath "%s" perf.SearchPerfTest -dirImpl %s -indexPath "%s" -analyzer %s -taskSource "%s" -searchThreadCount %s -taskRepeatCount %s -field body -tasksPerCat %s %s -staticSeed %s -seed %s -similarity %s -commit %s -hiliteImpl %s -log %s' % \
@@ -1183,7 +1183,6 @@ class RunAlgs:
         command += '-loadStoredFields'
       if c.vectorField:
         command += '-vectorField'
-        command += c.vectorField
 
     print('      log: %s + stdout' % logFile)
     t0 = time.time()

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -822,6 +822,10 @@ class RunAlgs:
       if index.useCMS:
         w('-useCMS')
 
+      if index.vectorFile:
+        w('-vectorFile', index.vectorFile)
+        w('-vectorDimension', index.vectorDimension)
+
       if index.optimize:
         w('-forceMerge')
 
@@ -852,6 +856,9 @@ class RunAlgs:
         w('-facetDVFormat', index.facetDVFormat)
 
       w('-idFieldPostingsFormat', index.idFieldPostingsFormat)
+
+      w('-idFieldPostingsFormat')
+      w(index.idFieldPostingsFormat)
 
       if index.grouping:
         w('-grouping')
@@ -1120,6 +1127,7 @@ class RunAlgs:
 
     command = []
     command += c.javaCommand.split()
+
     w = lambda *xs : [command.append(str(x)) for x in xs]
     w('-classpath', cp)
     w('perf.SearchPerfTest')
@@ -1154,6 +1162,8 @@ class RunAlgs:
       w('-pk')
     if c.loadStoredFields:
       w('-loadStoredFields')
+    if c.vectorField:
+      w('-vectorField', c.vectorField)
 
     if False:
       command = '%s -classpath "%s" perf.SearchPerfTest -dirImpl %s -indexPath "%s" -analyzer %s -taskSource "%s" -searchThreadCount %s -taskRepeatCount %s -field body -tasksPerCat %s %s -staticSeed %s -seed %s -similarity %s -commit %s -hiliteImpl %s -log %s' % \
@@ -1171,6 +1181,9 @@ class RunAlgs:
         command += '-pk'
       if c.loadStoredFields:
         command += '-loadStoredFields'
+      if c.vectorField:
+        command += '-vectorField'
+        command += c.vectorField
 
     print('      log: %s + stdout' % logFile)
     t0 = time.time()

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -218,7 +218,7 @@ class Competitor(object):
                printHeap = False,
                hiliteImpl = 'FastVectorHighlighter',
                pk = True,
-               vectorField = None,
+               vectorField = False,
                loadStoredFields = False,
                concurrentSearches = False,
                javacCommand = constants.JAVAC_EXE):

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -107,7 +107,9 @@ class Index(object):
                maxConcurrentMerges = 1,  # use 1 for spinning-magnets and 3 for fast SSD
                addDVFields = False,
                name = None,
-               indexSort = None
+               indexSort = None,
+               vectorFile = None,
+               vectorDimension = None
                ):
     self.checkout = checkout
     self.dataSource = dataSource
@@ -146,6 +148,8 @@ class Index(object):
     self.facetDVFormat = facetDVFormat
     self.assignedName = name
     self.indexSort = indexSort
+    self.vectorFile = vectorFile
+    self.vectorDimension = vectorDimension
     
     self.mergeFactor = 10
     if SEGS_PER_LEVEL >= self.mergeFactor:
@@ -193,6 +197,9 @@ class Index(object):
     if self.indexSort:
       name.append('sort=%s' % self.indexSort)
       
+    if self.vectorFile:
+      name.append('vectors=%d' % self.vectorDimension)
+
     name.append('nd%gM' % (self.numDocs/1000000.0))
     return '.'.join(name)
 
@@ -211,6 +218,7 @@ class Competitor(object):
                printHeap = False,
                hiliteImpl = 'FastVectorHighlighter',
                pk = True,
+               vectorField = None,
                loadStoredFields = False,
                concurrentSearches = False,
                javacCommand = constants.JAVAC_EXE):
@@ -232,6 +240,7 @@ class Competitor(object):
     self.hiliteImpl = hiliteImpl
     self.pk = pk
     self.loadStoredFields = loadStoredFields
+    self.vectorField = vectorField
     self.javacCommand = javacCommand
     self.concurrentSearches = concurrentSearches
 

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -31,7 +31,7 @@ if 'BENCH_BASE_DIR' not in globals():
 WIKI_MEDIUM_DOCS_LINE_FILE = '%s/data/enwiki-20120502-lines-1k.txt' % BASE_DIR
 WIKI_MEDIUM_DOCS_COUNT = 33332620
 
-# Word vectors downloaded from http://nlp.stanford.edu/data/glove.6B.zip
+# Word vectors downloaded from http://nlp.stanford.edu/data/glove.6B.zip (823MB download; 2.1GB unzipped)
 # Licensed under Public Domain (http://www.opendatacommons.org/licenses/pddl/1.0/);
 # see https://nlp.stanford.edu/projects/glove/
 # Thanks to Jeffrey Pennington, Richard Socher, and Christopher D. Manning.

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -31,6 +31,12 @@ if 'BENCH_BASE_DIR' not in globals():
 WIKI_MEDIUM_DOCS_LINE_FILE = '%s/data/enwiki-20120502-lines-1k.txt' % BASE_DIR
 WIKI_MEDIUM_DOCS_COUNT = 33332620
 
+# Word vectors downloaded from http://nlp.stanford.edu/data/glove.6B.zip
+# Licensed under Public Domain (http://www.opendatacommons.org/licenses/pddl/1.0/);
+# see https://nlp.stanford.edu/projects/glove/
+# Thanks to Jeffrey Pennington, Richard Socher, and Christopher D. Manning.
+GLOVE_WORD_VECTORS_FILE = '%s/data/glove.6B.100d.txt' % BASE_DIR
+
 #WIKI_MEDIUM_TASKS_10MDOCS_FILE = '%s/tasks/wikimedium.10M.tasks' % BENCH_BASE_DIR
 WIKI_MEDIUM_TASKS_10MDOCS_FILE = '%s/tasks/wikimedium.10M.nostopwords.tasks' % BENCH_BASE_DIR
 #WIKI_MEDIUM_TASKS_1MDOCS_FILE = '%s/tasks/wikimedium.1M.tasks' % BENCH_BASE_DIR
@@ -84,6 +90,7 @@ SEARCH_NUM_THREADS = 2
 REPRO_COMMAND_START = 'python -u %s/repeatLuceneTest.py -once -verbose -nolog' % BENCH_BASE_DIR
 REPRO_COMMAND_END = ''
 
+#SORT_REPORT_BY = 'p-value'
 SORT_REPORT_BY = 'pctchange'
 #SORT_REPORT_BY = 'query'
 

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -28,9 +28,10 @@ PYTHON_MAJOR_VER = sys.version_info.major
 
 BASE_URL = 'http://home.apache.org/~mikemccand'
 DATA_FILES = [
-  'enwiki-20120502-lines-1k.txt.lzma',
-  'wikimedium500.tasks'
-  ]
+  ('enwiki-20120502-lines-1k.txt.lzma', BASE_URL),
+  ('wikimedium500.tasks', BASE_URL),
+  ('glove.6B.zip', 'http://nlp.stanford.edu/data/glove.6B.zip')
+]
 USAGE= """
 Usage: python setup.py [-download]
 
@@ -80,8 +81,8 @@ def runSetup(download):
     print('localrun.py already exists - skipping')
     
   if download:
-    for filename in DATA_FILES:
-      url = '%s/%s' % (BASE_URL, filename)
+    for filename, base_url in DATA_FILES:
+      url = base_url + '/' + filename
       target_file = os.path.join(data_dir, filename)
       if os.path.exists(target_file):
         print('file %s already exists - skipping' % (target_file))
@@ -90,7 +91,7 @@ def runSetup(download):
         Downloader(url, target_file).download()
         print('')
         print('downloading %s to  %s done ' % (url, target_file))
-      if target_file.endswith('.bz2') or target_file.endswith('.lzma'):
+      if target_file.endswith('.bz2') or target_file.endswith('.lzma') or target_file.endswith('.zip'):
         print('NOTE: make sure you decompress %s' % (target_file))
 
   print('setup successful')

--- a/tasks/wikimedium.10M.nostopwords.tasks
+++ b/tasks/wikimedium.10M.nostopwords.tasks
@@ -13647,6 +13647,13 @@ HighTermDayOfYearSort: dayofyeardvsort//government # freq=384004
 HighTermDayOfYearSort: dayofyeardvsort//27 # freq=383042
 HighTermDayOfYearSort: dayofyeardvsort//old # freq=381809
 
+
+TermDateTimeSort: lastmodndvsort//0 # freq=708472
+TermDateTimeSort: lastmodndvsort//names # freq=402762
+TermDateTimeSort: lastmodndvsort//nbsp # freq=492778
+TermDateTimeSort: lastmodndvsort//part # freq=588644
+TermDateTimeSort: lastmodndvsort//st # freq=306811
+
 HighTermMonthSort: monthdvsort//ref # freq=3793973
 HighTermMonthSort: monthdvsort//http # freq=3493581
 HighTermMonthSort: monthdvsort//from # freq=3224339


### PR DESCRIPTION
  setup.py can now download a GloVe vector embeddings file
  WikiVectors.java computes document-embeddings from those per-term embeddings
  Indexer has new arguments -vectorFile <file> and -vectorDimension <dim>:
    These expect the output from WikiVectors and index vectors in a field called "vector".
  SearchPerfTest and python framework accept -vectorField <fieldName> and when present,
    the vector value in the named field is retrieved for every matching hit