### PR TITLE
Fix division by 0 in t-value calculation

### DIFF
--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1354,7 +1354,7 @@ class RunAlgs:
         qpsStdDev = math.sqrt((qpsStdDevBase * qpsStdDevBase + qpsStdDevCmp * qpsStdDevCmp) / 2)
 
         # t-value is the difference of the means normalized by the combined std.dev.
-        tValue = abs(qpsCmp - qpsBase) / (qpsStdDev * math.sqrt(2 / len(baseQPS)))
+        tValue = abs(qpsCmp - qpsBase) / (qpsStdDev * math.sqrt(2.0 / len(baseQPS)))
 
         # then we have tValue = exp(-x/(2 . stddev^2)) and
         # pValue = 1 - 2 * Integral(exp(-x/(2 . stddev^2)) [0 to tValue]) as the probability of the null hypothesis (that the


### PR DESCRIPTION
if `len(baseQPS) > 2` an expression `2 / len(baseQPS)` = 0,
causing a division by 0 error for the t-value calculation.

This patch fixes it to produce decimal number instead of 0.