### PR TITLE
TaskParser cleanup, breaking monolith into functions

### DIFF
--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -81,52 +81,139 @@ class TaskParser {
   private final static Pattern minShouldMatchPattern = Pattern.compile(" \\+minShouldMatch=(\\d+)($| )");
 
   public Task parseOneTask(String line) throws ParseException {
+    return new TaskBuilder(line).build();
+  }
 
-    final int spot = line.indexOf(':');
-    if (spot == -1) {
-      throw new RuntimeException("task line is malformed: " + line);
-    }
-    final String category = line.substring(0, spot);
+  class TaskBuilder {
+    final String line;
+    final String category;
+    final String origText;
 
-    int spot2 = line.indexOf(" #");
-    if (spot2 == -1) {
-      spot2 = line.length();
-    }
+    List<String> facets;
+    String text;
+    int minShouldMatch;
+    boolean doDrillSideways, doHilite, doStoredLoadsTask;
+    Sort sort;
+    String group;
 
-    String text = line.substring(spot+1, spot2).trim();
-    String origText = text;
+    TaskBuilder(String line) {
+      this.line = line;
 
-    final Task task;
-    if (category.equals("Respell")) {
-      task = new RespellTask(new Term(fieldName, text));
-    } else {
-      if (text.length() == 0) {
-        throw new RuntimeException("null query line");
+      final int spot = line.indexOf(':');
+      if (spot == -1) {
+        throw new RuntimeException("task line is malformed: " + line);
+      }
+      category = line.substring(0, spot);
+
+      int spot2 = line.indexOf(" #");
+      if (spot2 == -1) {
+        spot2 = line.length();
       }
 
+      origText = line.substring(spot+1, spot2).trim();
+    }
+
+    Task build() throws ParseException {
+      if (category.equals("Respell")) {
+        return new RespellTask(new Term(fieldName, origText));
+      } else {
+        if (origText.length() == 0) {
+          throw new RuntimeException("null query line");
+        }
+        return buildQueryTask(origText);
+      }
+    }
+
+    Task buildQueryTask(String input) throws ParseException {
+      text = input;
+      Query filter = parseFilter();
+      parseMinShouldMatch();
+      facets = parseFacets();
+      List<String> drillDowns = parseDrillDowns();
+      doStoredLoadsTask = TaskParser.this.doStoredLoads;
+      parseHilite();
+      String[] taskAndType = parseTaskType(text);
+      String taskType = taskAndType[0];
+      text = taskAndType[1];
+      Query query = buildQuery(taskType, text);
+      Query query2 = applyDrillDowns(query, drillDowns);
+      Query query3 = applyFilter(query2, filter);
+      return new SearchTask(category, query2, sort, group, topN, doHilite, doStoredLoads, facets, doDrillSideways);
+    }
+
+    String[] parseTaskType(String line) {
+      int spot = line.indexOf("//");
+      if (spot == -1) {
+        return new String[]{"", line};
+      } else {
+        return new String[]{
+          line.substring(0, spot),
+          line.substring(spot + 2)
+        };
+      }
+    }
+
+    Query applyFilter(Query query, Query filter) {
+      if (filter == null) {
+        return query;
+      } else {
+        return new BooleanQuery.Builder()
+          .add(query, Occur.MUST)
+          .add(filter, Occur.FILTER)
+          .build();
+      }
+    }
+
+    Query applyDrillDowns(Query query, List<String> drillDowns) {
+      if (drillDowns.isEmpty()) {
+        return query;
+      }
+      DrillDownQuery q = new DrillDownQuery(state.facetsConfig, query);
+      for(String s : drillDowns) {
+        int i = s.indexOf('=');
+        if (i == -1) {
+          throw new IllegalArgumentException("drilldown is missing =");
+        }
+        String dim = s.substring(0, i);
+        String values = s.substring(i+1);
+
+        while (true) {
+          i = values.indexOf(',');
+          if (i == -1) {
+            q.add(dim, values);
+            break;
+          }
+          q.add(dim, values.substring(0, i));
+          values = values.substring(i+1);
+        }
+      }
+      return q;
+    }
+
+    Query parseFilter() {
       // Check for filter (eg: " +filter=0.5%")
       final Matcher m = filterPattern.matcher(text);
-      Query filter;
       if (m.find()) {
         final double filterPct = Double.parseDouble(m.group(1));
         // Splice out the filter string:
         text = (text.substring(0, m.start(0)) + text.substring(m.end(0), text.length())).trim();
-        filter = new RandomQuery(filterPct);
-      } else {
-        filter = null;
+        return new RandomQuery(filterPct);
       }
+      return null;
+    }
 
+    void parseMinShouldMatch() {
       final Matcher m2 = minShouldMatchPattern.matcher(text);
       final int minShouldMatch;
       if (m2.find()) {
         minShouldMatch = Integer.parseInt(m2.group(1));
         // Splice out the minShouldMatch string:
         text = (text.substring(0, m2.start(0)) + text.substring(m2.end(0), text.length())).trim();
-      } else {
-        minShouldMatch = 0;
       }
+    }
 
-      final List<String> facets = new ArrayList<String>();
+    List<String> parseFacets() {
+      List<String> facets = new ArrayList<>();
       while (true) {
         int i = text.indexOf(" +facets:");
         if (i == -1) {
@@ -148,9 +235,11 @@ class TaskParser {
         facets.add(facetDim);
         text = text.substring(0, i) + text.substring(j);
       }
+      return facets;
+   }
 
-      final List<String> drillDowns = new ArrayList<String>();
-
+    List<String> parseDrillDowns() {
+      List<String> drillDowns = new ArrayList<>();
       // Eg: +drillDown:Date=2001,2004
       while (true) {
         int i = text.indexOf("+drillDown:");
@@ -168,7 +257,6 @@ class TaskParser {
         drillDowns.add(s);
       }
 
-      boolean doDrillSideways;
       if (text.indexOf("+drillSideways") != -1) {
         text = text.replace("+drillSideways", "");
         doDrillSideways = true;
@@ -178,162 +266,48 @@ class TaskParser {
       } else {
         doDrillSideways = false;
       }
+      return drillDowns;
+    }
 
-      final Sort sort;
-      Query query;
-      final String group;
-      final boolean doHilite;
-
-      boolean doStoredLoads = this.doStoredLoads;
-
+    void parseHilite() {
       if (text.startsWith("hilite//")) {
         doHilite = true;
         text = text.substring(8);
 
         // Highlighting does its own loading
-        doStoredLoads = false;
+        doStoredLoadsTask = false;
       } else {
         doHilite = false;
       }
+    }
 
-
-      if (text.startsWith("ordered//")) {
-        final int spot3 = text.indexOf(' ');
-        if (spot3 == -1) {
-          throw new RuntimeException("failed to parse query=" + text);
-        }
-        query = new IntervalQuery(fieldName,
-          Intervals.maxwidth(10,
-            Intervals.ordered(
-              Intervals.term(text.substring(9, spot3)),
-              Intervals.term(text.substring(spot3+1).trim())
-            )
-        ));
-        sort = null;
-        group = null;
-      } else if (text.startsWith("near//")) {
-        final int spot3 = text.indexOf(' ');
-        if (spot3 == -1) {
-          throw new RuntimeException("failed to parse query=" + text);
-        }
-        query = new SpanNearQuery(
-                                  new SpanQuery[] {new SpanTermQuery(new Term(fieldName, text.substring(6, spot3))),
-                                                   new SpanTermQuery(new Term(fieldName, text.substring(spot3+1).trim()))},
-                                  10,
-                                  true);
-        sort = null;
-        group = null;
-      } else if (text.startsWith("multiPhrase//(")) {
-        int colon = text.indexOf(':');
-        if (colon == -1) {
-          throw new RuntimeException("failed to parse query=" + text);
-        }
-        String field = text.substring("//multiPhrase(".length(), colon);
-        MultiPhraseQuery.Builder b = new MultiPhraseQuery.Builder();
-        int endParen = text.indexOf(')');
-        if (endParen == -1) {
-          throw new RuntimeException("failed to parse query=" + text);
-        }
-        String queryText = text.substring(colon+1, endParen);
-        String elements[] = queryText.split("\\s+");
-        for (int i = 0; i < elements.length; i++) {
-          String words[] = elements[i].split("\\|");
-          Term terms[] = new Term[words.length];
-          for (int j = 0; j < words.length; j++) {
-            terms[j] = new Term(field, words[j]);
-          }
-          b.add(terms);
-        }
-        query = b.build();
-        sort = null;
-        group = null;
-      } else if (text.startsWith("disjunctionMax//")) {
-        final int spot3 = text.indexOf(' ');
-        if (spot3 == -1) {
-          throw new RuntimeException("failed to parse query=" + text);
-        }
-        List<Query> clauses = new ArrayList<Query>();
-        clauses.add(new TermQuery(new Term(fieldName, text.substring(16, spot3))));
-        clauses.add(new TermQuery(new Term(fieldName, text.substring(spot3+1).trim())));
-        DisjunctionMaxQuery dismax = new DisjunctionMaxQuery(clauses, 0.1f);
-        query = dismax;
-        sort = null;
-        group = null;
-      } else if (text.startsWith("nrq//")) {
-        // field start end
-        final int spot3 = text.indexOf(' ');
-        if (spot3 == -1) {
-          throw new RuntimeException("failed to parse query=" + text);
-        }
-        final int spot4 = text.indexOf(' ', spot3+1);
-        if (spot4 == -1) {
-          throw new RuntimeException("failed to parse query=" + text);
-        }
-        final String nrqFieldName = text.substring(5, spot3);
-        final int start = Integer.parseInt(text.substring(1+spot3, spot4));
-        final int end = Integer.parseInt(text.substring(1+spot4));
-        query = IntPoint.newRangeQuery(nrqFieldName, start, end);
-        sort = null;
-        group = null;
-      } else if (text.startsWith("datetimesort//")) {
-        throw new IllegalArgumentException("use lastmodndvsort instead");
-      } else if (text.startsWith("titlesort//")) {
-        throw new IllegalArgumentException("use titledvsort instead");
-      } else if (text.startsWith("titledvsort//")) {
-        sort = titleDVSort;
-        query = queryParser.parse(text.substring(13, text.length()));
-        group = null;
-      } else if (text.startsWith("titlebdvsort//")) {
-        sort = titleBDVSort;
-        query = queryParser.parse(text.substring(14, text.length()));
-        group = null;
-      } else if (text.startsWith("monthdvsort//")) {
-        sort = monthDVSort;
-        query = queryParser.parse(text.substring(13, text.length()));
-        group = null;
-      } else if (text.startsWith("dayofyeardvsort//")) {
-        sort = dayOfYearDVSort;
-        query = queryParser.parse(text.substring(17, text.length()));
-        group = null;
-      } else if (text.startsWith("lastmodndvsort//")) {
-        sort = lastModNDVSort;
-        query = queryParser.parse(text.substring(16, text.length()));
-        group = null;
-      } else if (text.startsWith("group100//")) {
-        group = "group100";
-        query = queryParser.parse(text.substring(10, text.length()));
-        sort = null;
-      } else if (text.startsWith("group10K//")) {
-        group = "group10K";
-        query = queryParser.parse(text.substring(10, text.length()));
-        sort = null;
-      } else if (text.startsWith("group100K//")) {
-        group = "group100K";
-        query = queryParser.parse(text.substring(11, text.length()));
-        sort = null;
-      } else if (text.startsWith("group1M//")) {
-        group = "group1M";
-        query = queryParser.parse(text.substring(9, text.length()));
-        sort = null;
-      } else if (text.startsWith("groupblock1pass//")) {
-        group = "groupblock1pass";
-        query = queryParser.parse(text.substring(17, text.length()));
-        sort = null;
-      } else if (text.startsWith("groupblock//")) {
-        group = "groupblock";
-        query = queryParser.parse(text.substring(12, text.length()));
-        sort = null;
-      } else {
-        group = null;
-        query = queryParser.parse(text);
-        sort = null;
+    Query buildQuery(String type, String text) throws ParseException {
+      Query query;
+      switch(type) {
+        case "ordered":
+          return parseOrderedQuery();
+        case "near":
+          return parseNearQuery();
+        case "multiPhrase":
+          return parseMultiPhrase();
+        case "disjunctionMax":
+          return parseDisjunctionMax();
+        case "nrq":
+          return parseNRQ();
+        case "datetimesort":
+          throw new IllegalArgumentException("use lastmodndvsort instead");
+        case "titlesort":
+          throw new IllegalArgumentException("use titledvsort instead");
+        default:
+          setSortAndGroup(type);
+          query = queryParser.parse(text);
       }
-
       if (query.toString().equals("")) {
         throw new RuntimeException("query text \"" + text + "\" parsed to empty query");
       }
-
-      if (minShouldMatch != 0) {
+      if (minShouldMatch == 0) {
+        return query;
+      } else {
         if (!(query instanceof BooleanQuery)) {
           throw new RuntimeException("minShouldMatch can only be used with BooleanQuery: query=" + origText);
         }
@@ -342,54 +316,121 @@ class TaskParser {
         for (BooleanClause clause : ((BooleanQuery) query)) {
           b.add(clause);
         }
-        query = b.build();
+        return b.build();
       }
-
-      Query query2;
-
-      if (!drillDowns.isEmpty()) {
-        DrillDownQuery q = new DrillDownQuery(state.facetsConfig, query);
-        for(String s : drillDowns) {
-          int i = s.indexOf('=');
-          if (i == -1) {
-            throw new IllegalArgumentException("drilldown is missing =");
-          }
-          String dim = s.substring(0, i);
-          String values = s.substring(i+1);
-
-          while (true) {
-            i = values.indexOf(',');
-            if (i == -1) {
-              q.add(dim, values);
-              break;
-            }
-            q.add(dim, values.substring(0, i));
-            values = values.substring(i+1);
-          }
-        }
-        query2 = q;
-      } else {
-        query2 = query;
-      }
-
-      if (filter != null) {
-        query2 = new BooleanQuery.Builder()
-            .add(query2, Occur.MUST)
-            .add(filter, Occur.FILTER)
-            .build();
-      }
-
-      /*
-        if (category.startsWith("Or")) {
-        for(BooleanClause clause : ((BooleanQuery) query).clauses()) {
-        ((TermQuery) clause.getQuery()).setNoSkip();
-        }
-        }
-      */
-
-      task = new SearchTask(category, query2, sort, group, topN, doHilite, doStoredLoads, facets, doDrillSideways);
     }
 
-    return task;
+    void setSortAndGroup(String taskType) {
+      switch(taskType) {
+        case "titledvsort":
+          sort = titleDVSort;
+          break;
+        case "titlebdvsort":
+          sort = titleBDVSort;
+          break;
+        case "monthdvsort":
+          sort = monthDVSort;
+          break;
+        case "dayofyeardvsort":
+          sort = dayOfYearDVSort;
+          break;
+        case "lastmodndvsort":
+          sort = lastModNDVSort;
+          break;
+        case "group100":
+          group = "group100";
+          break;
+        case "group10K":
+          group = "group10K";
+          break;
+        case "group100K":
+          group = "group100K";
+          break;
+        case "group1M":
+          group = "group1M";
+          break;
+        case "groupblock1pass":
+          group = "groupblock1pass";
+          break;
+        case "groupblock":
+          group = "groupblock";
+          break;
+      }
+    }
+
+    Query parseNRQ() {
+      // field start end
+      final int spot3 = text.indexOf(' ');
+      if (spot3 == -1) {
+        throw new RuntimeException("failed to parse query=" + text);
+      }
+      final int spot4 = text.indexOf(' ', spot3+1);
+      if (spot4 == -1) {
+        throw new RuntimeException("failed to parse query=" + text);
+      }
+      final String nrqFieldName = text.substring(0, spot3);
+      final int start = Integer.parseInt(text.substring(1+spot3, spot4));
+      final int end = Integer.parseInt(text.substring(1+spot4));
+      return IntPoint.newRangeQuery(nrqFieldName, start, end);
+    }
+
+    Query parseOrderedQuery() {
+      final int spot3 = text.indexOf(' ');
+      if (spot3 == -1) {
+        throw new RuntimeException("failed to parse query=" + text);
+      }
+      return new IntervalQuery(fieldName,
+          Intervals.maxwidth(10,
+              Intervals.ordered(
+                  Intervals.term(text.substring(0, spot3)),
+                  Intervals.term(text.substring(spot3+1).trim()))));
+    }
+
+    Query parseNearQuery() {
+      final int spot3 = text.indexOf(' ');
+      if (spot3 == -1) {
+        throw new RuntimeException("failed to parse query=" + text);
+      }
+      return new SpanNearQuery(
+          new SpanQuery[] {new SpanTermQuery(new Term(fieldName, text.substring(0, spot3))),
+            new SpanTermQuery(new Term(fieldName, text.substring(spot3+1).trim()))},
+          10,
+          true);
+    }
+
+    Query parseMultiPhrase() {
+      int colon = text.indexOf(':');
+      if (colon == -1) {
+        throw new RuntimeException("failed to parse query=" + text);
+      }
+      String field = text.substring("(".length(), colon);
+      MultiPhraseQuery.Builder b = new MultiPhraseQuery.Builder();
+      int endParen = text.indexOf(')');
+      if (endParen == -1) {
+        throw new RuntimeException("failed to parse query=" + text);
+      }
+      String queryText = text.substring(colon+1, endParen);
+      String elements[] = queryText.split("\\s+");
+      for (int i = 0; i < elements.length; i++) {
+        String words[] = elements[i].split("\\|");
+        Term terms[] = new Term[words.length];
+        for (int j = 0; j < words.length; j++) {
+          terms[j] = new Term(field, words[j]);
+        }
+        b.add(terms);
+      }
+      return b.build();
+    }
+
+    Query parseDisjunctionMax() {
+      final int spot3 = text.indexOf(' ');
+      if (spot3 == -1) {
+        throw new RuntimeException("failed to parse query=" + text);
+      }
+      List<Query> clauses = new ArrayList<Query>();
+      clauses.add(new TermQuery(new Term(fieldName, text.substring(0, spot3))));
+      clauses.add(new TermQuery(new Term(fieldName, text.substring(spot3+1).trim())));
+      return new DisjunctionMaxQuery(clauses, 0.1f);
+    }
   }
 }


### PR DESCRIPTION
I wanted to add a new type of search task (for matching w/vectors), but I found this file kind of scary. I believe one should learn to face their fears, so this PR confronts the terror head-on, refactoring into a (more) functional style, collecting local variables that we share (and some of which we mutate) across many code blocks into a new TaskBuilder object, moving the code blocks into named functions.