### PR TITLE
Fixes glove 6B download

### DIFF
--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -32,7 +32,7 @@ DATA_FILES = [
   ('enwiki-20120502-lines-1k.txt.lzma', BASE_URL),
   ('enwiki-20120502-lines-1k-100d.vec', BASE_URL2),
   ('wikimedium500.tasks', BASE_URL),
-  ('glove.6B.zip', 'http://nlp.stanford.edu/data/glove.6B.zip')
+  ('glove.6B.zip', 'http://nlp.stanford.edu/data/')
 ]
 USAGE= """
 Usage: python setup.py [-download]


### PR DESCRIPTION
The glove 6B download seems to be pointing to the wrong location.

The tuple ('glove.6B.zip', 'http://nlp.stanford.edu/data/glove.6B.zip') seems
to make the downloader point to
http://nlp.stanford.edu/data/glove.6B.zip/glove.6B.zip which does not exist.
http://nlp.stanford.edu/data/glove.6B.zip does however exist. This commit
changes to specifying only http://nlp.stanford.edu/data/ as the base URL.