### PR TITLE
Fix taxonomy index DocValues to use BEST_COMPRESSION mode

### DIFF
--- a/src/main/perf/Indexer.java
+++ b/src/main/perf/Indexer.java
@@ -37,6 +37,7 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.codecs.lucene80.Lucene80DocValuesFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90Codec;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.taxonomy.TaxonomyWriter;
@@ -398,14 +399,14 @@ public final class Indexer {
       iwc.setIndexDeletionPolicy(NoDeletionPolicy.INSTANCE);
     }
     
-    final Codec codec = new Lucene90Codec() {
+    final Codec codec = new Lucene90Codec(Lucene90Codec.Mode.BEST_COMPRESSION) {
         @Override
         public PostingsFormat getPostingsFormatForField(String field) {
           return PostingsFormat.forName(field.equals("id") ?
                                         idFieldPostingsFormat : defaultPostingsFormat);
         }
 
-        private final DocValuesFormat facetsDVFormat = DocValuesFormat.forName(facetDVFormatName);
+        private final DocValuesFormat facetsDVFormat = new Lucene80DocValuesFormat(Lucene80DocValuesFormat.Mode.BEST_COMPRESSION);
         //private final DocValuesFormat lucene42DVFormat = DocValuesFormat.forName("Lucene42");
         //private final DocValuesFormat diskDVFormat = DocValuesFormat.forName("Disk");
 //        private final DocValuesFormat lucene45DVFormat = DocValuesFormat.forName("Lucene45");

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -102,7 +102,7 @@ if 'ANALYZER' in locals():
 
 POSTINGS_FORMAT_DEFAULT='Lucene84'
 ID_FIELD_POSTINGS_FORMAT_DEFAULT=POSTINGS_FORMAT_DEFAULT
-FACET_FIELD_DV_FORMAT_DEFAULT='Lucene80'
+FACET_FIELD_DV_FORMAT_DEFAULT='Lucene80' # this field is not used as a default. Change the code in src/main/perf/Indexer.java to use a different DV format
 ANALYZER_DEFAULT='StandardAnalyzer'
 SIMILARITY_DEFAULT='BM25Similarity'
 MERGEPOLICY_DEFAULT='LogDocMergePolicy'


### PR DESCRIPTION
This fixes the performance of BrowseDayOfYearTaxoFacets,
BrowseDateTaxoFacets, BrowseMonthTaxoFacets facets

| Task | Mainline  | Updated codec  |
|---|---|---|
| BrowseMonthSSDVFacets  | 2.94  | 2.93 |
|  BrowseDayOfYearSSDVFacets | 2.76  | 2.75 |
| BrowseDayOfYearTaxoFacets  | 0.71  | 1.23 |
| BrowseDateTaxoFacets  | 0.71  | 1.23 |
|    BrowseMonthTaxoFacets | 0.74  | 1.42 |
