### PR TITLE
Adds Socket I/O and File I/O profiling

### DIFF
--- a/src/python/profiling.jfc
+++ b/src/python/profiling.jfc
@@ -88,5 +88,28 @@ Collects only execution and method samples at a low interval
     <setting name="period">beginChunk</setting>
   </event>
 
+  <event name="jdk.FileRead">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.FileWrite">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.SocketRead">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.SocketWrite">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
 
 </configuration>


### PR DESCRIPTION
This PR adds Socket and File events to the profiling. These events
allows for tracking how much File & Socket I/O is done. Interestingly,
these events can also tell the stack trace of the I/O as well as the
path (for files) and host + port (for sockets). Only the bytes read are
recorded, so e.g. the path of a http request would not be recorded.

Some notes:

- I tested the performance impact of this change on some wiki_all_10M
indexing and searching. For indexing, it averaged at 0.2% slower. For
searching it averaged at 0.5% slower. At N=4 I'm pretty sure that it's
not statistically relevant, but at least it won't kill the benchmarks. I
would expect the impact to be less on the proper benchmarking machine,
since my machine is CPU-bound.
- File I/O essentially only looks at java.nio.File, which does capture
quite a few things. It does however *not* look at Memory Mapped Files,
which I believe that Lucene uses quite heavily, at least for searching.
This makes the profiling a bit less useful, but it could potentially
help finding I/O bottlenecks in Indexing.