### PR TITLE
#103: Add option to construct deterministic index using IndexRearranger

### DIFF
--- a/src/main/perf/BenchRearranger.java
+++ b/src/main/perf/BenchRearranger.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package perf;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.misc.index.BinaryDocValueSelector;
+import org.apache.lucene.misc.index.IndexRearranger;
+import org.apache.lucene.store.Directory;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+public class BenchRearranger {
+    private static final String ID_FIELD = "id";
+
+    /**
+     * Perform rearrange based on given arrangement
+     *      * rearrange /100 gives how many large segments desired
+     *      * (rearrange % 100) / 10 gives how many medium segments desired
+     *      * rearrange % 10 gives how many small segments desired
+     * where large segments has roughly 10 times documents as medium segments, medium has 10 times documents as small segments
+     * documents distribution is determined by {@link BenchRearranger#ID_FIELD}
+     * @param inputDir input directory, will not be modified
+     * @param outputDir output directory, will create new index under this dir
+     * @param iwc IndexWriterConfig, will be configured with {@link org.apache.lucene.index.NoMergePolicy} when rearrange
+     * @param arrangement and integer, will be parsed as explained above
+     * @throws Exception when rearrange
+     */
+    public static void rearrange(Directory inputDir, Directory outputDir, IndexWriterConfig iwc, int arrangement) throws Exception {
+        try (IndexReader reader = DirectoryReader.open(inputDir)) {
+            int large = arrangement / 100;
+            int medium = (arrangement % 100) / 10;
+            int small = arrangement % 10;
+            IndexRearranger rearranger = new IndexRearranger(
+                    inputDir,
+                    outputDir,
+                    iwc,
+                    getDocumentSelectors(reader, large, medium, small)
+            );
+            rearranger.execute();
+        }
+    }
+
+    private static List<IndexRearranger.DocumentSelector> getDocumentSelectors(IndexReader reader, int large, int medium, int small) {
+        int numAllDocs = 0;
+        int totalChunks = large * 100 + medium * 10 + small;
+        for (LeafReaderContext context: reader.leaves()) {
+            numAllDocs += context.reader().numDocs();
+        }
+        int docPerChunk = numAllDocs / totalChunks;
+        int docResidual = numAllDocs % totalChunks;
+        int upto = 0, nextSeg;
+        List<IndexRearranger.DocumentSelector> selectors = new ArrayList<>();
+        for (int i = 0; i < large; i++) {
+            nextSeg = upto + 100 * docPerChunk + Math.min(100, docResidual);
+            selectors.add(new StringFieldDocSelector(ID_FIELD, getIdSetOfRange(upto, nextSeg)));
+            docResidual = Math.max(0, docResidual - 100);
+            upto = nextSeg;
+        }
+
+        for (int i = 0; i < medium; i++) {
+            nextSeg = upto + 10 * docPerChunk + Math.min(10, docResidual);
+            selectors.add(new StringFieldDocSelector(ID_FIELD, getIdSetOfRange(upto, nextSeg)));
+            docResidual = Math.max(0, docResidual - 10);
+            upto = nextSeg;
+        }
+
+        for (int i = 0; i < small; i++) {
+            nextSeg = upto + docPerChunk + Math.min(1, docResidual);
+            selectors.add(new StringFieldDocSelector(ID_FIELD, getIdSetOfRange(upto, nextSeg)));
+            docResidual = Math.max(0, docResidual - 1);
+            upto = nextSeg;
+        }
+        assert docResidual == 0;
+        assert upto == numAllDocs;
+        return selectors;
+    }
+
+    private static HashSet<String> getIdSetOfRange(int from, int to) {
+        HashSet<String> rtn = new HashSet<>();
+        for (int i = from; i < to; i++) {
+            rtn.add(LineFileDocs.intToID(i));
+        }
+        return rtn;
+    }
+}

--- a/src/main/perf/BenchRearranger.java
+++ b/src/main/perf/BenchRearranger.java
@@ -42,7 +42,7 @@ public class BenchRearranger {
      * @param inputDir input directory, will not be modified
      * @param outputDir output directory, will create new index under this dir
      * @param iwc IndexWriterConfig, will be configured with {@link org.apache.lucene.index.NoMergePolicy} when rearrange
-     * @param arrangement and integer, will be parsed as explained above
+     * @param arrangement an integer, will be parsed as explained above
      * @throws Exception when rearrange
      */
     public static void rearrange(Directory inputDir, Directory outputDir, IndexWriterConfig iwc, int arrangement) throws Exception {
@@ -68,24 +68,24 @@ public class BenchRearranger {
         }
         int docPerChunk = numAllDocs / totalChunks;
         int docResidual = numAllDocs % totalChunks;
-        int upto = 0, nextSeg;
+        int upto = 0;
         List<IndexRearranger.DocumentSelector> selectors = new ArrayList<>();
         for (int i = 0; i < large; i++) {
-            nextSeg = upto + 100 * docPerChunk + Math.min(100, docResidual);
+            int nextSeg = upto + 100 * docPerChunk + Math.min(100, docResidual);
             selectors.add(new StringFieldDocSelector(ID_FIELD, getIdSetOfRange(upto, nextSeg)));
             docResidual = Math.max(0, docResidual - 100);
             upto = nextSeg;
         }
 
         for (int i = 0; i < medium; i++) {
-            nextSeg = upto + 10 * docPerChunk + Math.min(10, docResidual);
+            int nextSeg = upto + 10 * docPerChunk + Math.min(10, docResidual);
             selectors.add(new StringFieldDocSelector(ID_FIELD, getIdSetOfRange(upto, nextSeg)));
             docResidual = Math.max(0, docResidual - 10);
             upto = nextSeg;
         }
 
         for (int i = 0; i < small; i++) {
-            nextSeg = upto + docPerChunk + Math.min(1, docResidual);
+            int nextSeg = upto + docPerChunk + Math.min(1, docResidual);
             selectors.add(new StringFieldDocSelector(ID_FIELD, getIdSetOfRange(upto, nextSeg)));
             docResidual = Math.max(0, docResidual - 1);
             upto = nextSeg;

--- a/src/main/perf/Indexer.java
+++ b/src/main/perf/Indexer.java
@@ -233,10 +233,13 @@ public final class Indexer {
 
     int arrangement = 0;
     if (args.hasArg("-rearrange")) {
-      if (doForceMerge) {
+      arrangement = args.getInt("-rearrange");
+      if (doForceMerge && arrangement > 0) {
         throw new IllegalArgumentException("Force merge not compatible with rearrange!");
       }
-      arrangement = args.getInt("-rearrange");
+      if (arrangement < 0) {
+        throw new IllegalArgumentException("Illegal arrangement!");
+      }
     }
     
     String indexSortField = null;
@@ -347,6 +350,7 @@ public final class Indexer {
     System.out.println("Doc count limit: " + (docCountLimit == -1 ? "all docs" : ""+docCountLimit));
     System.out.println("Threads: " + numThreads);
     System.out.println("Force merge: " + (doForceMerge ? "yes" : "no"));
+    System.out.println("Rearrange to (0 for no rearrange): " + arrangement);
     System.out.println("Verbose: " + (verbose ? "yes" : "no"));
     System.out.println("RAM Buffer MB: " + ramBufferSizeMB);
     System.out.println("Max buffered docs: " + maxBufferedDocs);
@@ -607,6 +611,7 @@ public final class Indexer {
 
     if (arrangement != 0) {
       // rearrange after normal indexing routine is completed
+      System.out.println("\nIndexer: rearrange start");
       long rearrangeStartMSec = System.currentTimeMillis();
       Path tmpDirPath = Files.createTempDirectory("rearrange");
       System.out.println(tmpDirPath);

--- a/src/main/perf/PerfUtils.java
+++ b/src/main/perf/PerfUtils.java
@@ -24,6 +24,8 @@ package perf;
 //  - get pk lookup working w/ remote tasks
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +33,7 @@ import java.util.Map;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
 
 public class PerfUtils {
 
@@ -55,5 +58,16 @@ public class PerfUtils {
   public static long usedMemory(Runtime runtime) {
     return runtime.totalMemory() - runtime.freeMemory();
   }
-  
+
+  public static void clearDir(Directory directory) throws IOException {
+    for (String file: directory.listAll()) {
+      directory.deleteFile(file);
+    }
+  }
+
+  public static void copyDir(Directory from, Directory to) throws IOException {
+    for (String file: from.listAll()) {
+      to.copyFrom(from, file, file, IOContext.DEFAULT);
+    }
+  }
 }

--- a/src/main/perf/StringFieldDocSelector.java
+++ b/src/main/perf/StringFieldDocSelector.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package perf;
+
+import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.misc.index.IndexRearranger;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
+
+import java.io.IOException;
+import java.util.Set;
+
+public class StringFieldDocSelector implements IndexRearranger.DocumentSelector {
+
+    private final String field;
+    private final Set<String> keySet;
+
+    StringFieldDocSelector(String field, Set<String> keySet) {
+        this.field = field;
+        this.keySet = keySet;
+    }
+
+    @Override
+    public BitSet getFilteredLiveDocs(CodecReader reader) throws IOException {
+        TermsEnum termsEnum = reader.terms(field).iterator();
+        Bits oldLiveDocs = reader.getLiveDocs();
+        FixedBitSet bits = new FixedBitSet(reader.maxDoc());
+        PostingsEnum reuse = null;
+        for (String key: keySet) {
+            if (termsEnum.seekExact(new BytesRef(key))) {
+                reuse = termsEnum.postings(reuse);
+                assert reuse != null;
+                while (reuse.docID() != DocIdSetIterator.NO_MORE_DOCS) {
+                    if (reuse.docID() != -1 && (oldLiveDocs == null || oldLiveDocs.get(reuse.docID()))) {
+                        bits.set(reuse.docID());
+                    }
+                    reuse.nextDoc();
+                }
+            }
+        }
+        return bits;
+    }
+}

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -903,6 +903,9 @@ class RunAlgs:
       if index.indexSort:
         w('-indexSort', index.indexSort)
 
+      if index.rearrange != 0:
+        w('-rearrange', index.rearrange)
+
       fullLogFile = '%s/%s.%s.log' % (constants.LOGS_DIR, id, index.getName())
 
       print('    log %s' % fullLogFile)

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -116,7 +116,13 @@ class Index(object):
                name = None,
                indexSort = None,
                vectorFile = None,
-               vectorDimension = None
+               vectorDimension = None,
+               # an int defining how many segments to rearrange to, 0 represents not performing rearrange
+               # rearrange /100 gives how many large segments desired
+               # (rearrange % 100) / 10 gives how many medium segments desired
+               # rearrange % 10 gives how many small segments desired
+               # For example, rearrange = 555 means 5 large segments, 5 medium segments and 5 small segments
+               rearrange = 0
                ):
     self.checkout = checkout
     self.dataSource = dataSource
@@ -161,6 +167,7 @@ class Index(object):
     if SEGS_PER_LEVEL >= self.mergeFactor:
       raise RuntimeError('SEGS_PER_LEVEL (%s) is greater than mergeFactor (%s)' % (SEGS_PER_LEVEL, mergeFactor))
     self.useCMS = useCMS
+    self.rearrange = rearrange
 
   def getName(self):
     if self.assignedName is not None:
@@ -298,6 +305,7 @@ class Competitor(object):
       print('Skip compiling luceneutil: all .class are up to date')
       return
 
+    # Can we iterate the perf directory and get this list automatically?
     files = ['%s/perf/%s' % (perfSrc, x) for x in (
       'Args.java',
       'IndexState.java',
@@ -323,6 +331,8 @@ class Competitor(object):
       'TaskSource.java',
       'TaskThreads.java',
       'VectorDictionary.java',
+      'BenchRearranger.java',
+      'StringFieldDocSelector.java',
       )]
 
     print('files %s' % files)


### PR DESCRIPTION
 * Added a `rearrange` option to `Index` class in `competition.py` which configs the arrangement desired. E.g. 555 means 5 large, 5 medium, 5 small. For detailed explanation please refer to `BenchRearranger.java`
 * Added a `StringFieldDocSelector` class to select documents that has certain string indexed (this probably should belong to lucene/misc)
 * Added a `BenchRearranger` class holding execution logic of benchmark rearrangement
 * Added rearrange logic to `Indexer.java`