### PR TITLE
Remove call to CodecReader#ramBytesUsed() from geo benchmarks

### DIFF
--- a/src/main/perf/IndexAndSearchOpenStreetMaps.java
+++ b/src/main/perf/IndexAndSearchOpenStreetMaps.java
@@ -650,15 +650,6 @@ public class IndexAndSearchOpenStreetMaps {
     for(IndexSearcher s : searchers) {
       IndexReader r = s.getIndexReader();
       maxDoc += r.maxDoc();
-      for(LeafReaderContext ctx : r.leaves()) {
-        CodecReader cr = (CodecReader) ctx.reader();
-        /*
-        for(Accountable acc : cr.getChildResources()) {
-          System.out.println("  " + Accountables.toString(acc));
-        }
-        */
-        bytes += cr.ramBytesUsed();
-      }
     }
     System.out.println("READER MB: " + (bytes/1024./1024.));
     System.out.println("maxDoc=" + maxDoc);

--- a/src/main/perf/IndexAndSearchShapes.java
+++ b/src/main/perf/IndexAndSearchShapes.java
@@ -398,7 +398,6 @@ public class IndexAndSearchShapes {
                 if (values != null) {
                     numPoints += values.size();
                 }
-                bytes += cr.ramBytesUsed();
             }
         }
         System.out.println("READER MB: " + (bytes/1024./1024.));


### PR DESCRIPTION
The CodecReader does not implement Accountable any more (https://issues.apache.org/jira/browse/LUCENE-9387) so this method does not exists. 