### PR TITLE
#121: Make id assignment deterministic

### DIFF
--- a/src/main/perf/BenchRearranger.java
+++ b/src/main/perf/BenchRearranger.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
-import org.apache.lucene.misc.index.BinaryDocValueSelector;
 import org.apache.lucene.misc.index.IndexRearranger;
 import org.apache.lucene.store.Directory;
 
@@ -83,6 +82,7 @@ public class BenchRearranger {
         for (LeafReaderContext context: reader.leaves()) {
             numAllDocs += context.reader().numDocs();
         }
+        System.out.println("all docs num:" + numAllDocs);
         int docPerChunk = numAllDocs / totalChunks;
         int docResidual = numAllDocs % totalChunks;
         int upto = 0;
@@ -93,6 +93,7 @@ public class BenchRearranger {
             docResidual = Math.max(0, docResidual - 100);
             upto = nextSeg;
         }
+        System.out.println("large upto:" + upto);
 
         for (int i = 0; i < medium; i++) {
             int nextSeg = upto + 10 * docPerChunk + Math.min(10, docResidual);
@@ -100,6 +101,7 @@ public class BenchRearranger {
             docResidual = Math.max(0, docResidual - 10);
             upto = nextSeg;
         }
+        System.out.println("med upto:" + upto);
 
         for (int i = 0; i < small; i++) {
             int nextSeg = upto + docPerChunk + Math.min(1, docResidual);
@@ -107,6 +109,7 @@ public class BenchRearranger {
             docResidual = Math.max(0, docResidual - 1);
             upto = nextSeg;
         }
+        System.out.println("small upto:" + upto);
         assert docResidual == 0;
         assert upto == numAllDocs;
         return selectors;

--- a/src/main/perf/Indexer.java
+++ b/src/main/perf/Indexer.java
@@ -61,10 +61,12 @@ import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.PrintStreamInfoStream;
@@ -620,11 +622,26 @@ public final class Indexer {
       long rearrangeEndMSec = System.currentTimeMillis();
 //      IndexReader reader = DirectoryReader.open(dir);
 //      for (LeafReaderContext context: reader.leaves()) {
+//        HashSet<Integer> idSet = new HashSet<>();
+//        int min = Integer.MAX_VALUE;
+//        int max = -1;
+//        TermsEnum termsEnum = context.reader().terms("id").iterator();
+//        BytesRef next = termsEnum.next();
+//        while (next != null) {
+//          int id = LineFileDocs.idToInt(next);
+//          idSet.add(id);
+//          min = Math.min(min, id);
+//          max = Math.max(max, id);
+//          next = termsEnum.next();
+//        }
+//        System.out.println("---segment---");
 //        System.out.println(context.reader().numDocs());
+//        System.out.println("Unique id num: " + idSet.size());
+//        System.out.println("min id: " + min);
+//        System.out.println("max id: " + max);
 //      }
 //      reader.close();
-      /* code above will print '1810' once, '1800' 4 times, '180' 5 times, '18' 5 times
-       on a 10000 doc, 555 arrangement */
+      /* code above could be used to inspect the rearranged index for debugging */
       System.out.println("\nIndexer: rearrange done (took " + (rearrangeEndMSec-rearrangeStartMSec) + " msec)");
     }
 

--- a/src/main/perf/LineFileDocs.java
+++ b/src/main/perf/LineFileDocs.java
@@ -73,7 +73,7 @@ import org.apache.lucene.util.UnicodeUtil;
 public class LineFileDocs implements Closeable {
 
   // sentinel:
-  private final static LineFileDoc END = new LineFileDoc("END", null);
+  private final static LineFileDoc END = new LineFileDoc("END", null, -1);
 
   private final AtomicInteger nextID = new AtomicInteger();
 
@@ -166,7 +166,7 @@ public class LineFileDocs implements Closeable {
           throw new RuntimeException("expected " + length + " document bytes but read " + x);
         }
         buffer.position(0);
-        queue.put(new LineFileDoc(buffer, readVector(count)));
+        queue.put(new LineFileDoc(buffer, readVector(count), nextID.getAndIncrement()));
       }
     } else {
       while (true) {
@@ -180,7 +180,7 @@ public class LineFileDocs implements Closeable {
             break;
           }
         }
-        queue.put(new LineFileDoc(line, readVector(1)));
+        queue.put(new LineFileDoc(line, readVector(1), nextID.getAndIncrement()));
       }
     }
     for(int i=0;i<128;i++) {
@@ -480,12 +480,13 @@ public class LineFileDocs implements Closeable {
     String line;
     String title;
     String body;
+    LineFileDoc lfd;
 
     if (isBinary) {
 
       float[] vector = new float[vectorDimension];
       FloatBuffer vectorBuffer = null;
-      LineFileDoc lfd = nextDocs.get();
+      lfd = nextDocs.get();
       if (lfd == null || lfd.byteText.hasRemaining() == false) {
         /*
         System.out.println("  prev buffer=" + buffer);
@@ -533,7 +534,6 @@ public class LineFileDocs implements Closeable {
         lfd.vector.get(doc.vector.vectorValue());
       }
     } else {
-      LineFileDoc lfd;
       try {
         lfd = queue.take();
       } catch (InterruptedException ie) {
@@ -581,7 +581,7 @@ public class LineFileDocs implements Closeable {
       }
     }
 
-    final int myID = nextID.getAndIncrement();
+    final int myID = lfd.id;
 
     bytesIndexed.addAndGet(body.length() + title.length());
     doc.body.setStringValue(body);
@@ -699,10 +699,12 @@ public class LineFileDocs implements Closeable {
     final FloatBuffer vector;
     final String stringText;
     final ByteBuffer byteText;
+    final int id;
 
-    LineFileDoc(String text, float[] vector) {
+    LineFileDoc(String text, float[] vector, int id) {
       stringText = text;
       byteText = null;
+      this.id = id;
       if (vector == null) {
         this.vector = null;
       } else {
@@ -710,9 +712,10 @@ public class LineFileDocs implements Closeable {
       }
     }
 
-    LineFileDoc(ByteBuffer bytes, float[] vector) {
+    LineFileDoc(ByteBuffer bytes, float[] vector, int id) {
       stringText = null;
       byteText = bytes;
+      this.id = id;
       if (vector == null) {
         this.vector = null;
       } else {


### PR DESCRIPTION
Make id assignment deterministic by moving the id assignment to the thread that handles input.
Also includes some minor print out changes that is helpful to debug rearrange.