### PR TITLE
#121: Add idNDV NumericDocValue field

### DIFF
--- a/src/main/perf/LineFileDocs.java
+++ b/src/main/perf/LineFileDocs.java
@@ -43,7 +43,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -338,6 +337,7 @@ public class LineFileDocs implements Closeable {
     final LongPoint lastModLP;
     final Field body;
     final Field id;
+    final Field idNDV;
     final Field idPoint;
     final Field date;
     //final NumericDocValuesField dateMSec;
@@ -361,6 +361,10 @@ public class LineFileDocs implements Closeable {
       doc.add(title);
 
       if (addDVFields) {
+
+        idNDV = new NumericDocValuesField("idNDV", -1);
+        doc.add(idNDV);
+
         titleDV = new SortedDocValuesField("titleDV", new BytesRef(""));
         doc.add(titleDV);
 
@@ -380,6 +384,7 @@ public class LineFileDocs implements Closeable {
         dayOfYearIP = new IntPoint("dayOfYearNumericDV", 0); //points field must have the same name and value as DV field
         doc.add(dayOfYearIP);
       } else {
+        idNDV = null;
         titleDV = null;
         titleBDV = null;
         lastModNDV = null;
@@ -587,6 +592,7 @@ public class LineFileDocs implements Closeable {
     doc.body.setStringValue(body);
     doc.title.setStringValue(title);
     if (addDVFields) {
+      doc.idNDV.setLongValue(myID);
       doc.titleBDV.setBytesValue(new BytesRef(title));
       doc.titleDV.setBytesValue(new BytesRef(title));
       doc.monthDV.setBytesValue(new BytesRef(months[doc.dateCal.get(Calendar.MONTH)]));

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -900,7 +900,7 @@ def run():
                                useCMS=True)
                                
 
-  # Must use only 1 thread so we get same index structure, always:
+  # Must use rearrange and indexSort to ensure we get same index structure, always:
   index = comp.newIndex(NIGHTLY_DIR, mediumSource,
                         analyzer='StandardAnalyzerNoStopWords',
                         postingsFormat='Lucene90',
@@ -916,6 +916,7 @@ def run():
                                   ('sortedset:Month', 'Month'),
                                   ('sortedset:DayOfYear', 'DayOfYear')),
                         addDVFields=True,
+                        indexSort="idNDV:long",
                         vectorFile=constants.GLOVE_VECTOR_DOCS_FILE,
                         vectorDimension=100,
                         rearrange=555,


### PR DESCRIPTION
Add idNDV NumericDocValue field and let nightly benchmark depend on it to produce consistent results

Local test shows this resolves issue #121 