### PR TITLE
VectorValues#search has been moved to LeafReader

### DIFF
--- a/src/main/perf/KnnQuery.java
+++ b/src/main/perf/KnnQuery.java
@@ -85,7 +85,7 @@ public class KnnQuery extends Query {
 
     @Override
     public Scorer scorer(LeafReaderContext context) throws IOException {
-      return new TopDocScorer(this, context.reader().getVectorValues(field).search(vector, topK, 0));
+      return new TopDocScorer(this, context.reader().searchNearestVectors(field, vector, topK, 0));
     }
 
     @Override


### PR DESCRIPTION
Fixes compile error due to API change in Vector search.