### PR TITLE
Add tasks for positional queries with nested disjunctions

### DIFF
--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -55,6 +55,21 @@ EURO_MEDIUM = Data('euromedium', constants.EUROPARL_MEDIUM_DOCS_LINE_FILE, 50000
 
 WIKI_VECTOR_10K = Data('wikivector10k', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 10000, constants.WIKI_VECTOR_TASKS_FILE)
 
+DISJUNCTION_SIMPLE = Data('disjunctionSimple',
+                          constants.DISJUNCTION_DOCS_LINE_FILE,
+                          constants.DISJUNCTION_DOC_COUNT,
+                          constants.DISJUNCTION_SIMPLE_TASKS_FILE)
+
+DISJUNCTION_REALISTIC = Data('disjunctionRealistic',
+                             constants.DISJUNCTION_DOCS_LINE_FILE,
+                             constants.DISJUNCTION_DOC_COUNT,
+                             constants.DISJUNCTION_REALISTIC_TASKS_FILE)
+
+DISJUNCTION_INTENSIVE = Data('disjunctionIntensive',
+                             constants.DISJUNCTION_DOCS_LINE_FILE,
+                             constants.DISJUNCTION_DOC_COUNT,
+                             constants.DISJUNCTION_INTENSIVE_TASKS_FILE)
+
 DATA = {'wikimediumall': WIKI_MEDIUM_ALL,
         'wikimedium10m' : WIKI_MEDIUM_10M,
         'wikimedium1m' : WIKI_MEDIUM_1M,
@@ -69,6 +84,9 @@ DATA = {'wikimediumall': WIKI_MEDIUM_ALL,
         'wikibig1m' : WIKI_BIG_1M,
         'euromedium' : EURO_MEDIUM,
         'wikivector10k' : WIKI_VECTOR_10K,
+        'disjunctionSimple' : DISJUNCTION_SIMPLE,
+        'disjunctionRealistic' : DISJUNCTION_REALISTIC,
+        'disjunctionIntensive' : DISJUNCTION_INTENSIVE
         }
 
 # for multi-segment index:

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -45,6 +45,9 @@ WIKI_MEDIUM_TASKS_1MDOCS_FILE = '%s/tasks/wikimedium.1M.nostopwords.tasks' % BEN
 WIKI_MEDIUM_TASKS_ALL_FILE = '%s/tasks/wikimedium.10M.tasks' % BENCH_BASE_DIR
 WIKI_VECTOR_TASKS_FILE = '%s/tasks/vector.tasks' % BENCH_BASE_DIR
 SORTED_TASKS_FILE = '%s/tasks/sorted.tasks' % BENCH_BASE_DIR
+DISJUNCTION_SIMPLE_TASKS_FILE = '%s/tasks/disjunctionSimple.tasks' % BENCH_BASE_DIR
+DISJUNCTION_REALISTIC_TASKS_FILE = '%s/tasks/disjunctionRealistic.tasks' % BENCH_BASE_DIR
+DISJUNCTION_INTENSIVE_TASKS_FILE = '%s/tasks/disjunctionIntensive.tasks' % BENCH_BASE_DIR
 
 # wget http://home.apache.org/~mikemccand/enwiki-20100302-pages-articles-lines.txt.bz2
 WIKI_BIG_DOCS_LINE_FILE = '%s/data/enwiki-20100302-pages-articles-lines.txt' % BASE_DIR
@@ -59,6 +62,9 @@ WIKI_BIG_TASKS_FILE = '%s/data/wikibig.tasks' % BASE_DIR
 # enwiki-20120502-lines.txt has 6726515 docs
 # enwiki-20130102-lines.txt has 6647577 docs
 WIKI_BIG_DOCS_COUNT = 6726515
+
+DISJUNCTION_DOC_COUNT = 500000
+DISJUNCTION_DOCS_LINE_FILE = WIKI_MEDIUM_DOCS_LINE_FILE
 
 #WIKI_FILE = '%s/data/enwiki-20100302-pages-articles.xml.bz2' % BENCH_BASE_DIR
 

--- a/tasks/disjunctionIntensive.tasks
+++ b/tasks/disjunctionIntensive.tasks
@@ -1,0 +1,29 @@
+# these are artificially designed to create intensive disjunction queries. The
+# goal is to illustrate performance profile; particularly, e.g., with
+# potentially adversarial queries
+
+# NOTE: alternating between "a|in-the" and "the|in-the" clauses is required
+# to induce `pullUpDisjunctions()` query rewriting, which otherwise seems
+# to be prevented by `OrderedIntervalSource.deduplicate()`?
+
+# NOTE: the "smith" term is arbitrary, just to restrict the domain somewhat
+# and push QPS into friendlier number ranges
+
+IntervalDis1: intervalDis//(body:smith a|in-the)
+IntervalMinDis1: intervalMinDis//(body:smith a|in-the)
+SpanDis1: spanDis//(body:smith a|in-the)
+IntervalDis2: intervalDis//(body:smith a|in-the the|in-the)
+IntervalMinDis2: intervalMinDis//(body:smith a|in-the the|in-the)
+SpanDis2: spanDis//(body:smith a|in-the the|in-the)
+IntervalDis3: intervalDis//(body:smith a|in-the the|in-the a|in-the)
+IntervalMinDis3: intervalMinDis//(body:smith a|in-the the|in-the a|in-the)
+SpanDis3: spanDis//(body:smith a|in-the the|in-the a|in-the)
+IntervalDis4: intervalDis//(body:smith a|in-the the|in-the a|in-the the|in-the)
+IntervalMinDis4: intervalMinDis//(body:smith a|in-the the|in-the a|in-the the|in-the)
+SpanDis4: spanDis//(body:smith a|in-the the|in-the a|in-the the|in-the)
+IntervalDis5: intervalDis//(body:smith a|in-the the|in-the a|in-the the|in-the a|in-the)
+IntervalMinDis5: intervalMinDis//(body:smith a|in-the the|in-the a|in-the the|in-the a|in-the)
+SpanDis5: spanDis//(body:smith a|in-the the|in-the a|in-the the|in-the a|in-the)
+IntervalDis6: intervalDis//(body:smith a|in-the the|in-the a|in-the the|in-the a|in-the the|in-the)
+IntervalMinDis6: intervalMinDis//(body:smith a|in-the the|in-the a|in-the the|in-the a|in-the the|in-the)
+SpanDis6: spanDis//(body:smith a|in-the the|in-the a|in-the the|in-the a|in-the the|in-the)

--- a/tasks/disjunctionRealistic.tasks
+++ b/tasks/disjunctionRealistic.tasks
@@ -1,0 +1,6 @@
+# This is intended to illustrate a realistic-type query that would have
+# relatively significant combinatorial expansion in `pullUpDisjunctions()`
+
+IntervalDis: intervalDis//(body:us|united-states health|health-care policy|public-policy law|legal-aspects)
+IntervalMinDis: intervalMinDis//(body:us|united-states health|health-care policy|public-policy law|legal-aspects)
+SpanDis: spanDis//(body:us|united-states health|health-care policy|public-policy law|legal-aspects)

--- a/tasks/disjunctionSimple.tasks
+++ b/tasks/disjunctionSimple.tasks
@@ -1,0 +1,6 @@
+# These should not actually result in positional queries; they exist to evaluate
+# realistic pure-disjunction queries in isolation (i.e.: SpanOrQuery,
+# DisjunctionIntervalsSource)
+
+PlainIntervalDis: intervalDis//(body:trash|waste|garbage|recycling|refuse)
+PlainSpanDis: spanDis//(body:trash|waste|garbage|recycling|refuse)


### PR DESCRIPTION
Disjunctions, and particularly positional queries with inner disjunctions, are not really covered at the moment. Building off of existing work for "multiPhrase", this PR adds tasks that test straight disjunctions, and positional queries with nested disjunctions (SpanNearQuery with nested SpanOrQueries, and Intervals.ordered with nested disjunctions, both with and without rewriting to `pullUpDisjunctions()`).

NOTE: I think in order to work properly this may require a minor change in Lucene, to enable `DisjunctionIntervalsSource.toString()` to serve as a stable key on the python side:
```
@@ -120,7 +120,7 @@ class DisjunctionIntervalsSource extends IntervalsSource {
 
   @Override
   public String toString() {
-    return subSources.stream().map(Object::toString).collect(Collectors.joining(",", "or(", ")"));
+    return subSources.stream().map(Object::toString).sorted().collect(Collectors.joining(",", "or(", ")"));
   }

``` 