### PR TITLE
Added facet benchmark that chooses random words as labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *.ipr
 *.iws
 
+## Java flight recording
+*.jfr
+
 ## project files
 .project
 .classpath

--- a/src/python/buildBinaryLineDocs.py
+++ b/src/python/buildBinaryLineDocs.py
@@ -25,15 +25,15 @@ with open(sys.argv[1], 'r', errors='replace') as f, open(sys.argv[2], 'wb') as f
       first = False
       if line.startswith('FIELDS_HEADER_INDICATOR'):
         print('skip header')
-        if len(line.strip().split('\t')) != 4:
-          raise RuntimeError('cannot convert line doc files that have more than title, timestamp, text fields: saw header %s' % line.rstrip())
+        if len(line.strip().split('\t')) != 5:
+          raise RuntimeError('cannot convert line doc files that have more than title, timestamp, text fields, random label: saw header %s' % line.rstrip())
         continue
       else:
         print('no header')
     tup = line.split('\t')
-    if len(tup) != 3:
+    if len(tup) != 4:
       raise RuntimeError('got %s' % str(tup))
-    title, date, body = tup
+    title, date, body, randomLabel = tup
 
     dt = datetime.datetime.strptime(date.replace('.000', ''), '%d-%b-%Y %H:%M:%S')
     msecSinceEpoch = int((dt - epoch).total_seconds() * 1000)
@@ -41,13 +41,14 @@ with open(sys.argv[1], 'r', errors='replace') as f, open(sys.argv[2], 'wb') as f
     timeSec = dt.hour*3600 + dt.minute * 60 + dt.second
     titleBytes = title.encode('utf-8')
     bodyBytes = body.encode('utf-8')
-    totalLength = len(titleBytes)+len(bodyBytes)+16
+    randomLabelBytes = randomLabel.strip().encode('utf-8')
+    totalLength = len(titleBytes)+len(bodyBytes)+len(randomLabelBytes)+20
     #print('len=%s' % totalLength)
     #print('HERE: %s, offset=%s' % (struct.pack('i', totalLength), fOut.tell()))
-
-    pending.write(struct.pack('iili', len(titleBytes), len(bodyBytes), msecSinceEpoch, timeSec))
+    pending.write(struct.pack('iiiil', len(titleBytes), len(bodyBytes), len(randomLabelBytes), timeSec, msecSinceEpoch))
     pending.write(titleBytes)
     pending.write(bodyBytes)
+    pending.write(randomLabelBytes)
     pendingDocCount += 1
     
     if pending.tell() > 64*1024:

--- a/src/python/buildBinaryLineDocs.py
+++ b/src/python/buildBinaryLineDocs.py
@@ -33,6 +33,9 @@ with open(sys.argv[1], 'r', errors='replace') as f, open(sys.argv[2], 'wb') as f
     tup = line.split('\t')
     if len(tup) != 4:
       raise RuntimeError('got %s' % str(tup))
+    for s in tup:
+      if not s.strip():
+        raise RuntimeError('contained empty category' % str(tup))
     title, date, body, randomLabel = tup
 
     dt = datetime.datetime.strptime(date.replace('.000', ''), '%d-%b-%Y %H:%M:%S')

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -28,7 +28,8 @@ if 'BENCH_BASE_DIR' not in globals():
 #WIKI_MEDIUM_DOCS_LINE_FILE = '%s/data/enwiki-20100302-pages-articles-lines-1k-shuffled.txt' % BASE_DIR
 
 # wget http://home.apache.org/~mikemccand/enwiki-20120502-lines-1k.txt.lzma
-WIKI_MEDIUM_DOCS_LINE_FILE = '%s/data/enwiki-20120502-lines-1k.txt' % BASE_DIR
+WIKI_MEDIUM_DOC_BIN_LINE_FILE = '%s/data/enwiki-20120502-lines-1k-with-random-label.bin' % BASE_DIR
+WIKI_MEDIUM_DOCS_LINE_FILE = '%s/data/enwiki-20120502-lines-1k-with-random-label.txt' % BASE_DIR
 WIKI_MEDIUM_DOCS_COUNT = 33332620
 
 # Word vectors downloaded from http://nlp.stanford.edu/data/glove.6B.zip (823MB download; 2.1GB unzipped)

--- a/src/python/createLineFileDocsWithRandomLabel.py
+++ b/src/python/createLineFileDocsWithRandomLabel.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import os
+
+from random import randrange
+
+USAGE= """
+Usage: python createLineFileDocsWithRandomLabel.py
+
+"""
+
+ORIGINAL_LINEFILE = 'enwiki-20120502-lines-1k.txt'
+TARGET_LINEFILE = 'enwiki-20120502-lines-1k-with-random-label.txt'
+
+def createLineFileDocsWithRandomLabels():
+    cwd = os.getcwd()
+    parent, base = os.path.split(cwd)
+    data_dir = os.path.join(parent, 'data')
+
+    if not os.path.exists(data_dir):
+        print('download data before running this script')
+        exit()
+
+    original_file = os.path.join(data_dir, ORIGINAL_LINEFILE)
+    target_file = os.path.join(data_dir, TARGET_LINEFILE)
+
+    with open(original_file, 'r', encoding='ISO-8859-1') as original, open(target_file, 'w', encoding='ISO-8859-1') as out:
+        first_line = True
+        i = 0
+        for line in original:
+            if i % 100000 == 0:
+                print("Converted ", i, " line file docs")
+            line_arr = line.strip().split('\t')
+            if first_line:
+                line_arr.append('RandomLabel')
+                first_line = False
+            else:
+                try:
+                    random_label = chooseRandomLabel(line_arr[2])
+                except IndexError:
+                    # found a few lines that looked like this: ['Biosensor', '05-APR-2012 04:12:36.000'] with no body
+                    line_arr.append('EMPTY_LABEL')
+                    random_label = 'EMPTY_LABEL'
+                line_arr.append(random_label)
+            line_to_write = '\t'.join(line_arr) + '\n'
+            out.write(line_to_write)
+            i += 1
+
+def chooseRandomLabel(body):
+    body_arr = body.split(' ')
+    label = None
+    i = 0
+    while (label == None or label == '') and i < 5:
+        label = body_arr[randrange(len(body_arr))]
+    if label == None or label == '':
+        return "EMPTY_LABEL"
+    else:
+        return label
+
+if __name__ == '__main__':
+    if '-help' in sys.argv or '--help' in sys.argv:
+        print(USAGE)
+    else:
+        createLineFileDocsWithRandomLabels()

--- a/src/python/createLineFileDocsWithRandomLabel.py
+++ b/src/python/createLineFileDocsWithRandomLabel.py
@@ -17,6 +17,7 @@
 
 import sys
 import os
+import re
 
 from random import randrange
 
@@ -28,20 +29,26 @@ Usage: python createLineFileDocsWithRandomLabel.py
 ORIGINAL_LINEFILE = 'enwiki-20120502-lines-1k.txt'
 TARGET_LINEFILE = 'enwiki-20120502-lines-1k-with-random-label.txt'
 
-def createLineFileDocsWithRandomLabels():
-    cwd = os.getcwd()
-    parent, base = os.path.split(cwd)
-    data_dir = os.path.join(parent, 'data')
+def createLineFileDocsWithRandomLabels(original_file, target_file):
+    if original_file is None:
+        cwd = os.getcwd()
+        parent, base = os.path.split(cwd)
+        data_dir = os.path.join(parent, 'data')
 
-    if not os.path.exists(data_dir):
-        print('download data before running this script')
-        exit()
+        if not os.path.exists(data_dir):
+            print('download data before running this script')
+            exit()
 
-    original_file = os.path.join(data_dir, ORIGINAL_LINEFILE)
-    target_file = os.path.join(data_dir, TARGET_LINEFILE)
+        original_file = os.path.join(data_dir, ORIGINAL_LINEFILE)
+        target_file = os.path.join(data_dir, TARGET_LINEFILE)
+    else:
+        if not os.path.exist(original_file):
+            print("Recieved invalid path to data")
+            exit()
 
     with open(original_file, 'r', encoding='ISO-8859-1') as original, open(target_file, 'w', encoding='ISO-8859-1') as out:
         first_line = True
+        skipped = 0
         i = 0
         for line in original:
             if i % 100000 == 0:
@@ -50,31 +57,57 @@ def createLineFileDocsWithRandomLabels():
             if first_line:
                 line_arr.append('RandomLabel')
                 first_line = False
+                line_to_write = '\t'.join(line_arr) + '\n'
+                out.write(line_to_write)
+                continue
             else:
                 try:
-                    random_label = chooseRandomLabel(line_arr[2])
+                    if not isNotEmpty(line_arr[2]):
+                        line_arr.append('EMPTY_LABEL')
+                        random_label = "EMPTY_LABEL"
+                    else:
+                        random_label = chooseRandomLabel(line_arr[2])
+                        if random_label == "EMPTY_BODY":
+                            random_label = "EMPTY_LABEL"
+                            line_arr[2] = "EMPTY_LABEL"
                 except IndexError:
                     # found a few lines that looked like this: ['Biosensor', '05-APR-2012 04:12:36.000'] with no body
                     line_arr.append('EMPTY_LABEL')
                     random_label = 'EMPTY_LABEL'
                 line_arr.append(random_label)
+            first_line = False
             line_to_write = '\t'.join(line_arr) + '\n'
             out.write(line_to_write)
             i += 1
+        print("Indexed ", i, " total documents")
+        print("Skipped ", skipped, " documents")
 
 def chooseRandomLabel(body):
-    body_arr = body.split(' ')
+    body_arr = list(filter(isNotEmpty, re.split(r'\W', body)))
+    if (len(body_arr) == 0):
+        return "EMPTY_BODY"
     label = None
     i = 0
-    while (label == None or label == '') and i < 5:
+    while not isNotEmpty(label) and i < 5:
         label = body_arr[randrange(len(body_arr))]
-    if label == None or label == '':
+    if not isNotEmpty(label):
         return "EMPTY_LABEL"
     else:
         return label
+
+def isNotEmpty(str):
+    if str and str.strip():
+        return True
+    return False
 
 if __name__ == '__main__':
     if '-help' in sys.argv or '--help' in sys.argv:
         print(USAGE)
     else:
-        createLineFileDocsWithRandomLabels()
+        if len(sys.argv) == 3:
+            createLineFileDocsWithRandomLabels(sys.argv[1], sys.argv[2])
+        elif len(sys.argv) == 1:
+            createLineFileDocsWithRandomLabels(None, None)
+        else:
+            print("Invalid arguments")
+            exit()

--- a/src/python/example.py
+++ b/src/python/example.py
@@ -29,7 +29,9 @@ if __name__ == '__main__':
                                   ('taxonomy:Month', 'Month'),
                                   ('taxonomy:DayOfYear', 'DayOfYear'),
                                   ('sortedset:Month', 'Month'),
-                                  ('sortedset:DayOfYear', 'DayOfYear')))
+                                  ('sortedset:DayOfYear', 'DayOfYear'),
+                                  ('taxonomy:RandomLabel', 'RandomLabel'),
+                                  ('sortedset:RandomLabel', 'RandomLabel')))
 
   #Warning -- Do not break the order of arguments
   #TODO -- Fix the following by using argparser

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -1738,6 +1738,8 @@ def writeIndexHTML(searchChartData, days):
   writeOneLine(w, done, 'OrHighMedDayTaxoFacets', 'high-freq medium-freq +dayOfYear taxo facets')
   writeOneLine(w, done, 'AndHighHighDayTaxoFacets', '+high-freq +high-freq +dayOfYear taxo facets')
   writeOneLine(w, done, 'AndHighMedDayTaxoFacets', '+high-freq +medium-freq +dayOfYear taxo facets')
+  writeOneLine(w, done, 'BrowseRandomLabelTaxoFacets', 'Random labels chosen from each doc')
+  writeOneLine(w, done, 'BrowseRandomLabelSSDVFacets', 'Random labels chosen from each doc (doc values)')
 
   w('<br><br><b>Sorting (on TermQuery):</b>')
   writeOneLine(w, done, 'TermDTSort', 'Date/time (long, high cardinality)')
@@ -1811,7 +1813,9 @@ taskRename = {
   'BrowseDateTaxoFacets': 'All hierarchical taxonomy facet counts for last-modified year/month/day',
   'BrowseDayOfYearSSDVFacets': 'All flat sorted-set doc values facet counts for last-modified day-of-year',
   'BrowseMonthSSDVFacets': 'All flat sorted-set doc values facet counts for last-modified month',
-  }
+  'BrowseRandomLabelTaxoFacets': 'All flat taxonomy facet counts for a random word chosen from each doc',
+  'BrowseRandomLabelSSDVFacets' : 'All flat sorted-set doc values counts for a random word chosen from each doc',
+}
 
 def htmlEscape(s):
   return s.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')

--- a/tasks/wikimedium.10M.nostopwords.tasks
+++ b/tasks/wikimedium.10M.nostopwords.tasks
@@ -14409,7 +14409,7 @@ BrowseDayOfYearTaxoFacets: *:* +facets:DayOfYear.taxonomy
 BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
 BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
 BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
-BrowseRandomLabelSSDVFacets: *.* +facets:RandomLabel.sortedset
+BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
 
 HighTermDayOfYearSort: dayofyeardvsort//ref # freq=3793973
 HighTermDayOfYearSort: dayofyeardvsort//http # freq=3493581

--- a/tasks/wikimedium.10M.nostopwords.tasks
+++ b/tasks/wikimedium.10M.nostopwords.tasks
@@ -14408,6 +14408,8 @@ BrowseMonthTaxoFacets: *:* +facets:Month.taxonomy
 BrowseDayOfYearTaxoFacets: *:* +facets:DayOfYear.taxonomy
 BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
 BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
+BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
+BrowseRandomLabelSSDVFacets: *.* +facets:RandomLabel.sortedset
 
 HighTermDayOfYearSort: dayofyeardvsort//ref # freq=3793973
 HighTermDayOfYearSort: dayofyeardvsort//http # freq=3493581

--- a/tasks/wikimedium.10M.tasks
+++ b/tasks/wikimedium.10M.tasks
@@ -11230,6 +11230,8 @@ BrowseMonthTaxoFacets: *:* +facets:Month.taxonomy
 BrowseDayOfYearTaxoFacets: *:* +facets:DayOfYear.taxonomy
 BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
 BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
+BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
+BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
 
 HighTermDayOfYearSort: dayofyeardvsort//ref # freq=3793973
 HighTermDayOfYearSort: dayofyeardvsort//http # freq=3493581

--- a/tasks/wikimedium.1M.nostopwords.tasks
+++ b/tasks/wikimedium.1M.nostopwords.tasks
@@ -11268,6 +11268,8 @@ BrowseMonthTaxoFacets: *:* +facets:Month.taxonomy
 BrowseDayOfYearTaxoFacets: *:* +facets:DayOfYear.taxonomy
 BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
 BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
+BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
+BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
 HighTermDayOfYearSort: dayofyeardvsort//ref # freq=541190
 HighTermDayOfYearSort: dayofyeardvsort//http # freq=389790
 HighTermDayOfYearSort: dayofyeardvsort//from # freq=359428

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -73,6 +73,8 @@ BrowseMonthTaxoFacets: *:* +facets:Month.taxonomy
 BrowseDayOfYearTaxoFacets: *:* +facets:DayOfYear.taxonomy
 BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
 BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
+BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
+BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
 TermDateFacets: 0 +facets:Date.taxonomy # freq=708472
 TermDateFacets: names +facets:Date.taxonomy # freq=402762
 TermDateFacets: nbsp +facets:Date.taxonomy # freq=492778


### PR DESCRIPTION
Related issue: https://github.com/mikemccand/luceneutil/issues/141

Here are some distribution stats I got from a test run for these labels:
```
Number of ords:
1780371
Singleton count:
1416244
Top 20 taxonomy counts: 
[RandomLabel.taxonomy, the] 372665
[RandomLabel.taxonomy, of] 276350
[RandomLabel.taxonomy, |] 189343
[RandomLabel.taxonomy, and] 183320
[RandomLabel.taxonomy, in] 164785
[RandomLabel.taxonomy, =] 155886
[RandomLabel.taxonomy, to] 127328
[RandomLabel.taxonomy, a] 117079
[RandomLabel.taxonomy, *] 65859
[RandomLabel.taxonomy, is] 63901
[RandomLabel.taxonomy, was] 56826
[RandomLabel.taxonomy, The] 55280
[RandomLabel.taxonomy, for] 55161
[RandomLabel.taxonomy, EMPTY_WORD] 49364
[RandomLabel.taxonomy, by] 47790
[RandomLabel.taxonomy, on] 46427
[RandomLabel.taxonomy, as] 46382
[RandomLabel.taxonomy, with] 41801
[RandomLabel.taxonomy, |-] 38454
[RandomLabel.taxonomy, from] 35806
Average value: 
5.616806834081211
p999 count: 
460
p99 count: 
40
p95 count: 
6
p75 count: 
1
Median count: 
1
p25 count: 
1
```
