### PR TITLE
Added basic test to verify that faceting works with high cardinality …

### DIFF
--- a/src/main/perf/facets/BenchmarkFacets.java
+++ b/src/main/perf/facets/BenchmarkFacets.java
@@ -1,0 +1,160 @@
+package perf.facets;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// javac -d ../../../../build -cp ../../../../../../lucene/lucene/core/build/libs/lucene-core-10.0.0-SNAPSHOT.jar:../../../../../../lucene/lucene/facet/build/libs/lucene-facet-10.0.0-SNAPSHOT.jar:../../../../build BenchmarkFacets.java
+
+// java -cp ../../../../../../lucene/lucene/core/build/libs/lucene-core-10.0.0-SNAPSHOT.jar:../../../../../../lucene/lucene/facet/build/libs/lucene-facet-10.0.0-SNAPSHOT.jar:../../../../build perf.facets.BenchmarkFacets
+
+// java -cp ../../../../../../lucene/lucene/core/build/libs/lucene-core-10.0.0-SNAPSHOT.jar:../../../../../../lucene/lucene/facet/build/libs/lucene-facet-10.0.0-SNAPSHOT.jar:../../../../build perf.facets.BenchmarkFacets ../../../../../indices/NADFacets
+import java.io.File;
+import java.io.IOException;
+
+import java.util.List;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.facet.Facets;
+import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsConfig;
+import org.apache.lucene.facet.FacetResult;
+import org.apache.lucene.facet.sortedset.DefaultSortedSetDocValuesReaderState;
+import org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetCounts;
+import org.apache.lucene.facet.sortedset.SortedSetDocValuesReaderState;
+import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
+import org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.SearcherFactory;
+import org.apache.lucene.search.SearcherManager;
+import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.store.Directory;
+
+import perf.OpenDirectory;
+
+public class BenchmarkFacets {
+
+    public static double BILLION = 1000000000;
+
+    public static void main(String[] args) throws IOException {
+        File indexPath = new File(args[0]);
+
+        final Directory dir;
+        OpenDirectory od = OpenDirectory.get("NIOFSDirectory");
+        dir = od.open(indexPath.toPath());
+
+        IndexWriterConfig iwc = new IndexWriterConfig(new StandardAnalyzer());
+        IndexWriter writer = new IndexWriter(dir, iwc);
+
+        final ReferenceManager<IndexSearcher> mgr = new SearcherManager(writer, new SearcherFactory() {
+            @Override
+            public IndexSearcher newSearcher(IndexReader reader, IndexReader previous) {
+                IndexSearcher s = new IndexSearcher(reader);
+                s.setQueryCache(null); // don't bench the cache
+                return s;
+            }
+        });
+
+        IndexSearcher s = mgr.acquire();
+
+        final Directory taxoDir;
+        File taxoPath = new File(args[0] + "/taxonomy");
+        taxoDir = od.open(taxoPath.toPath());
+        DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
+
+        FacetsConfig config = new FacetsConfig();
+        config.setIndexFieldName("address.taxonomy", "address.taxonomy");
+        config.setHierarchical("address.taxonomy", true);
+
+        try {
+            System.out.println("Number of docs: " + s.getIndexReader().numDocs());
+            System.out.println("Number of segments: " + s.getIndexReader().leaves().size());
+            String ssdvFieldName = "address.sortedset";
+            String taxoFieldName = "address.taxonomy";
+
+            System.out.println("Testing facet instanciation...");
+
+            FacetsCollector c = new FacetsCollector();
+            s.search(new MatchAllDocsQuery(), c);
+
+            long createFastTaxoCountsStart = System.nanoTime();
+            Facets taxoFacets = new FastTaxonomyFacetCounts(taxoFieldName, taxoReader, config, c);
+            long createFastTaxoCountsEnd = System.nanoTime();
+            double createFastTaxoCountsTime = (double)(createFastTaxoCountsEnd - createFastTaxoCountsStart) / BILLION;
+
+            // only benchmark count creation
+            SortedSetDocValuesReaderState state = new DefaultSortedSetDocValuesReaderState(s.getIndexReader());
+            long createSSDVReaderStateStart = System.nanoTime();
+            Facets ssdvFacets = new SortedSetDocValuesFacetCounts(state, c);
+            long createSSDVReaderStateEnd = System.nanoTime();
+            double createSSDVReaderStateTime = (double)(createSSDVReaderStateEnd - createSSDVReaderStateStart) / BILLION;
+
+            System.out.println("Time (s) taken to instanciate FastTaxonomyFacetCounts: " + createFastTaxoCountsTime);
+            System.out.println("Time (s) taken to instanciate SSDVFacetCounts: " + createSSDVReaderStateTime);
+            System.out.println("Percent difference: " + getPercentDiff(createFastTaxoCountsTime, createSSDVReaderStateTime) + "%");
+
+            // test getAllDims (there is only 1 dim, address.taxonomy or sortedset.taxonomy)
+            System.out.println("Testing getAllDims...");
+
+            long taxoGetAllDimsStart = System.nanoTime();
+            List<FacetResult> results = taxoFacets.getAllDims(5);
+            long taxoGetAllDimsEnd = System.nanoTime();
+            double taxoGetAllDimsTime = (double) (taxoGetAllDimsEnd - taxoGetAllDimsStart) / BILLION;
+
+            long ssdvGetAllDimsStart = System.nanoTime();
+            results = ssdvFacets.getAllDims(5);
+            long ssdvGetAllDimsEnd = System.nanoTime();
+            double ssdvGetAllDimsTime = (double) (ssdvGetAllDimsEnd - ssdvGetAllDimsStart) / BILLION;
+
+            System.out.println("Time (s) taken to get all dims for taxonomy: " + taxoGetAllDimsTime);
+            System.out.println("Time (s) taken to get all dims for SSDV: " + ssdvGetAllDimsTime);
+            System.out.println("Percent difference: " + getPercentDiff(taxoGetAllDimsTime, ssdvGetAllDimsTime) + "%");
+
+            // test get top children
+            System.out.println("Testing getTopChildren...");
+
+            long taxoGetChildrenStart = System.nanoTime();
+            FacetResult result = taxoFacets.getTopChildren(10, taxoFieldName, "TX");
+            long taxoGetAllChildrenEnd = System.nanoTime();
+            double taxoGetAllChildrenTime = (double) (taxoGetAllChildrenEnd - taxoGetAllDimsStart) / BILLION;
+
+            long ssdvGetChildrenStart = System.nanoTime();
+            result = ssdvFacets.getTopChildren(10, ssdvFieldName, "TX");
+            long ssdvGetChildrenEnd = System.nanoTime();
+            double ssdvGetAllChildrenTime = (double) (ssdvGetChildrenEnd - ssdvGetAllDimsStart) / BILLION;
+
+            System.out.println("Time (s) taken to get all dims for taxonomy: " + taxoGetAllChildrenTime);
+            System.out.println("Time (s) taken to get all dims for SSDV: " + ssdvGetAllChildrenTime);
+            System.out.println("Percent difference: " + getPercentDiff(taxoGetAllChildrenTime, ssdvGetAllChildrenTime) + "%");
+
+        } finally {
+            mgr.release(s);
+        }
+    }
+
+    public static double getPercentDiff(double a, double b) {
+        if (a == b) {
+            return 100.0;
+        }
+        double larger = a > b ? a : b;
+        double smaller = a > b ? b : a;
+        return (larger / smaller) * 100;
+    }
+}

--- a/src/main/perf/facets/IndexFacets.java
+++ b/src/main/perf/facets/IndexFacets.java
@@ -1,0 +1,127 @@
+package perf.facets;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// javac -d ../../../../build -cp ../../../../../../lucene/lucene/core/build/libs/lucene-core-10.0.0-SNAPSHOT.jar:../../../../../../lucene/lucene/facet/build/libs/lucene-facet-10.0.0-SNAPSHOT.jar:../../../../build IndexFacets.java
+
+// java -cp ../../../../../../lucene/lucene/core/build/libs/lucene-codecs-10.0.0-SNAPSHOT.jar:../../../../../../lucene/lucene/facet/build/libs/lucene-facet-10.0.0-SNAPSHOT.jar:../../../../build perf.facets.IndexFacets
+
+// for indexing NAD facets: java -cp ../../../../../../lucene/lucene/core/build/libs/lucene-core-10.0.0-SNAPSHOT.jar:../../../../../../lucene/lucene/facet/build/libs/lucene-facet-10.0.0-SNAPSHOT.jar:../../../../build perf.facets.IndexFacets ../../../../../data/NAD_taxonomy.txt.gz ../../../../../indices/NADFacets
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.io.Reader;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Enumeration;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.zip.GZIPInputStream;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.facet.FacetsConfig;
+import org.apache.lucene.facet.FacetField;
+import org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetField;
+import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
+import org.apache.lucene.facet.taxonomy.TaxonomyWriter;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+
+import perf.OpenDirectory;
+
+public class IndexFacets {
+
+    public static void main(String args[]) throws IOException {
+        String facetFile = args[0];
+        File indexPath = new File(args[1]);
+
+        final Directory dir;
+        OpenDirectory od = OpenDirectory.get("NIOFSDirectory");
+        dir = od.open(indexPath.toPath());
+
+        IndexWriterConfig iwc = new IndexWriterConfig(new StandardAnalyzer());
+        IndexWriter writer = new IndexWriter(dir, iwc);
+
+        final Directory taxoDir;
+        File taxoPath = new File(args[1] + "/taxonomy");
+        taxoDir = od.open(taxoPath.toPath());
+        TaxonomyWriter taxo = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode.CREATE);
+
+        InputStream fileStream = new FileInputStream(facetFile);
+        InputStream gzipStream = new GZIPInputStream(fileStream);
+        Reader decoder = new InputStreamReader(gzipStream, "utf8");
+        BufferedReader buffered = new BufferedReader(decoder);
+        Stream<String> lines = buffered.lines();
+
+        FacetsConfig config = new FacetsConfig();
+        config.setIndexFieldName("address.taxonomy", "address.taxonomy");
+        config.setHierarchical("address.taxonomy", true);
+
+        lines.limit(60000000).forEach(withCounter((i, line) -> {
+            String[] lineArr = line.split(",");
+
+            if (lineArr == null) {
+                return;
+            }
+            for (String label : lineArr) {
+                if (label == null || label.isEmpty()) {
+                    return;
+                }
+            }
+
+            Document doc = new Document();
+            doc.add(new SortedSetDocValuesFacetField("address.sortedset", lineArr));
+
+            Document doc2 = new Document();
+            doc2.add(new FacetField("address.taxonomy", lineArr));
+
+            try {
+                writer.addDocument(config.build(doc));
+                writer.addDocument(config.build(taxo, doc2));
+            } catch (Exception e) {
+                System.out.println("Problem adding document");
+            }
+
+            if (i % 100000 == 0) {
+                System.out.println("Indexed " + i + " documents");
+            }
+        }));
+
+        writer.commit();
+        writer.forceMerge(1);
+        taxo.commit();
+        writer.close();
+        taxo.close();
+        dir.close();
+        taxoDir.close();
+    }
+
+    public static <T> Consumer<T> withCounter(BiConsumer<Integer, T> consumer) {
+        AtomicInteger counter = new AtomicInteger(0);
+        return item -> consumer.accept(counter.getAndIncrement(), item);
+    }
+}

--- a/src/python/generateNADTaxonomies.py
+++ b/src/python/generateNADTaxonomies.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# source data: https://www.transportation.gov/gis/national-address-database
+
+from zipfile import ZipFile
+import gzip
+import os
+
+STATE_INDEX = 1
+COUNTY_INDEX = 2
+STREETNAME_INDEX = 15
+ADDNAME_INDEX = 20
+
+with ZipFile('../../../data/NAD_r8_TXT.zip', 'r') as zip:
+    with zip.open('TXT/NAD_r8.txt', 'r') as nad:
+        with gzip.open('../../../data/NAD_taxonomy.txt.gz', 'wb') as out:
+            i = 0
+            skipped_lines = 0
+            for line in nad:
+                if i % 100000 == 0:
+                    print("Processed ", i, " lines")
+                str_line = line.decode('utf-8')
+                line_arr = str_line.split(',')
+                if len(line_arr) < 21:
+                    skipped_lines += 1
+                    continue
+                hierarchy = (
+                    line_arr[STATE_INDEX],
+                    line_arr[COUNTY_INDEX],
+                    line_arr[STREETNAME_INDEX],
+                    line_arr[ADDNAME_INDEX]
+                )
+                if hierarchy[2] == '':
+                    hierarchy = (hierarchy[0], hierarchy[1], 'NONE', hierarchy[3])
+                if hierarchy[3] == '':
+                    hierarchy = (hierarchy[0], hierarchy[1], hierarchy[2], 'NONE')
+                str_hierarchy = hierarchy[0] + "," + hierarchy[1] + "," + hierarchy[2] + "," + hierarchy[3] + '\n'
+                out.write(str_hierarchy.encode('utf8'))
+                i += 1
+            print('Read', i, 'lines')
+            print('Skipped', skipped_lines, 'lines')
+            print('NAD_taxonomy.txt.gz contains', os.stat('../../../data/NAD_taxonomy.txt.gz').st_size,
+                  'bytes of compressed data')


### PR DESCRIPTION
…fields, files added in this commit are not accurate benchmarks

Wrote a script that reads the NAD database (can be downloaded here: https://www.transportation.gov/gis/national-address-database/national-address-database-nad-disclaimer), then indexes and runs some basic faceting tests. This is not an accurate benchmark, but can probably be used as the basis for a real high cardinality faceting benchmark in the future. It also serves a test to make sure that faceting is still able to be used with high cardinality facets even if benchmark timing is not accurate.

Also needs to be used in conjunction with the SSDV hierarchical field changes: https://github.com/apache/lucene/pull/509