### PR TITLE
Wrap directory reader by ExitableDirectoryReader when timeout is given

### DIFF
--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -411,7 +411,7 @@ public class SearchPerfTest {
     } else {
       dir = dir0;
       writer = null;
-      DirectoryReader _reader;
+      final DirectoryReader _reader;
       if (commit != null && commit.length() > 0) {
         System.out.println("Opening searcher on commit=" + commit);
         _reader = DirectoryReader.open(PerfUtils.findCommitPoint(commit, dir));

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1111,6 +1111,8 @@ class RunAlgs:
       w('-loadStoredFields')
     if c.vectorDict:
       w('-vectorDict', c.vectorDict)
+    if c.timeout:
+      w('-timeout', c.timeout)
 
     print('      log: %s + stdout' % logFile)
     t0 = time.time()

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -268,6 +268,7 @@ class Competitor(object):
                pk = True,
                vectorDict = None,
                loadStoredFields = False,
+               timeout = None,
                concurrentSearches = False,
                javacCommand = constants.JAVAC_EXE):
     self.name = name
@@ -289,6 +290,7 @@ class Competitor(object):
     self.pk = pk
     self.loadStoredFields = loadStoredFields
     self.vectorDict = vectorDict
+    self.timeout = timeout
     self.javacCommand = javacCommand
     self.concurrentSearches = concurrentSearches
 


### PR DESCRIPTION
#168 

Wrap the directory reader by `ExitableDirectoryReader` when `timeout` parameter is given to `Competitor`. The `timeout` value is passed to `QueryTimeoutImpl`'s constroctor.

Usage (`localrun.py`)
```python
  # baseline
  comp.competitor('baseline', 'lucene_baseline',
                  index = index, concurrentSearches = concurrentSearches)
  # with timeout = -1 (interpreted to Long.MAX_VALUE)
  comp.competitor('exitable_directory_reader', 'lucene_candidate',
                  index = index, timeout = -1, concurrentSearches = concurrentSearches)
```

Result (with `-source wikimedium1m`)
```
                           TaskQPS baseline      StdDevQPS exitable_directory_reader      StdDev                Pct diff p-value
           BrowseMonthSSDVFacets      215.32     (12.5%)      108.82      (8.6%)  -49.5% ( -62% -  -32%) 0.000
           BrowseMonthTaxoFacets      161.40      (8.6%)       84.60     (19.7%)  -47.6% ( -69% -  -21%) 0.000
       BrowseDayOfYearTaxoFacets      170.11      (5.0%)       91.32     (23.5%)  -46.3% ( -71% -  -18%) 0.000
            BrowseDateTaxoFacets      170.15      (5.5%)       91.78     (23.7%)  -46.1% ( -71% -  -17%) 0.000
       BrowseDayOfYearSSDVFacets      188.28     (10.5%)      101.95      (6.8%)  -45.9% ( -57% -  -31%) 0.000
     BrowseRandomLabelTaxoFacets      159.62      (5.8%)       87.30     (23.0%)  -45.3% ( -70% -  -17%) 0.000
     BrowseRandomLabelSSDVFacets      130.81      (6.7%)       79.89      (7.0%)  -38.9% ( -49% -  -27%) 0.000
                          IntNRQ      673.87     (11.7%)      594.62      (8.3%)  -11.8% ( -28% -    9%) 0.000
            BrowseDateSSDVFacets       24.90     (13.1%)       22.25      (8.0%)  -10.7% ( -28% -   11%) 0.002
               HighTermMonthSort     1067.73     (17.5%)      991.56     (12.8%)   -7.1% ( -31% -   28%) 0.141
           HighTermDayOfYearSort      781.71     (16.5%)      730.64     (12.3%)   -6.5% ( -30% -   26%) 0.156
                      OrHighHigh      272.23      (5.1%)      263.73      (5.1%)   -3.1% ( -12% -    7%) 0.052
                       OrHighMed      685.53      (5.1%)      668.52      (4.0%)   -2.5% ( -11% -    7%) 0.089
             MedIntervalsOrdered      158.82      (8.0%)      156.62      (6.4%)   -1.4% ( -14% -   14%) 0.546
            HighIntervalsOrdered      186.14      (8.2%)      184.74      (6.4%)   -0.8% ( -14% -   15%) 0.746
                      HighPhrase       95.81      (3.4%)       95.20      (4.1%)   -0.6% (  -7% -    7%) 0.593
                     AndHighHigh      224.46      (4.4%)      223.45      (3.2%)   -0.5% (  -7% -    7%) 0.712
                         Respell      174.56      (3.4%)      173.89      (3.0%)   -0.4% (  -6% -    6%) 0.707
                       LowPhrase      441.50      (2.4%)      440.13      (2.7%)   -0.3% (  -5% -    4%) 0.702
                       MedPhrase      512.08      (3.3%)      511.27      (3.1%)   -0.2% (  -6% -    6%) 0.877
                      AndHighLow     2884.69      (6.5%)     2882.72      (7.2%)   -0.1% ( -12% -   14%) 0.975
                       OrHighLow      966.84      (3.4%)      966.69      (5.4%)   -0.0% (  -8% -    9%) 0.991
                         MedTerm     3089.48      (4.2%)     3090.78      (6.4%)    0.0% ( -10% -   11%) 0.980
                 MedSloppyPhrase      191.41      (2.9%)      191.55      (2.1%)    0.1% (  -4% -    5%) 0.925
                         LowTerm     4190.05      (6.6%)     4199.21      (7.0%)    0.2% ( -12% -   14%) 0.919
                HighSloppyPhrase      144.64      (3.5%)      145.28      (2.2%)    0.4% (  -5% -    6%) 0.632
                 LowSloppyPhrase      204.37      (3.5%)      205.28      (2.4%)    0.4% (  -5% -    6%) 0.642
                          Fuzzy2      235.10      (5.2%)      236.56      (5.1%)    0.6% (  -9% -   11%) 0.701
             LowIntervalsOrdered      992.74      (5.9%)      999.93      (4.6%)    0.7% (  -9% -   11%) 0.663
                      AndHighMed     1222.84      (6.2%)     1235.50      (5.0%)    1.0% (  -9% -   13%) 0.562
                     LowSpanNear      904.43      (3.2%)      917.86      (3.5%)    1.5% (  -5% -    8%) 0.160
                          Fuzzy1      183.16      (3.3%)      185.90      (3.1%)    1.5% (  -4% -    8%) 0.140
                     MedSpanNear      552.09      (2.6%)      561.28      (2.8%)    1.7% (  -3% -    7%) 0.050
                    HighSpanNear       57.30      (5.6%)       58.50      (5.2%)    2.1% (  -8% -   13%) 0.222
                        PKLookup      258.67      (8.3%)      264.17      (8.2%)    2.1% ( -13% -   20%) 0.415
                         Prefix3     1412.27      (7.4%)     1445.00      (5.5%)    2.3% (  -9% -   16%) 0.261
                        HighTerm     2254.64      (6.1%)     2308.29      (4.0%)    2.4% (  -7% -   13%) 0.146
                        Wildcard      494.59      (4.2%)      507.74      (5.3%)    2.7% (  -6% -   12%) 0.081
```
