### PR TITLE
handle vectors scaled for 8 bit storage

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,7 +37,7 @@
   <target name="vectors300-docs" depends="build">
     <java className="WikiVectors" classpathref="build.classpath">
       <arg value="${data.dir}/glove.6B.300d.txt"/>
-      <arg value="${data.dir}/enwiki-20120502-lines-1k.txt"/>
+      <arg value="${data.dir}/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt"/>
       <arg value="${data.dir}/enwiki-20120502-lines-1k-300d.vec"/>
     </java>
   </target>
@@ -55,11 +55,23 @@
   <target name="vectors100-docs" depends="build">
     <java className="WikiVectors" classpathref="build.classpath">
       <arg value="${data.dir}/glove.6B.100d.txt"/>
-      <arg value="${data.dir}/enwiki-20120502-lines-1k.txt"/>
+      <arg value="${data.dir}/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt"/>
       <arg value="${data.dir}/enwiki-20120502-lines-1k-100d.vec"/>
     </java>
   </target>
 
-  <target name="vectors100" depends="vectors100-tasks,vectors100-docs"/>
+  <target name="vectors100-8bit-docs" depends="build">
+    <java className="WikiVectors" classpathref="build.classpath">
+      <!-- scale was determined by checking 1/99 %iles of vector samples in this data = 1 -->
+      <arg value="-scale"/>
+      <arg value="128"/>
+      <arg value="${data.dir}/glove.6B.100d.txt"/>
+      <arg value="${data.dir}/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt"/>
+      <arg value="${data.dir}/enwiki-20120502-lines-1k-100d-8bit.vec"/>
+    </java>
+  </target>
+
+  <!-- don't scale the task data here; we'll do it later after summing vectors for each term -->
+  <target name="vectors100" depends="vectors100-tasks,vectors100-docs,vectors100-8bit-docs"/>
 
 </project>

--- a/src/main/WikiVectors.java
+++ b/src/main/WikiVectors.java
@@ -29,6 +29,8 @@ import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 import perf.VectorDictionary;
 
@@ -45,12 +47,25 @@ public class WikiVectors {
   int dimension;
 
   public static void main(String[] args) throws Exception {
-    if (args.length != 3) {
-      System.err.println("usage: WikiVectors <vectorDictionary> <lineDocs> <docVectorOutput>");
-      System.exit(-1);
+    if (args.length < 3) {
+      usage();
     }
-    WikiVectors wv = new WikiVectors(new VectorDictionary(args[0]));
-    wv.computeVectors(args[1], args[2]);
+    float scale = 1;
+    List<String> argList = List.of(args);
+    if (args[0].equals("-scale")) {
+      scale = Float.parseFloat(args[1]);
+      argList = argList.subList(2, argList.size());
+    }
+    if (argList.size() != 3) {
+      usage();
+    }
+    WikiVectors wv = new WikiVectors(new VectorDictionary(argList.get(0), scale));
+    wv.computeVectors(argList.get(1), argList.get(2));
+  }
+
+  static void usage() {
+      System.err.println("usage: WikiVectors [-scale X] <vectorDictionary> <lineDocs> <docVectorOutput>");
+      System.exit(-1);
   }
 
   WikiVectors(VectorDictionary dict) {

--- a/src/main/perf/LineFileDocs.java
+++ b/src/main/perf/LineFileDocs.java
@@ -73,6 +73,14 @@ public class LineFileDocs implements Closeable {
 
   // sentinel:
   private final static LineFileDoc END = new LineFileDoc("END", null);
+  private final static VectorSimilarityFunction VECTOR_SIMILARITY = dotProductSimilarity();
+  private static VectorSimilarityFunction dotProductSimilarity() {
+    try {
+      return VectorSimilarityFunction.valueOf("DOT_PRODUCT8");
+    } catch (IllegalArgumentException e) {
+      return VectorSimilarityFunction.DOT_PRODUCT;
+    }
+  }
 
   private final AtomicInteger nextID = new AtomicInteger();
 
@@ -441,7 +449,7 @@ public class LineFileDocs implements Closeable {
 
       if (vectorDimension > 0) {
         // create a throwaway vector so the field's type gets the proper dimension
-        vector = new KnnVectorField("vector", new float[vectorDimension], VectorSimilarityFunction.DOT_PRODUCT);
+        vector = new KnnVectorField("vector", new float[vectorDimension], VECTOR_SIMILARITY);
         doc.add(vector);
       } else {
         vector = null;

--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -435,7 +435,7 @@ public class SearchPerfTest {
     {
       IndexSearcher s = mgr.acquire();
       try {
-        System.out.println("Searcher: numDocs=" + s.getIndexReader().numDocs() + " maxDoc=" + s.getIndexReader().maxDoc() + ": " + s);
+        System.out.println("Searcher: numDocs=" + s.getIndexReader().numDocs() + " maxDoc=" + s.getIndexReader().maxDoc());
       } finally {
         mgr.release(s);
       }
@@ -510,7 +510,18 @@ public class SearchPerfTest {
     final IndexState indexState = new IndexState(mgr, taxoReader, fieldName, spellChecker, hiliteImpl, facetsConfig, facetDimMethods);
 
     final QueryParser queryParser = new QueryParser("body", a);
-    TaskParser taskParser = new TaskParser(indexState, queryParser, fieldName, topN, staticRandom, vectorFile, doStoredLoads);
+    VectorDictionary vectorDictionary;
+    if (vectorFile != null) {
+      Float scale = args.getFloat("-vectorScale");
+      if (scale != null) {
+        vectorDictionary = new VectorDictionary(vectorFile, scale);
+      } else {
+        vectorDictionary = new VectorDictionary(vectorFile, 1f);
+      }
+    } else {
+      vectorDictionary = null;
+    }
+    TaskParser taskParser = new TaskParser(indexState, queryParser, fieldName, topN, staticRandom, vectorDictionary, doStoredLoads);
 
     final TaskSource tasks;
 

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -70,7 +70,7 @@ class TaskParser {
                     String fieldName,
                     int topN,
                     Random random,
-                    String vectorFile,
+                    VectorDictionary vectorDictionary,
                     boolean doStoredLoads) throws IOException {
     this.queryParser = queryParser;
     this.fieldName = fieldName;
@@ -78,11 +78,10 @@ class TaskParser {
     this.random = random;
     this.doStoredLoads = doStoredLoads;
     this.state = state;
-    if (vectorFile != null) {
-      vectorDictionary = new VectorDictionary(vectorFile);
+    this.vectorDictionary = vectorDictionary;
+    if (vectorDictionary != null) {
       vectorField = "vector";
     } else {
-      vectorDictionary = null;
       vectorField = null;
     }
     titleDVSort = new Sort(new SortField("titleDV", SortField.Type.STRING));

--- a/src/main/perf/VectorDictionary.java
+++ b/src/main/perf/VectorDictionary.java
@@ -30,12 +30,14 @@ import java.util.HashMap;
 public class VectorDictionary {
 
   private final Map<String, float[]> dict = new HashMap<>();
+  private final float scale;
 
   public final int dimension;
 
-  public VectorDictionary(String filename) throws IOException {
+  public VectorDictionary(String filename, float scale) throws IOException {
     // read a dictionary file where each line has a token and its n-dimensional vector as text:
     // <word> <f1> <f2> ... <fn>
+    this.scale = scale;
     int dim = 0;
     try (BufferedReader reader = Files.newBufferedReader(Paths.get(filename), StandardCharsets.UTF_8)) {
       String line = reader.readLine();
@@ -46,11 +48,13 @@ public class VectorDictionary {
           String err = String.format("vector dimension %s is not the initial dimension: %s for line: %s", lineDim, dim, line);
           throw new IllegalStateException(err);
         }
+        /*
         if (dict.size() % 10000 == 0) {
           System.out.print("loaded " + dict.size() + "\n");
         }
+        */
       }
-    } catch (IOException e) {
+    } catch (Exception e) {
       System.err.println("An error occurred after reading " + dict.size() + " entries from " + filename);
       throw e;
     }
@@ -70,8 +74,8 @@ public class VectorDictionary {
       vector[i - 1] = Float.parseFloat(parts[i]);
     }
     double norm = vectorNorm(vector);
-    // We want only unit vectors
     if (norm > 0) {
+      // We want unit vectors
       vectorDiv(vector, norm);
       dict.put(token, vector);
     } else {
@@ -94,11 +98,7 @@ public class VectorDictionary {
         count++;
       }
     }
-    vectorDiv(dvec, vectorNorm(dvec));
-    if (Math.abs(vectorNorm(dvec) - 1) > 1e-5) {
-      throw new IllegalStateException("Vector is not unitary for doc '" + text + "'" +
-                                      " norm=" + vectorNorm(dvec));
-    }
+    vectorDiv(dvec, vectorNorm(dvec) / scale);
     return dvec;
   }
 

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -743,7 +743,7 @@ def stats(l):
     return min(l), max(l), sum/len(l), math.sqrt(len(l)*sumSQ - sum*sum)/len(l)
 
 def run(cmd, logFile=None, indent='    '):
-  print('%s[RUN: %s, cwd=%s]' % (indent, cmd, os.getcwd()))
+  #print('%s[RUN: %s, cwd=%s]' % (indent, cmd, os.getcwd()))
   if logFile is not None:
     out = open(logFile, 'wb')
   else:
@@ -1111,6 +1111,8 @@ class RunAlgs:
       w('-loadStoredFields')
     if c.vectorDict:
       w('-vectorDict', c.vectorDict)
+    if c.vectorScale:
+      w('-vectorScale', c.vectorScale)
     if c.exitable:
       w('-exitable')
 

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -54,6 +54,7 @@ WIKI_BIG_1M = Data('wikibig1m', constants.WIKI_BIG_DOCS_LINE_FILE, 1000000, cons
 EURO_MEDIUM = Data('euromedium', constants.EUROPARL_MEDIUM_DOCS_LINE_FILE, 5000000, constants.EUROPARL_MEDIUM_TASKS_FILE)
 
 WIKI_VECTOR_10K = Data('wikivector10k', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 10000, constants.WIKI_VECTOR_TASKS_FILE)
+WIKI_VECTOR_1M = Data('wikivector1m', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 1000000, constants.WIKI_VECTOR_TASKS_FILE)
 
 DISJUNCTION_SIMPLE = Data('disjunctionSimple',
                           constants.DISJUNCTION_DOCS_LINE_FILE,
@@ -97,6 +98,7 @@ DATA = {'wikimediumall': WIKI_MEDIUM_ALL,
         'wikibig1m' : WIKI_BIG_1M,
         'euromedium' : EURO_MEDIUM,
         'wikivector10k' : WIKI_VECTOR_10K,
+        'wikivector1m' : WIKI_VECTOR_1M,
         'disjunctionSimple' : DISJUNCTION_SIMPLE,
         'disjunctionRealistic' : DISJUNCTION_REALISTIC,
         'disjunctionIntensive' : DISJUNCTION_INTENSIVE,
@@ -267,6 +269,7 @@ class Competitor(object):
                hiliteImpl = 'FastVectorHighlighter',
                pk = True,
                vectorDict = None,
+               vectorScale = 1,
                loadStoredFields = False,
                exitable = False,
                concurrentSearches = False,
@@ -291,6 +294,7 @@ class Competitor(object):
     self.loadStoredFields = loadStoredFields
     self.exitable = exitable
     self.vectorDict = vectorDict
+    self.vectorScale = vectorScale
     self.javacCommand = javacCommand
     self.concurrentSearches = concurrentSearches
 

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -38,6 +38,7 @@ WIKI_MEDIUM_DOCS_COUNT = 33332620
 # Thanks to Jeffrey Pennington, Richard Socher, and Christopher D. Manning.
 GLOVE_WORD_VECTORS_FILE = '%s/data/glove.6B.100d.txt' % BASE_DIR
 GLOVE_VECTOR_DOCS_FILE = '%s/data/enwiki-20120502-lines-1k-100d.vec' % BASE_DIR
+GLOVE_VECTOR8_DOCS_FILE = '%s/data/enwiki-20120502-lines-1k-100d-8bit.vec' % BASE_DIR
 
 #WIKI_MEDIUM_TASKS_10MDOCS_FILE = '%s/tasks/wikimedium.10M.tasks' % BENCH_BASE_DIR
 WIKI_MEDIUM_TASKS_10MDOCS_FILE = '%s/tasks/wikimedium.10M.nostopwords.tasks' % BENCH_BASE_DIR

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -31,6 +31,7 @@ BASE_URL2 = 'https://home.apache.org/~sokolov'
 DATA_FILES = [
   ('enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma', BASE_URL),
   ('enwiki-20120502-lines-1k-100d.vec', BASE_URL2),
+  #('enwiki-20120502-lines-1k-100d-8bit.vec', BASE_URL2),
   ('wikimedium500.tasks', BASE_URL),
   ('glove.6B.zip', 'https://downloads.cs.stanford.edu/nlp/data/')
 ]


### PR DESCRIPTION
I wanted to test LUCENE-10577: https://github.com/apache/lucene/pull/913 with luceneutil. This 

1. Adds a reference to a scaled vector document file that I uploaded to a shared space in my apache homedir
2. Adds support for scaling vectors to WIkiVectors, VectorDictionary, and SearchPerfTest
3. Defaults to using 8-bit vector storage when it is available

We probably shouldn't push this until we actually commit the Lucene changes it's intended to test. Although it wouldn't break anything. we might end up shipping something a bit different