### PR TITLE
added getAllChildren to benchmark

### DIFF
--- a/src/main/perf/facets/BenchmarkFacets.java
+++ b/src/main/perf/facets/BenchmarkFacets.java
@@ -105,8 +105,8 @@ public class BenchmarkFacets {
                 ssdvFacets.getTopDims(5, 5);
                 taxoFacets.getTopChildren(10, TAXO_FIELD_NAME, "TX");
                 ssdvFacets.getTopChildren(10, SSDV_FIELD_NAME, "TX");
-                taxoFacets.getAllChildren(TAXO_FIELD_NAME);
-                ssdvFacets.getAllChildren(SSDV_FIELD_NAME);
+                taxoFacets.getAllChildren(TAXO_FIELD_NAME, "TX");
+                ssdvFacets.getAllChildren(SSDV_FIELD_NAME, "TX");
             }
 
             System.out.println("Number of docs: " + s.getIndexReader().numDocs());
@@ -180,13 +180,13 @@ public class BenchmarkFacets {
                 totalSSDVGetTopChildrenTimeMS += ssdvGetTopChildrenTimeMS;
 
                 long taxoGetAllChildrenStartNS = System.nanoTime();
-                result = taxoFacets.getAllChildren(TAXO_FIELD_NAME);
+                result = taxoFacets.getAllChildren(TAXO_FIELD_NAME, "TX");
                 long taxoGetAllChildrenEndNS = System.nanoTime();
                 double taxoGetAllChildrenTimeMS = (double) (taxoGetAllChildrenEndNS - taxoGetAllChildrenStartNS) / MILLION;
                 totalTaxoGetAllChildrenTimeMS += taxoGetAllChildrenTimeMS;
 
                 long ssdvGetAllChildrenStartNS = System.nanoTime();
-                result = ssdvFacets.getAllChildren(SSDV_FIELD_NAME);
+                result = ssdvFacets.getAllChildren(SSDV_FIELD_NAME, "TX");
                 long ssdvGetAllChildrenEndNS = System.nanoTime();
                 double ssdvGetAllChildrenTimeMS = (double) (ssdvGetAllChildrenEndNS - ssdvGetAllChildrenStartNS) / MILLION;
                 totalSSDVGetAllChildrenTimeMS += ssdvGetAllChildrenTimeMS;

--- a/src/main/perf/facets/BenchmarkFacets.java
+++ b/src/main/perf/facets/BenchmarkFacets.java
@@ -105,6 +105,8 @@ public class BenchmarkFacets {
                 ssdvFacets.getTopDims(5, 5);
                 taxoFacets.getTopChildren(10, TAXO_FIELD_NAME, "TX");
                 ssdvFacets.getTopChildren(10, SSDV_FIELD_NAME, "TX");
+                taxoFacets.getAllChildren(TAXO_FIELD_NAME);
+                ssdvFacets.getAllChildren(SSDV_FIELD_NAME);
             }
 
             System.out.println("Number of docs: " + s.getIndexReader().numDocs());
@@ -120,8 +122,10 @@ public class BenchmarkFacets {
             double totalSSDVGetAllDimsTimeMS = 0;
             double totalTaxoGetTopDimsTimeMS = 0;
             double totalSSDVGetTopDimsTimeMS = 0;
-            double totalTaxoGetChildrenTimeMS = 0;
-            double totalSSDVGetChildrenTimeMS = 0;
+            double totalTaxoGetTopChildrenTimeMS = 0;
+            double totalSSDVGetTopChildrenTimeMS = 0;
+            double totalTaxoGetAllChildrenTimeMS = 0;
+            double totalSSDVGetAllChildrenTimeMS = 0;
 
             for (int i = 1; i < numIters + 1; i++) {
                 FacetsCollector c = new FacetsCollector();
@@ -163,17 +167,29 @@ public class BenchmarkFacets {
                 double ssdvGetTopDimsTimeMS = (double) (ssdvGetTopDimsEndNS - ssdvGetTopDimsStartNS) / MILLION;
                 totalSSDVGetTopDimsTimeMS += ssdvGetTopDimsTimeMS;
 
-                long taxoGetChildrenStartNS = System.nanoTime();
+                long taxoGetTopChildrenStartNS = System.nanoTime();
                 FacetResult result = taxoFacets.getTopChildren(10, TAXO_FIELD_NAME, "TX");
-                long taxoGetAllChildrenEndNS = System.nanoTime();
-                double taxoGetAllChildrenTimeMS = (double) (taxoGetAllChildrenEndNS - taxoGetChildrenStartNS) / MILLION;
-                totalTaxoGetChildrenTimeMS += taxoGetAllChildrenTimeMS;
+                long taxoGetTopChildrenEndNS = System.nanoTime();
+                double taxoGetTopChildrenTimeMS = (double) (taxoGetTopChildrenEndNS - taxoGetTopChildrenStartNS) / MILLION;
+                totalTaxoGetTopChildrenTimeMS += taxoGetTopChildrenTimeMS;
 
-                long ssdvGetChildrenStartNS = System.nanoTime();
+                long ssdvGetTopChildrenStartNS = System.nanoTime();
                 result = ssdvFacets.getTopChildren(10, SSDV_FIELD_NAME, "TX");
-                long ssdvGetChildrenEndNS = System.nanoTime();
-                double ssdvGetAllChildrenTimeMS = (double) (ssdvGetChildrenEndNS - ssdvGetChildrenStartNS) / MILLION;
-                totalSSDVGetChildrenTimeMS += ssdvGetAllChildrenTimeMS;
+                long ssdvGetTopChildrenEndNS = System.nanoTime();
+                double ssdvGetTopChildrenTimeMS = (double) (ssdvGetTopChildrenEndNS - ssdvGetTopChildrenStartNS) / MILLION;
+                totalSSDVGetTopChildrenTimeMS += ssdvGetTopChildrenTimeMS;
+
+                long taxoGetAllChildrenStartNS = System.nanoTime();
+                result = taxoFacets.getAllChildren(TAXO_FIELD_NAME);
+                long taxoGetAllChildrenEndNS = System.nanoTime();
+                double taxoGetAllChildrenTimeMS = (double) (taxoGetAllChildrenEndNS - taxoGetAllChildrenStartNS) / MILLION;
+                totalTaxoGetAllChildrenTimeMS += taxoGetAllChildrenTimeMS;
+
+                long ssdvGetAllChildrenStartNS = System.nanoTime();
+                result = ssdvFacets.getAllChildren(SSDV_FIELD_NAME);
+                long ssdvGetAllChildrenEndNS = System.nanoTime();
+                double ssdvGetAllChildrenTimeMS = (double) (ssdvGetAllChildrenEndNS - ssdvGetAllChildrenStartNS) / MILLION;
+                totalSSDVGetAllChildrenTimeMS += ssdvGetAllChildrenTimeMS;
 
                 System.out.println("Results after iteration " + i + "\n");
 
@@ -192,9 +208,14 @@ public class BenchmarkFacets {
                 reportPercentDifference(totalTaxoGetTopDimsTimeMS / (double) i, totalSSDVGetTopDimsTimeMS / (double) i);
                 System.out.println("");
 
-                System.out.println("Time (ms) taken to get top children of \"address.taxonomy/TX\" children for taxonomy: " + totalTaxoGetChildrenTimeMS / (double) i);
-                System.out.println("Time (ms) taken to get top \"address.sortedset/TX\" children for SSDV: " + totalSSDVGetChildrenTimeMS / (double) i);
-                reportPercentDifference(totalTaxoGetChildrenTimeMS / (double) i, totalSSDVGetChildrenTimeMS / (double) i);
+                System.out.println("Time (ms) taken to get top children of \"address.taxonomy/TX\" children for taxonomy: " + totalTaxoGetTopChildrenTimeMS / (double) i);
+                System.out.println("Time (ms) taken to get top \"address.sortedset/TX\" children for SSDV: " + totalSSDVGetTopChildrenTimeMS / (double) i);
+                reportPercentDifference(totalTaxoGetTopChildrenTimeMS / (double) i, totalSSDVGetTopChildrenTimeMS / (double) i);
+                System.out.println("");
+
+                System.out.println("Time (ms) taken to get all children of \"address.taxonomy/TX\" children for taxonomy: " + totalTaxoGetAllChildrenTimeMS / (double) i);
+                System.out.println("Time (ms) taken to get all \"address.sortedset/TX\" children for SSDV: " + totalSSDVGetAllChildrenTimeMS / (double) i);
+                reportPercentDifference(totalTaxoGetAllChildrenTimeMS / (double) i, totalSSDVGetAllChildrenTimeMS / (double) i);
 
                 System.out.print("\n");
             }


### PR DESCRIPTION
We now support the getAllChildren functionality in facet and it would be nice to add it to benchmark as well. Please see below for the benchmark results after adding getAllChildren.

```
Results after iteration 20

Time (ms) taken to instanciate FastTaxonomyFacetCounts: 4123.887288349999
Time (ms) taken to instanciate SSDVFacetCounts: 10977.917832749998
SSDV is 166.2% slower than Taxonomy

Time (ms) taken to get all dims for taxonomy: 2.79734245
Time (ms) taken to get all dims for SSDV: 1.1225765500000002
Taxonomy is 149.2% slower than SSDV

Time (ms) taken to get top dims for taxonomy: 0.26965845
Time (ms) taken to get top dims for SSDV: 0.0748355
Taxonomy is 260.3% slower than SSDV

Time (ms) taken to get top children of "address.taxonomy/TX" children for taxonomy: 2.8276866000000003
Time (ms) taken to get top "address.sortedset/TX" children for SSDV: 2.7328451
Taxonomy is 3.5% slower than SSDV

Time (ms) taken to get all children of "address.taxonomy/TX" children for taxonomy: 6.882804899999999
Time (ms) taken to get all "address.sortedset/TX" children for SSDV: 3.1600861499999997
Taxonomy is 117.8% slower than SSDV
```
