### PR TITLE
benchUtil.py hppc version check inconsistency fix

### DIFF
--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1562,14 +1562,15 @@ def getClassPath(checkout):
   # TODO: this is horrible hackity abstraction violation!!  can i somehow just ask
   # gradle to tell me necessary dependency paths?
   found = False
+  hppc_dependency = 'hppc-0.9.0.jar'
   for root_path, dirs, files in os.walk(os.path.expanduser('~/.gradle/caches/modules-2/files-2.1/com.carrotsearch/hppc')):
     for file in files:
-      if file == 'hppc-0.9.0.jar':
+      if file == hppc_dependency:
         cp.append('%s/%s' % (root_path, file))
         found = True
 
   if not found:
-    raise RuntimeError('unable to locate hppc-0.8.2.jar dependency for lucene/facet!')
+    raise RuntimeError(f'unable to locate {hppc_dependency} dependency for lucene/facet!')
 
   # so perf.* is found:
   lib = os.path.join(checkoutToUtilPath(checkout), "lib")


### PR DESCRIPTION
benchUtil.py checks for hppc version 0.9.0, but raises the exception an incorrect version in the message if this dependency is not found.