### PR TITLE
Add id docValue field, fix the concurrent bug when index using binary lfd

### DIFF
--- a/src/main/perf/IndexThreads.java
+++ b/src/main/perf/IndexThreads.java
@@ -229,7 +229,7 @@ class IndexThreads {
           }
           final double docsPerGroupBlock = numTotalDocs / (double) groupBlocks.length;
 
-          while (!stop.get()) {
+          while (!stop.get() && docs.reserve()) {
             final int groupCounter = groupBlockIndex.getAndIncrement();
             if (groupCounter >= groupBlocks.length) {
               break;

--- a/src/main/perf/PKLookupTask.java
+++ b/src/main/perf/PKLookupTask.java
@@ -142,10 +142,9 @@ final class PKLookupTask extends Task {
   @Override
   public void printResults(PrintStream out, IndexState state) throws IOException {
     for(int idx=0;idx<ids.length;idx++) {
-
       if (answers[idx] == -1) {
         if (!state.hasDeletions) {
-          throw new RuntimeException("PKLookup: id=" + ids[idx].utf8ToString() + " failed to find a matching document");
+          throw new RuntimeException("PKLookup: id=" + LineFileDocs.idToInt(ids[idx].utf8ToString()) + " failed to find a matching document");
         } else {
           // TODO: we should verify that these are in fact
           // the deleted docs...


### PR DESCRIPTION
 * Add the id docValue field so that we can use indexSort on id field
 * Fix the bug where group index are claimed but not used, which eventually leads to missing document in the index when indexing using multiple threads