### PR TITLE
move jfr to logs; run out of the box after setup.py using wikimedium500

### DIFF
--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -818,7 +818,7 @@ class RunAlgs:
       w = lambda *xs : [cmd.append(str(x)) for x in xs]
       w('-classpath', classPathToString(getClassPath(index.checkout)))
 
-      jfrOutput = f'{constants.BENCH_BASE_DIR}/bench-index-{id}-{index.getName()}.jfr'
+      jfrOutput = f'{constants.LOGS_DIR}/bench-index-{id}-{index.getName()}.jfr'
 
       # 77: always enable Java Flight Recorder profiling
       w(f'-XX:StartFlightRecording=dumponexit=true,maxsize=250M,settings={constants.BENCH_BASE_DIR}/src/python/profiling.jfc' +
@@ -1071,7 +1071,7 @@ class RunAlgs:
 
     # 77: always enable Java Flight Recorder profiling
     command += [f'-XX:StartFlightRecording=dumponexit=true,maxsize=250M,settings={constants.BENCH_BASE_DIR}/src/python/profiling.jfc' +
-                f',filename={constants.BENCH_BASE_DIR}/bench-search-{id}-{c.name}-{iter}.jfr',
+                f',filename={constants.LOGS_DIR}/bench-search-{id}-{c.name}-{iter}.jfr',
                 '-XX:+UnlockDiagnosticVMOptions',
                 '-XX:+DebugNonSafepoints']
 

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -38,6 +38,7 @@ WIKI_MEDIUM_10M = Data('wikimedium10m', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 10
 WIKI_MEDIUM_5M = Data('wikimedium5m', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 5000000, constants.WIKI_MEDIUM_TASKS_10MDOCS_FILE)
 WIKI_MEDIUM_1M = Data('wikimedium1m', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 1000000, constants.WIKI_MEDIUM_TASKS_1MDOCS_FILE)
 WIKI_MEDIUM_10K = Data('wikimedium10k', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 10000, constants.WIKI_MEDIUM_TASKS_1MDOCS_FILE)
+WIKI_MEDIUM_500 = Data('wikimedium500', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 500, constants.WIKI_MEDIUM_TASKS_500DOCS_FILE)
 WIKI_MEDIUM_500K = Data('wikimedium500k', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 500000, constants.WIKI_MEDIUM_TASKS_1MDOCS_FILE)
 WIKI_MEDIUM_2M = Data('wikimedium2m', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 2000000, constants.WIKI_MEDIUM_TASKS_1MDOCS_FILE)
 
@@ -86,6 +87,7 @@ COMBINED_FIELDS_UNEVENLY_WEIGHTED_MEDIUM_10M = Data('combinedFieldsUnevenlyWeigh
 DATA = {'wikimediumall': WIKI_MEDIUM_ALL,
         'wikimedium10m' : WIKI_MEDIUM_10M,
         'wikimedium1m' : WIKI_MEDIUM_1M,
+        'wikimedium500' : WIKI_MEDIUM_500,
         'wikimedium500k' : WIKI_MEDIUM_500K,
         'wikimedium10k' : WIKI_MEDIUM_10K,
         'wikimedium5m' : WIKI_MEDIUM_5M,
@@ -173,6 +175,8 @@ class Index(object):
     self.extraNamePart = extraNamePart
     if ramBufferMB == -1:
       self.maxBufferedDocs = self.numDocs // (SEGS_PER_LEVEL*111)
+      if self.maxBufferedDocs < 2:
+        self.maxBufferedDocs = self.numDocs
     else:
       self.maxBufferedDocs = -1
     self.mergePolicy = mergePolicy
@@ -314,7 +318,7 @@ class Competitor(object):
          f'-Dtests.profile.stacksize={size}',
          f'-Dtests.profile.count={count}',
          'org.apache.lucene.gradle.ProfileResults'] + \
-         glob.glob(f'{constants.BENCH_BASE_DIR}/bench-search-{id}-{self.name}-*.jfr')
+         glob.glob(f'{constants.LOGS_DIR}/bench-search-{id}-{self.name}-*.jfr')
 
       print(f'JFR aggregation command: {" ".join(command)}')
       t0 = time.time()
@@ -485,7 +489,7 @@ class Competition(object):
     else:
       challenger = self.competitors[0]
 
-    for fileName in glob.glob(f'{constants.BENCH_BASE_DIR}/bench-search-*.jfr'):
+    for fileName in glob.glob(f'{constants.LOGS_DIR}/bench-search-*.jfr'):
       print('Removing old JFR %s...' % fileName)
       os.remove(fileName)
 

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -43,6 +43,7 @@ GLOVE_VECTOR_DOCS_FILE = '%s/data/enwiki-20120502-lines-1k-100d.vec' % BASE_DIR
 WIKI_MEDIUM_TASKS_10MDOCS_FILE = '%s/tasks/wikimedium.10M.nostopwords.tasks' % BENCH_BASE_DIR
 #WIKI_MEDIUM_TASKS_1MDOCS_FILE = '%s/tasks/wikimedium.1M.tasks' % BENCH_BASE_DIR
 WIKI_MEDIUM_TASKS_1MDOCS_FILE = '%s/tasks/wikimedium.1M.nostopwords.tasks' % BENCH_BASE_DIR
+WIKI_MEDIUM_TASKS_500DOCS_FILE = '%s/tasks/wikimedium500.tasks' % BENCH_BASE_DIR
 WIKI_MEDIUM_TASKS_ALL_FILE = '%s/tasks/wikimedium.10M.tasks' % BENCH_BASE_DIR
 WIKI_VECTOR_TASKS_FILE = '%s/tasks/vector.tasks' % BENCH_BASE_DIR
 SORTED_TASKS_FILE = '%s/tasks/sorted.tasks' % BENCH_BASE_DIR

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -865,7 +865,7 @@ def run():
     print('will compare to last goot result files!')
 
   # TODO: understand why the attempted removal in Competition.benchmark did not actually run for nightly bench!
-  for fileName in glob.glob(f'{constants.BENCH_BASE_DIR}/bench-search-*.jfr'):
+  for fileName in glob.glob(f'{constants.LOGS_DIR}/bench-search-*.jfr'):
     print('Removing old JFR %s...' % fileName)
     os.remove(fileName)
 

--- a/src/python/vector-test.py
+++ b/src/python/vector-test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import competition
+import sys
+import constants
+
+# simple example that runs benchmark with WIKI_MEDIUM source and task files 
+# Baseline here is ../lucene_baseline versus ../lucene_candidate
+if __name__ == '__main__':
+  #sourceData = competition.sourceData('wikivector1m')
+  #sourceData = competition.sourceData('wikivector10k')
+  sourceData = competition.sourceData('wikimedium10k')
+  comp =  competition.Competition()
+
+  index = comp.newIndex('baseline', sourceData,
+                        vectorFile=constants.GLOVE_VECTOR_DOCS_FILE,
+                        vectorDimension=100,
+                        facets = (('taxonomy:Date', 'Date'),
+                                  ('taxonomy:Month', 'Month'),
+                                  ('taxonomy:DayOfYear', 'DayOfYear'),
+                                  ('sortedset:Month', 'Month'),
+                                  ('sortedset:DayOfYear', 'DayOfYear')))
+
+  #Warning -- Do not break the order of arguments
+  #TODO -- Fix the following by using argparser
+  if len(sys.argv) > 3 and sys.argv[3] == '-concurrentSearches':
+    concurrentSearches = True
+  else:
+    concurrentSearches = False
+
+  # create a competitor named baseline with sources in the ../trunk folder
+  comp.competitor('baseline', 'baseline',
+                  vectorDict=constants.GLOVE_WORD_VECTORS_FILE,
+                  index = index, concurrentSearches = concurrentSearches)
+
+  # use a different index 
+  index = comp.newIndex('candidate', sourceData,
+                        vectorFile=constants.GLOVE_VECTOR_DOCS_FILE,
+                        vectorDimension=100,
+                        facets = (('taxonomy:Date', 'Date'),
+                                  ('taxonomy:Month', 'Month'),
+                                  ('taxonomy:DayOfYear', 'DayOfYear'),
+                                  ('sortedset:Month', 'Month'),
+                                  ('sortedset:DayOfYear', 'DayOfYear')))
+  # create a competitor named my_modified_version with sources in the ../patch folder
+  # note that we haven't specified an index here, luceneutil will automatically use the index from the base competitor for searching 
+  # while the codec that is used for running this competitor is taken from this competitor.
+  comp.competitor('candidate', 'candidate',
+                  vectorDict=constants.GLOVE_WORD_VECTORS_FILE,
+                  index = index, concurrentSearches = concurrentSearches)
+
+  # start the benchmark - this can take long depending on your index and machines
+  comp.benchmark("baseline_vs_candidate")
+  


### PR DESCRIPTION
I feel like it's cleaner to write JFR files to logs dir - wdyt?

Also, made some small changes to enable wikimedium500 which is what setup.py sets up. It always bothered me that you could not check out run setup.py and then successfully run benchmarks; I think with this you will be able to.