### PR TITLE
Further fixing concurrent bug while using binary LFD and group index

### DIFF
--- a/src/main/perf/IndexThreads.java
+++ b/src/main/perf/IndexThreads.java
@@ -53,7 +53,7 @@ class IndexThreads {
                       boolean addGroupingFields, boolean printDPS, Mode mode, float docsPerSecPerThread, UpdatesListener updatesListener,
                       double nrtEverySec, int randomDocIDMax)
     throws IOException, InterruptedException {
-    AtomicInteger groupBlockIndex;
+    final AtomicInteger groupBlockIndex;
 
     this.docs = lineFileDocs;
     if (addGroupingFields) {

--- a/src/main/perf/Indexer.java
+++ b/src/main/perf/Indexer.java
@@ -506,18 +506,12 @@ public final class Indexer {
       throw new RuntimeException("exceptions during indexing");
     }
 
-    // Very tricky: if the line file docs source is binary, and you use multiple threads, and you use grouping fields, then the doc count
-    // may not match:
     boolean countShouldMatch;
 
     if (docCountLimit == -1) {
       countShouldMatch = false;
-    } else if (mode == Mode.UPDATE) {
-      countShouldMatch = false;
-    } else if (lineFileDocs.isBinary && numThreads > 1 && addGroupingFields) {
-      countShouldMatch = false;
     } else {
-      countShouldMatch = true;
+      countShouldMatch = mode != Mode.UPDATE;
     }
 
     if (countShouldMatch) {


### PR DESCRIPTION
* Add a synchronized block to make sure group index and docs are both ready before starting indexing a new group
* Recycling the remaining document block when there's no more group index (since this means there's must be some groups that needs more documents)

Tested using a 10k docs binary LFD with group size of 10k (1 doc per group) and 400 (25 doc per group, near the ratio of what we have in nightly bench)