### PR TITLE
Demonstrate ordinal map building on refresh

### DIFF
--- a/src/main/perf/IndexState.java
+++ b/src/main/perf/IndexState.java
@@ -18,6 +18,7 @@ package perf;
  */
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -67,6 +68,8 @@ class IndexState {
     this.taxoReader = taxoReader;
     this.facetsConfig = facetsConfig;
     this.facetFields = facetFields;
+
+    preLoadSsdvFacetStates();
     
     groupEndQuery = new TermQuery(new Term("groupend", "x"));
     if (hiliteImpl.equals("FastVectorHighlighter")) {
@@ -105,6 +108,21 @@ class IndexState {
     }
 
     return result;
+  }
+
+  public void preLoadSsdvFacetStates() {
+    if (facetsConfig == null) {
+      return;
+    }
+    facetsConfig.getDimConfigs().keySet().forEach(facetField -> {
+      try {
+        getSortedSetReaderState(facetField);
+      } catch (IllegalArgumentException ignore) {
+        // Some fields in the FacetsConfig are not indexed with SSDVs
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    });
   }
 
   /** Holds re-used thread-private classes for postings primary key lookup for one LeafReader */

--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -25,7 +25,6 @@ package perf;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -40,7 +39,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -53,8 +51,6 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.lucene94.Lucene94Codec;
 import org.apache.lucene.facet.FacetsConfig;
-import org.apache.lucene.facet.sortedset.DefaultSortedSetDocValuesReaderState;
-import org.apache.lucene.facet.sortedset.SortedSetDocValuesReaderState;
 import org.apache.lucene.facet.taxonomy.TaxonomyReader;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
@@ -279,56 +275,6 @@ public class SearchPerfTest {
       throw new UnsupportedOperationException("recacheFilterDeletes was deprecated");
     }
 
-    FacetsConfig facetsConfig = new FacetsConfig();
-    facetsConfig.setHierarchical("Date.taxonomy", true);
-    facetsConfig.setHierarchical("Date.sortedset", true);
-
-    // all unique facet group fields ($facet alone, by default):
-    final Set<String> facetFields = new HashSet<>();
-
-    // facet dim name -> facet method
-    final Map<String,Integer> facetDimMethods = new HashMap<>();
-    if (args.hasArg("-facets")) {
-      for(String arg : args.getStrings("-facets")) {
-        String[] dims = arg.split(";");
-        String facetGroupField;
-        String facetMethod;
-        if (dims[0].equals("taxonomy") || dims[0].equals("sortedset")) {
-          // method --> use the default facet field for this group
-          facetGroupField = FacetsConfig.DEFAULT_INDEX_FIELD_NAME;
-          facetMethod = dims[0];
-        } else {
-          // method:indexFieldName --> use a custom facet field for this group
-          int i = dims[0].indexOf(":");
-          if (i == -1) {
-            throw new IllegalArgumentException("-facets: expected (taxonomy|sortedset):fieldName but got " + dims[0]);
-          }
-          facetMethod = dims[0].substring(0, i);
-          if (facetMethod.equals("taxonomy") == false && facetMethod.equals("sortedset") == false) {
-            throw new IllegalArgumentException("-facets: expected (taxonomy|sortedset):fieldName but got " + dims[0]);
-          }
-          facetGroupField = dims[0].substring(i+1);
-        }
-        facetFields.add(facetGroupField);
-        for(int i=1;i<dims.length;i++) {
-          int flag;
-          if (facetDimMethods.containsKey(dims[i])) {
-            flag = facetDimMethods.get(dims[i]);
-          } else {
-            flag = 0;
-          }
-          if (facetMethod.equals("taxonomy")) {
-            flag |= 1;
-            facetsConfig.setIndexFieldName(dims[i]+".taxonomy", facetGroupField + ".taxonomy");
-          } else {
-            flag |= 2;
-            facetsConfig.setIndexFieldName(dims[i]+".sortedset", facetGroupField + ".sortedset");
-          }
-          facetDimMethods.put(dims[i], flag);
-        }
-      }
-    }
-
     if (args.getFlag("-nrt")) {
       // TODO: get taxoReader working here too
       // TODO: factor out & share this CL processing w/ Indexer
@@ -444,18 +390,6 @@ public class SearchPerfTest {
                 mgr.maybeRefresh();
                 reopenCount++;
                 IndexSearcher s = mgr.acquire();
-
-                // An application that uses facets should create new reader states after refreshing.
-                // Here we're demonstrating correct usage, but don't really need the reader states.
-                List<SortedSetDocValuesReaderState> freshReaderStates = facetsConfig.getDimConfigs().keySet().stream()
-                        .map(field -> {
-                            try {
-                              return new DefaultSortedSetDocValuesReaderState(s.getIndexReader(), field, facetsConfig);
-                            } catch (IOException e) {
-                              throw new UncheckedIOException(e);
-                            }
-                          }
-                ).collect(Collectors.toList());
                 try {
                   System.out.println(String.format(Locale.ENGLISH, "%.1fs: done reopen; writer.maxDoc()=%d; searcher.maxDoc()=%d; searcher.numDocs()=%d",
                                                    (System.currentTimeMillis() - startMS)/1000.0,
@@ -508,6 +442,56 @@ public class SearchPerfTest {
     }
 
     //System.out.println("searcher=" + searcher);
+
+    FacetsConfig facetsConfig = new FacetsConfig();
+    facetsConfig.setHierarchical("Date.taxonomy", true);
+    facetsConfig.setHierarchical("Date.sortedset", true);
+
+    // all unique facet group fields ($facet alone, by default):
+    final Set<String> facetFields = new HashSet<>();
+
+    // facet dim name -> facet method
+    final Map<String,Integer> facetDimMethods = new HashMap<>();
+    if (args.hasArg("-facets")) {
+      for(String arg : args.getStrings("-facets")) {
+        String[] dims = arg.split(";");
+        String facetGroupField;
+        String facetMethod;
+        if (dims[0].equals("taxonomy") || dims[0].equals("sortedset")) {
+          // method --> use the default facet field for this group
+          facetGroupField = FacetsConfig.DEFAULT_INDEX_FIELD_NAME;
+          facetMethod = dims[0];
+        } else {
+          // method:indexFieldName --> use a custom facet field for this group
+          int i = dims[0].indexOf(":");
+          if (i == -1) {
+            throw new IllegalArgumentException("-facets: expected (taxonomy|sortedset):fieldName but got " + dims[0]);
+          }
+          facetMethod = dims[0].substring(0, i);
+          if (facetMethod.equals("taxonomy") == false && facetMethod.equals("sortedset") == false) {
+            throw new IllegalArgumentException("-facets: expected (taxonomy|sortedset):fieldName but got " + dims[0]);
+          }
+          facetGroupField = dims[0].substring(i+1);
+        }
+        facetFields.add(facetGroupField);
+        for(int i=1;i<dims.length;i++) {
+          int flag;
+          if (facetDimMethods.containsKey(dims[i])) {
+            flag = facetDimMethods.get(dims[i]);
+          } else {
+            flag = 0;
+          }
+          if (facetMethod.equals("taxonomy")) {
+            flag |= 1;
+            facetsConfig.setIndexFieldName(dims[i]+".taxonomy", facetGroupField + ".taxonomy");
+          } else {
+            flag |= 2;
+            facetsConfig.setIndexFieldName(dims[i]+".sortedset", facetGroupField + ".sortedset");
+          }
+          facetDimMethods.put(dims[i], flag);
+        }
+      }
+    }
 
     TaxonomyReader taxoReader;
     Path taxoPath = Paths.get(args.getString("-indexPath"), "facets");


### PR DESCRIPTION
We're considering [building ordinal maps eagerly](https://github.com/apache/lucene/issues/11601). This can already be done to some extent using the current API. This PR shows how that should be done.

I'm don't know if the change is worth committing as is. The reader states that we compute are unused and there's no useful performance data we would be getting.

Testing: `python3 src/python/localrun.py -source wikimedium10k -facets -nrt`