### PR TITLE
Cut over Wikipedia benchmark to KeywordField, take 2 (with bug fix)

### DIFF
--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -28,6 +28,7 @@ import org.apache.lucene.document.IntField;
  */
 
 import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.KeywordField;
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.facet.DrillDownQuery;
 import org.apache.lucene.index.Term;
@@ -52,6 +53,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSelector;
+import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.TermQuery;
 
 class TaskParser {
@@ -89,9 +91,9 @@ class TaskParser {
     } else {
       vectorField = null;
     }
-    titleDVSort = new Sort(new SortField("title", SortField.Type.STRING));
+    titleDVSort = new Sort(KeywordField.newSortField("title", false, SortedSetSelector.Type.MIN));
     titleBDVSort = new Sort(new SortField("titleBDV", SortField.Type.STRING_VAL));
-    monthDVSort = new Sort(new SortField("month", SortField.Type.STRING));
+    monthDVSort = new Sort(KeywordField.newSortField("month", false, SortedSetSelector.Type.MIN));
     dayOfYearSort = new Sort(IntField.newSortField("dayOfYear", false, SortedNumericSelector.Type.MIN));
     lastModSort = new Sort(LongField.newSortField("lastMod", false, SortedNumericSelector.Type.MIN));
   }

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -411,11 +411,11 @@ def parseResults(resultsFiles):
             task.hitCount = "0"
           else:
             task.hitCount = hitCount
-          if sort in ('<string: "title">', '<string: "titleDV">'):
+          if sort in ('<string: "title">', '<string: "titleDV">', '<sortedset: "title"> selector=MIN'):
             task.sort = 'Title'
           elif sort.startswith('<long: "datenum">') or sort.startswith('<long: "lastModNDV">') or sort.startswith('<sortednumeric: "lastMod"> selector=MIN type=LONG'):
             task.sort = 'DateTime'
-          elif sort in ('<string: "month">', '<string: "monthSortedDV">'):
+          elif sort in ('<string: "month">', '<string: "monthSortedDV">', '<sortedset: "month"> selector=MIN'):
             task.sort = 'Month'
           elif sort == '<int: "dayOfYearNumericDV">' or sort.startswith('<sortednumeric: "dayOfYear"> selector=MIN type=INT'):
             task.sort = 'DayOfYear'


### PR DESCRIPTION
I _think_ this fixes the bug that showed up in the previous attempt to cutover to `KeywordField`, but I'm not entirely sure how to repro the last issue, so I can't verify the fix. Should running `wikimedium10k` expose the bug with the last attempt?