### PR TITLE
Make task parsing part of search

### DIFF
--- a/src/main/perf/LocalTaskSource.java
+++ b/src/main/perf/LocalTaskSource.java
@@ -43,11 +43,11 @@ class LocalTaskSource implements TaskSource {
   private final List<Task> tasks;
   private final AtomicInteger nextTask = new AtomicInteger();
 
-  public LocalTaskSource(IndexState indexState, String tasksFile,
+  public LocalTaskSource(IndexState indexState, String tasksFile, TaskParser taskParser,
                          Random staticRandom, Random random, int numTaskPerCat, int taskRepeatCount,
                          boolean doPKLookup, boolean groupByCat) throws IOException, ParseException {
 
-    final List<Task> loadedTasks = loadTasks(tasksFile);
+    final List<Task> loadedTasks = loadTasks(tasksFile, taskParser);
     Collections.shuffle(loadedTasks, staticRandom);
     final List<Task> prunedTasks = pruneTasks(loadedTasks, numTaskPerCat);
 
@@ -150,7 +150,7 @@ class LocalTaskSource implements TaskSource {
   public void taskDone(Task task, long queueTimeNS, TotalHits toalHitCount) {
   }
 
-  static List<Task> loadTasks(String filePath) throws IOException, ParseException {
+  static List<Task> loadTasks(String filePath, TaskParser taskParser) throws IOException, ParseException {
     final List<Task> tasks = new ArrayList<Task>();
     final BufferedReader taskFile = new BufferedReader(new InputStreamReader(new FileInputStream(filePath), "UTF-8"), 16384);
     while (true) {
@@ -169,7 +169,7 @@ class LocalTaskSource implements TaskSource {
       }
 
       // Only parse the category here, will parse to specific task when searching
-      tasks.add(new UnparsedTask(parseCategory(line)));
+      tasks.add(taskParser.firstPassParse(line));
     }
     taskFile.close();
     return tasks;

--- a/src/main/perf/LocalTaskSource.java
+++ b/src/main/perf/LocalTaskSource.java
@@ -36,16 +36,18 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.BytesRef;
 
+import static perf.TaskParser.parseCategory;
+
 // Serves up tasks from locally loaded list:
 class LocalTaskSource implements TaskSource {
   private final List<Task> tasks;
   private final AtomicInteger nextTask = new AtomicInteger();
 
-  public LocalTaskSource(IndexState indexState, TaskParser taskParser, String tasksFile,
+  public LocalTaskSource(IndexState indexState, String tasksFile,
                          Random staticRandom, Random random, int numTaskPerCat, int taskRepeatCount,
                          boolean doPKLookup, boolean groupByCat) throws IOException, ParseException {
 
-    final List<Task> loadedTasks = loadTasks(taskParser, tasksFile);
+    final List<Task> loadedTasks = loadTasks(tasksFile);
     Collections.shuffle(loadedTasks, staticRandom);
     final List<Task> prunedTasks = pruneTasks(loadedTasks, numTaskPerCat);
 
@@ -148,7 +150,7 @@ class LocalTaskSource implements TaskSource {
   public void taskDone(Task task, long queueTimeNS, TotalHits toalHitCount) {
   }
 
-  static List<Task> loadTasks(TaskParser taskParser, String filePath) throws IOException, ParseException {
+  static List<Task> loadTasks(String filePath) throws IOException, ParseException {
     final List<Task> tasks = new ArrayList<Task>();
     final BufferedReader taskFile = new BufferedReader(new InputStreamReader(new FileInputStream(filePath), "UTF-8"), 16384);
     while (true) {
@@ -166,7 +168,8 @@ class LocalTaskSource implements TaskSource {
         continue;
       }
 
-      tasks.add(taskParser.parseOneTask(line));
+      // Only parse the category here, will parse to specific task when searching
+      tasks.add(new UnparsedTask(parseCategory(line)));
     }
     taskFile.close();
     return tasks;

--- a/src/main/perf/NRTPerfTest.java
+++ b/src/main/perf/NRTPerfTest.java
@@ -186,8 +186,8 @@ public class NRTPerfTest {
     private final AtomicInteger nextTask = new AtomicInteger();
     private final int numTasks;
 
-    public RandomTaskSource(String tasksFile, Random random) throws IOException, ParseException {
-      tasks = LocalTaskSource.loadTasks(tasksFile);
+    public RandomTaskSource(String tasksFile, Random random, TaskParser taskParser) throws IOException, ParseException {
+      tasks = LocalTaskSource.loadTasks(tasksFile, taskParser);
       numTasks = tasks.size();
       Collections.shuffle(tasks, random);
       System.out.println("TASK LEN=" + tasks.size());
@@ -375,7 +375,7 @@ public class NRTPerfTest {
     final IndexState indexState = new IndexState(manager, null, field, spellChecker, "FastVectorHighlighter", null, null);
     TaskParserFactory taskParserFactory =
             new TaskParserFactory(indexState, field, analyzer, field, 10, random, null, true);
-    final TaskSource tasks = new RandomTaskSource(tasksFile, random) {
+    final TaskSource tasks = new RandomTaskSource(tasksFile, random, taskParserFactory.getTaskParser()) {
         @Override
         public void taskDone(Task task, long queueTimeNS, TotalHits toalHitCount) {
           searchesByTime[currentQT.get()].incrementAndGet();

--- a/src/main/perf/NRTPerfTest.java
+++ b/src/main/perf/NRTPerfTest.java
@@ -186,8 +186,8 @@ public class NRTPerfTest {
     private final AtomicInteger nextTask = new AtomicInteger();
     private final int numTasks;
 
-    public RandomTaskSource(TaskParser taskParser, String tasksFile, Random random) throws IOException, ParseException {
-      tasks = LocalTaskSource.loadTasks(taskParser, tasksFile);
+    public RandomTaskSource(String tasksFile, Random random) throws IOException, ParseException {
+      tasks = LocalTaskSource.loadTasks(tasksFile);
       numTasks = tasks.size();
       Collections.shuffle(tasks, random);
       System.out.println("TASK LEN=" + tasks.size());
@@ -373,9 +373,9 @@ public class NRTPerfTest {
 
     final DirectSpellChecker spellChecker = new DirectSpellChecker();
     final IndexState indexState = new IndexState(manager, null, field, spellChecker, "FastVectorHighlighter", null, null);
-    final QueryParser qp = new QueryParser(field, analyzer);
-    TaskParser taskParser = new TaskParser(indexState, qp, field, 10, random, null, true);
-    final TaskSource tasks = new RandomTaskSource(taskParser, tasksFile, random) {
+    TaskParserFactory taskParserFactory =
+            new TaskParserFactory(indexState, field, analyzer, field, 10, random, null, true);
+    final TaskSource tasks = new RandomTaskSource(tasksFile, random) {
         @Override
         public void taskDone(Task task, long queueTimeNS, TotalHits toalHitCount) {
           searchesByTime[currentQT.get()].incrementAndGet();
@@ -384,7 +384,7 @@ public class NRTPerfTest {
     System.out.println("Task repeat count 1");
     System.out.println("Tasks file " + tasksFile);
     System.out.println("Num task per cat 20");
-    final TaskThreads taskThreads = new TaskThreads(tasks, indexState, numSearchThreads);
+    final TaskThreads taskThreads = new TaskThreads(tasks, indexState, numSearchThreads, taskParserFactory);
 
     final ReopenThread reopenThread = new ReopenThread(reopenPerSec, manager, reopensByTime, runTimeSec);
     reopenThread.setName("ReopenThread");

--- a/src/main/perf/PKLookupTask.java
+++ b/src/main/perf/PKLookupTask.java
@@ -24,13 +24,10 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
-import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 
 final class PKLookupTask extends Task {
@@ -78,7 +75,7 @@ final class PKLookupTask extends Task {
   }
 
   @Override
-  public void go(IndexState state) throws IOException {
+  public void go(IndexState state, TaskParser taskParser) throws IOException {
 
     final IndexSearcher searcher = state.mgr.acquire();
     try {

--- a/src/main/perf/PointsPKLookupTask.java
+++ b/src/main/perf/PointsPKLookupTask.java
@@ -24,17 +24,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.PostingsEnum;
-import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.BytesRef;
 
 final class PointsPKLookupTask extends Task {
   private final int[] ids;
@@ -74,7 +65,7 @@ final class PointsPKLookupTask extends Task {
   }
 
   @Override
-  public void go(IndexState state) throws IOException {
+  public void go(IndexState state, TaskParser taskParser) throws IOException {
 
     final IndexSearcher searcher = state.mgr.acquire();
     try {

--- a/src/main/perf/RemoteTaskSource.java
+++ b/src/main/perf/RemoteTaskSource.java
@@ -35,16 +35,14 @@ import org.apache.lucene.search.TotalHits;
 // Serves up tasks from remote client
 class RemoteTaskSource extends Thread implements TaskSource {
   private final ServerSocket serverSocket;
-  private final TaskParser taskParser;
   private final int numThreads;
   private static final int MAX_BYTES = 70;
 
   // nocommit maybe fair=true?
   private final BlockingQueue<Task> queue = new ArrayBlockingQueue<Task>(100000);
 
-  public RemoteTaskSource(String iface, int port, int numThreads, TaskParser taskParser) throws IOException {
+  public RemoteTaskSource(String iface, int port, int numThreads) throws IOException {
     this.numThreads = numThreads;
-    this.taskParser = taskParser;
     serverSocket = new ServerSocket(port, 50, InetAddress.getByName(iface));
     System.out.println("Waiting for client connection on interface " + iface + ", port " + port);
     setPriority(Thread.MAX_PRIORITY);
@@ -118,7 +116,7 @@ class RemoteTaskSource extends Thread implements TaskSource {
           }
           Task task;
           try {
-            task = taskParser.parseOneTask(s);
+            task = new UnparsedTask(TaskParser.parseCategory(s));
           } catch (RuntimeException re) {
             re.printStackTrace();
             continue;

--- a/src/main/perf/RemoteTaskSource.java
+++ b/src/main/perf/RemoteTaskSource.java
@@ -37,12 +37,14 @@ class RemoteTaskSource extends Thread implements TaskSource {
   private final ServerSocket serverSocket;
   private final int numThreads;
   private static final int MAX_BYTES = 70;
+  private final TaskParser taskParser;
 
   // nocommit maybe fair=true?
   private final BlockingQueue<Task> queue = new ArrayBlockingQueue<Task>(100000);
 
-  public RemoteTaskSource(String iface, int port, int numThreads) throws IOException {
+  public RemoteTaskSource(String iface, int port, int numThreads, TaskParser taskParser) throws IOException {
     this.numThreads = numThreads;
+    this.taskParser = taskParser;
     serverSocket = new ServerSocket(port, 50, InetAddress.getByName(iface));
     System.out.println("Waiting for client connection on interface " + iface + ", port " + port);
     setPriority(Thread.MAX_PRIORITY);
@@ -116,7 +118,7 @@ class RemoteTaskSource extends Thread implements TaskSource {
           }
           Task task;
           try {
-            task = new UnparsedTask(TaskParser.parseCategory(s));
+            task = taskParser.firstPassParse(s);
           } catch (RuntimeException re) {
             re.printStackTrace();
             continue;

--- a/src/main/perf/RespellTask.java
+++ b/src/main/perf/RespellTask.java
@@ -39,7 +39,7 @@ final class RespellTask extends Task {
   }
 
   @Override
-  public void go(IndexState state) throws IOException {
+  public void go(IndexState state, TaskParser taskParser) throws IOException {
     final IndexSearcher searcher = state.mgr.acquire();
     try {
       answers = state.spellChecker.suggestSimilar(term, 10, searcher.getIndexReader(), SuggestMode.SUGGEST_MORE_POPULAR);

--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -532,7 +532,7 @@ public class SearchPerfTest {
       }
       String iface = tasksFile.substring(7, idx);
       int port = Integer.valueOf(tasksFile.substring(1+idx));
-      RemoteTaskSource remoteTasks = new RemoteTaskSource(iface, port, searchThreadCount);
+      RemoteTaskSource remoteTasks = new RemoteTaskSource(iface, port, searchThreadCount, taskParserFactory.getTaskParser());
 
       // nocommit must stop thread?
       tasks = remoteTasks;
@@ -540,7 +540,8 @@ public class SearchPerfTest {
       // Load the tasks from a file:
       final int taskRepeatCount = args.getInt("-taskRepeatCount");
       final int numTaskPerCat = args.getInt("-tasksPerCat");
-      tasks = new LocalTaskSource(indexState, tasksFile, staticRandom, random, numTaskPerCat, taskRepeatCount, doPKLookup, doConcurrentSearches);
+      tasks = new LocalTaskSource(indexState, tasksFile, taskParserFactory.getTaskParser(), staticRandom, random,
+              numTaskPerCat, taskRepeatCount, doPKLookup, doConcurrentSearches);
       System.out.println("Task repeat count " + taskRepeatCount);
       System.out.println("Tasks file " + tasksFile);
       System.out.println("Num task per cat " + numTaskPerCat);

--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -509,7 +509,6 @@ public class SearchPerfTest {
     final DirectSpellChecker spellChecker = new DirectSpellChecker();
     final IndexState indexState = new IndexState(mgr, taxoReader, fieldName, spellChecker, hiliteImpl, facetsConfig, facetDimMethods);
 
-    final QueryParser queryParser = new QueryParser("body", a);
     VectorDictionary vectorDictionary;
     if (vectorFile != null) {
       Float scale = args.getFloat("-vectorScale", null);
@@ -521,7 +520,8 @@ public class SearchPerfTest {
     } else {
       vectorDictionary = null;
     }
-    TaskParser taskParser = new TaskParser(indexState, queryParser, fieldName, topN, staticRandom, vectorDictionary, doStoredLoads);
+    TaskParserFactory taskParserFactory =
+            new TaskParserFactory(indexState, fieldName, a, "body", topN, random, vectorDictionary, doStoredLoads);
 
     final TaskSource tasks;
 
@@ -532,7 +532,7 @@ public class SearchPerfTest {
       }
       String iface = tasksFile.substring(7, idx);
       int port = Integer.valueOf(tasksFile.substring(1+idx));
-      RemoteTaskSource remoteTasks = new RemoteTaskSource(iface, port, searchThreadCount, taskParser);
+      RemoteTaskSource remoteTasks = new RemoteTaskSource(iface, port, searchThreadCount);
 
       // nocommit must stop thread?
       tasks = remoteTasks;
@@ -540,7 +540,7 @@ public class SearchPerfTest {
       // Load the tasks from a file:
       final int taskRepeatCount = args.getInt("-taskRepeatCount");
       final int numTaskPerCat = args.getInt("-tasksPerCat");
-      tasks = new LocalTaskSource(indexState, taskParser, tasksFile, staticRandom, random, numTaskPerCat, taskRepeatCount, doPKLookup, doConcurrentSearches);
+      tasks = new LocalTaskSource(indexState, tasksFile, staticRandom, random, numTaskPerCat, taskRepeatCount, doPKLookup, doConcurrentSearches);
       System.out.println("Task repeat count " + taskRepeatCount);
       System.out.println("Tasks file " + tasksFile);
       System.out.println("Num task per cat " + numTaskPerCat);
@@ -551,7 +551,7 @@ public class SearchPerfTest {
     // Evil respeller:
     //spellChecker.setMinPrefix(0);
     //spellChecker.setMaxInspections(1024);
-    final TaskThreads taskThreads = new TaskThreads(tasks, indexState, searchThreadCount);
+    final TaskThreads taskThreads = new TaskThreads(tasks, indexState, searchThreadCount, taskParserFactory);
     Thread.sleep(10);
 
     final long startNanos = System.nanoTime();

--- a/src/main/perf/SearchTask.java
+++ b/src/main/perf/SearchTask.java
@@ -128,7 +128,7 @@ final class SearchTask extends Task {
   }
 
   @Override
-  public void go(IndexState state) throws IOException {
+  public void go(IndexState state, TaskParser taskParser) throws IOException {
     //System.out.println("go group=" + this.group + " single=" + singlePassGroup + " xxx=" + xxx + " this=" + this);
     final IndexSearcher searcher = state.mgr.acquire();
 

--- a/src/main/perf/Task.java
+++ b/src/main/perf/Task.java
@@ -29,13 +29,15 @@ import org.apache.lucene.search.TotalHits;
 abstract class Task {
   //public String origString;
 
+  // fields below are only for RemoteTask
   public int taskID;
-
-  public TotalHits totalHitCount;
-
   public long recvTimeNS;
 
-  public abstract void go(IndexState state) throws IOException;
+  // fields below will be set after search
+  public TotalHits totalHitCount;
+  public long runTimeNanos;
+
+  public abstract void go(IndexState state, TaskParser taskParser) throws IOException;
 
   public abstract String getCategory();
 
@@ -43,7 +45,6 @@ abstract class Task {
   public abstract Task clone();
 
   // these are set once the task is executed
-  public long runTimeNanos;
   public int threadID;
 
   // Called after go, to return "summary" of the results.
@@ -61,7 +62,7 @@ abstract class Task {
   static final Task END_TASK = new Task() {
 
     @Override
-    public void go(IndexState state) {
+    public void go(IndexState state, TaskParser taskParser) {
     }
 
     @Override

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -104,11 +104,11 @@ class TaskParser {
   // this pattern doesn't handle all variations of floating numbers, such as .9 , but should be good enough for perf test query parsing purpose
   private final static Pattern combinedFieldsPattern = Pattern.compile(" \\+combinedFields=((\\p{Alnum}+(\\^\\d+.\\d)?,)+\\p{Alnum}+(\\^\\d+.\\d)?)");
 
-  public Task parseOneTask(String line) throws ParseException {
-    return new TaskBuilder(line).build();
+  public Task firstPassParse(String line) throws ParseException {
+    return new UnparsedTask(parseCategory(line));
   }
 
-  public Task parseOneTask(UnparsedTask unparsedSearchTask) throws ParseException {
+  public Task secondPassParse(UnparsedTask unparsedSearchTask) throws ParseException {
     return new TaskBuilder(unparsedSearchTask).build();
   }
 

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -104,10 +104,18 @@ class TaskParser {
   // this pattern doesn't handle all variations of floating numbers, such as .9 , but should be good enough for perf test query parsing purpose
   private final static Pattern combinedFieldsPattern = Pattern.compile(" \\+combinedFields=((\\p{Alnum}+(\\^\\d+.\\d)?,)+\\p{Alnum}+(\\^\\d+.\\d)?)");
 
+  /**
+   * First pass, parsing from String to some task, may/may not be an UnparsedTask
+   * Called within TaskSource while creating tasks
+   */
   public Task firstPassParse(String line) throws ParseException {
     return new UnparsedTask(parseCategory(line));
   }
 
+  /**
+   * Second pass, parsing from UnparsedTask to some concrete tasks, like SearchTask
+   * May not be called from the same parser that did the first pass
+   */
   public Task secondPassParse(UnparsedTask unparsedSearchTask) throws ParseException {
     return new TaskBuilder(unparsedSearchTask).build();
   }

--- a/src/main/perf/TaskParserFactory.java
+++ b/src/main/perf/TaskParserFactory.java
@@ -1,0 +1,44 @@
+package perf;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.queryparser.classic.QueryParser;
+
+import java.io.IOException;
+import java.util.Random;
+
+/**
+ * Create TaskParser, this class should be thread-safe
+ */
+public class TaskParserFactory {
+    private final IndexState indexState;
+    private final String field;
+    private final String fieldForQueryParser;
+    private final Analyzer analyzer;
+    private final int topN;
+    private final Random random;
+    private final VectorDictionary<?> vectorDictionary;
+    private final boolean doStoredLoads;
+
+    public TaskParserFactory(IndexState state,
+                             String field,
+                             Analyzer analyzer,
+                             String fieldForQueryParser,
+                             int topN,
+                             Random random,
+                             VectorDictionary<?> vectorDictionary,
+                             boolean doStoredLoads) {
+        this.indexState = state;
+        this.field = field;
+        this.fieldForQueryParser = fieldForQueryParser;
+        this.analyzer = analyzer;
+        this.topN = topN;
+        this.random = random;
+        this.vectorDictionary = vectorDictionary;
+        this.doStoredLoads = doStoredLoads;
+    }
+
+    public TaskParser getTaskParser() throws IOException {
+        QueryParser qp = new QueryParser(fieldForQueryParser, analyzer);
+        return new TaskParser(indexState, qp, field, topN, random, vectorDictionary, doStoredLoads);
+    }
+}

--- a/src/main/perf/TaskParserFactory.java
+++ b/src/main/perf/TaskParserFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package perf;
 
 import org.apache.lucene.analysis.Analyzer;

--- a/src/main/perf/UnparsedTask.java
+++ b/src/main/perf/UnparsedTask.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package perf;
 
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -32,7 +48,7 @@ public class UnparsedTask extends Task{
             throw new IllegalStateException("Task cannot be reused");
         }
         try {
-            parsedTask.set(taskParser.parseOneTask(this));
+            parsedTask.set(taskParser.secondPassParse(this));
         } catch (ParseException parseException) {
             throw new RuntimeException(parseException);
         }

--- a/src/main/perf/UnparsedTask.java
+++ b/src/main/perf/UnparsedTask.java
@@ -82,4 +82,13 @@ public class UnparsedTask extends Task{
         assert parsedTask.get() != null: "task should be already parsed before this method";
         parsedTask.get().printResults(out, state);
     }
+
+    @Override
+    public String toString() {
+        if (parsedTask.get() != null) {
+            return parsedTask.toString();
+        } else {
+            return "UnparsedTask cat:" + category + " text:" + origText;
+        }
+    }
 }

--- a/src/main/perf/UnparsedTask.java
+++ b/src/main/perf/UnparsedTask.java
@@ -1,0 +1,69 @@
+package perf;
+
+import org.apache.lucene.queryparser.classic.ParseException;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * The task that contains only category and unparsed text
+ * and will only be parsed when running
+ */
+public class UnparsedTask extends Task{
+    private final String category;
+    private final String origText;
+    private final AtomicReference<Task> parsedTask = new AtomicReference<>();
+
+    public UnparsedTask(String[] categoryAndText) {
+        this.category = categoryAndText[0];
+        this.origText = categoryAndText[1];
+    }
+
+    private UnparsedTask(String category, String origText) {
+        this.category = category;
+        this.origText = origText;
+    }
+
+
+    @Override
+    public void go(IndexState state, TaskParser taskParser) throws IOException {
+        if (parsedTask.get() != null) {
+            throw new IllegalStateException("Task cannot be reused");
+        }
+        try {
+            parsedTask.set(taskParser.parseOneTask(this));
+        } catch (ParseException parseException) {
+            throw new RuntimeException(parseException);
+        }
+        parsedTask.get().go(state, taskParser);
+        this.totalHitCount = parsedTask.get().totalHitCount;
+        this.runTimeNanos = parsedTask.get().runTimeNanos;
+    }
+
+    @Override
+    public String getCategory() {
+        return category;
+    }
+
+    public String getOrigText() {
+        return origText;
+    }
+
+    @Override
+    public Task clone() {
+        return new UnparsedTask(category, origText);
+    }
+
+    @Override
+    public long checksum() {
+        assert parsedTask.get() != null: "task should be already parsed before this method";
+        return parsedTask.get().checksum();
+    }
+
+    @Override
+    public void printResults(PrintStream out, IndexState state) throws IOException {
+        assert parsedTask.get() != null: "task should be already parsed before this method";
+        parsedTask.get().printResults(out, state);
+    }
+}

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -329,7 +329,7 @@ class Competitor(object):
          'org.apache.lucene.gradle.ProfileResults'] + \
          glob.glob(f'{constants.LOGS_DIR}/bench-search-{id}-{self.name}-*.jfr')
 
-      print(f'JFR aggregation command: {" ".join(command)}')
+      # print(f'JFR aggregation command: {" ".join(command)}')
       t0 = time.time()
       result = subprocess.run(command,
                               stdout = subprocess.PIPE,
@@ -384,6 +384,8 @@ class Competitor(object):
       'VectorDictionary.java',
       'BenchRearranger.java',
       'StringFieldDocSelector.java',
+      'UnparsedTask.java',
+      'TaskParserFactory.java',
       )]
 
     print('files %s' % files)


### PR DESCRIPTION
Created an `UnparsedTask` and all it does is to parse itself to other tasks when running.
Make every TaskThread carry one TaskParser and pass it into `Task.go` method

Test with wikimedium10k
before change:
```
                            TaskQPS baseline      StdDevQPS candidate      StdDev                Pct diff p-value
                          IntNRQ     2759.40      (6.0%)     2861.93      (6.0%)    3.7% (  -7% -   16%) 0.051
               HighTermMonthSort     2314.12     (12.3%)     2419.55     (10.4%)    4.6% ( -16% -   31%) 0.207
     BrowseRandomLabelSSDVFacets     1387.03      (8.3%)     1452.92      (8.5%)    4.8% ( -11% -   23%) 0.073
                       OrHighMed     2057.11      (9.9%)     2186.84      (8.7%)    6.3% ( -11% -   27%) 0.033
                      OrHighHigh     1699.57      (8.5%)     1811.58      (9.4%)    6.6% ( -10% -   26%) 0.020
                 MedSloppyPhrase     1290.72      (8.7%)     1386.15      (7.2%)    7.4% (  -7% -   25%) 0.003
     BrowseRandomLabelTaxoFacets     1976.56     (10.3%)     2128.06      (9.2%)    7.7% ( -10% -   30%) 0.013
                         Prefix3     2113.35      (9.2%)     2276.83      (6.8%)    7.7% (  -7% -   26%) 0.002
                     AndHighHigh     2134.89      (7.3%)     2300.67      (7.6%)    7.8% (  -6% -   24%) 0.001
                       MedPhrase     1745.29      (7.9%)     1884.37      (8.0%)    8.0% (  -7% -   25%) 0.001
           HighTermDayOfYearSort     3131.02      (9.8%)     3393.04      (8.8%)    8.4% (  -9% -   29%) 0.005
                     MedSpanNear     1816.22      (9.0%)     1974.27      (7.5%)    8.7% (  -7% -   27%) 0.001
                    HighSpanNear      580.99      (9.4%)      632.13      (7.9%)    8.8% (  -7% -   28%) 0.001
                HighSloppyPhrase     1819.62      (9.4%)     2000.59      (6.2%)    9.9% (  -5% -   28%) 0.000
                      AndHighMed     3583.50      (5.3%)     3940.72      (8.8%)   10.0% (  -3% -   25%) 0.000
                     LowSpanNear     3121.94     (10.4%)     3456.09      (7.1%)   10.7% (  -6% -   31%) 0.000
                      AndHighLow     7666.66      (9.3%)     8605.84     (10.8%)   12.3% (  -7% -   35%) 0.000
                       OrHighLow     2268.03     (10.5%)     2551.58      (9.4%)   12.5% (  -6% -   36%) 0.000
                      HighPhrase     1907.00     (11.8%)     2155.60      (7.2%)   13.0% (  -5% -   36%) 0.000
                 LowSloppyPhrase     2510.02     (12.0%)     2840.24      (9.3%)   13.2% (  -7% -   39%) 0.000
                        HighTerm     3824.28     (11.3%)     4350.73     (10.9%)   13.8% (  -7% -   40%) 0.000
             MedIntervalsOrdered     3304.21     (11.1%)     3789.14      (9.4%)   14.7% (  -5% -   39%) 0.000
                         MedTerm     6858.14      (9.8%)     7877.73     (10.3%)   14.9% (  -4% -   38%) 0.000
                        Wildcard     1076.09     (10.1%)     1244.99      (9.4%)   15.7% (  -3% -   39%) 0.000
             LowIntervalsOrdered     4249.43      (9.5%)     4923.01      (9.5%)   15.9% (  -2% -   38%) 0.000
            HighIntervalsOrdered     2714.79      (9.8%)     3146.60      (6.8%)   15.9% (   0% -   36%) 0.000
            BrowseDateTaxoFacets     4408.85     (10.3%)     5178.00     (10.8%)   17.4% (  -3% -   42%) 0.000
       BrowseDayOfYearTaxoFacets     4088.32      (9.5%)     4846.58     (10.1%)   18.5% (   0% -   42%) 0.000
                       LowPhrase     7224.51      (9.8%)     8590.67     (10.1%)   18.9% (   0% -   42%) 0.000
           BrowseMonthTaxoFacets     3970.64     (15.1%)     4783.30     (11.5%)   20.5% (  -5% -   55%) 0.000
            BrowseDateSSDVFacets     1389.41     (20.4%)     1689.69     (18.2%)   21.6% ( -14% -   75%) 0.000
                         LowTerm     8438.58     (10.4%)    10312.04     (14.5%)   22.2% (  -2% -   52%) 0.000
       BrowseDayOfYearSSDVFacets     4041.25     (20.4%)     4955.89     (15.8%)   22.6% ( -11% -   73%) 0.000
           BrowseMonthSSDVFacets     3967.29     (19.2%)     5102.64     (16.6%)   28.6% (  -6% -   79%) 0.000
                         Respell      446.53     (17.2%)      590.91     (11.9%)   32.3% (   2% -   74%) 0.000
                          Fuzzy2      112.99     (22.2%)      155.92     (16.7%)   38.0% (   0% -   98%) 0.000
                          Fuzzy1      430.07     (21.9%)      597.08     (17.3%)   38.8% (   0% -   99%) 0.000
                        PKLookup      195.00     (31.1%)      316.02     (29.0%)   62.1% (   1% -  177%) 0.000
```
After change:
```
                            TaskQPS baseline      StdDevQPS candidate      StdDev                Pct diff p-value
                          IntNRQ     2989.22      (7.6%)     2793.43      (7.5%)   -6.5% ( -20% -    9%) 0.006
                         Prefix3     1895.71      (6.6%)     1812.07      (6.5%)   -4.4% ( -16% -    9%) 0.032
           HighTermDayOfYearSort     2033.34      (5.9%)     1959.02      (7.3%)   -3.7% ( -15% -   10%) 0.080
                 LowSloppyPhrase     2845.87      (8.4%)     2766.00      (8.5%)   -2.8% ( -18% -   15%) 0.293
                      HighPhrase     1730.39      (6.9%)     1682.36      (8.1%)   -2.8% ( -16% -   13%) 0.243
                      AndHighMed     2926.19      (7.0%)     2855.74      (7.0%)   -2.4% ( -15% -   12%) 0.277
               HighTermMonthSort     2262.47      (7.5%)     2217.30      (7.3%)   -2.0% ( -15% -   13%) 0.393
                     AndHighHigh     2237.55      (7.8%)     2210.99      (7.4%)   -1.2% ( -15% -   15%) 0.624
                       MedPhrase     2102.66      (9.3%)     2078.58      (5.8%)   -1.1% ( -14% -   15%) 0.639
                       OrHighLow     1883.80      (8.2%)     1865.08      (7.8%)   -1.0% ( -15% -   16%) 0.696
                         MedTerm     5927.86      (6.7%)     5872.21      (9.1%)   -0.9% ( -15% -   15%) 0.711
                HighSloppyPhrase     1926.48      (7.0%)     1908.92      (6.7%)   -0.9% ( -13% -   13%) 0.674
                         LowTerm     7236.67      (9.0%)     7215.84      (8.7%)   -0.3% ( -16% -   19%) 0.918
                        Wildcard     1107.02      (4.6%)     1105.65      (4.9%)   -0.1% (  -9% -    9%) 0.935
                 MedSloppyPhrase     2359.59      (6.9%)     2378.95      (7.5%)    0.8% ( -12% -   16%) 0.720
                       LowPhrase     3250.16      (8.3%)     3276.96      (7.5%)    0.8% ( -13% -   18%) 0.743
            BrowseDateTaxoFacets     4908.55      (7.5%)     4955.64      (4.0%)    1.0% (  -9% -   13%) 0.615
                    HighSpanNear     1699.46      (5.3%)     1715.89      (6.3%)    1.0% ( -10% -   13%) 0.599
           BrowseMonthTaxoFacets     4628.43      (6.5%)     4689.18      (4.1%)    1.3% (  -8% -   12%) 0.448
                     LowSpanNear     2458.83      (9.4%)     2492.86      (7.1%)    1.4% ( -13% -   19%) 0.600
                      OrHighHigh     1720.61      (6.3%)     1746.88      (8.0%)    1.5% ( -12% -   16%) 0.503
                     MedSpanNear     2697.12      (7.8%)     2743.61      (8.0%)    1.7% ( -13% -   18%) 0.490
       BrowseDayOfYearTaxoFacets     4547.16      (6.5%)     4627.31      (5.6%)    1.8% (  -9% -   14%) 0.360
             LowIntervalsOrdered     3141.25     (10.0%)     3210.38      (8.0%)    2.2% ( -14% -   22%) 0.442
                        HighTerm     4054.44      (8.7%)     4170.35      (8.3%)    2.9% ( -12% -   21%) 0.286
                      AndHighLow     3760.29      (9.6%)     3882.44      (7.9%)    3.2% ( -13% -   22%) 0.244
                       OrHighMed     1435.97      (7.4%)     1507.42      (7.6%)    5.0% (  -9% -   21%) 0.037
     BrowseRandomLabelTaxoFacets     2055.51     (10.2%)     2173.53     (10.3%)    5.7% ( -13% -   29%) 0.077
            HighIntervalsOrdered     3564.02     (11.2%)     3801.79      (7.6%)    6.7% ( -10% -   28%) 0.027
     BrowseRandomLabelSSDVFacets     1422.25      (7.1%)     1540.03     (12.4%)    8.3% ( -10% -   29%) 0.009
           BrowseMonthSSDVFacets     4445.20     (14.4%)     4833.08     (23.1%)    8.7% ( -25% -   54%) 0.152
             MedIntervalsOrdered      949.64     (17.9%)     1048.27     (10.2%)   10.4% ( -15% -   46%) 0.024
       BrowseDayOfYearSSDVFacets     4346.56     (14.0%)     4820.37     (17.9%)   10.9% ( -18% -   49%) 0.032
                         Respell      409.93     (12.4%)      460.67      (5.0%)   12.4% (  -4% -   33%) 0.000
                          Fuzzy2      165.69     (17.4%)      191.40      (5.9%)   15.5% (  -6% -   46%) 0.000
                          Fuzzy1      588.77     (19.7%)      692.10      (9.2%)   17.5% (  -9% -   57%) 0.000
            BrowseDateSSDVFacets     1555.28     (12.9%)     1842.59     (30.2%)   18.5% ( -21% -   70%) 0.012
                        PKLookup      249.09     (25.5%)      314.47     (18.1%)   26.2% ( -13% -   93%) 0.000
```