### PR TITLE
Add argparse support to python runner scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,25 @@ git clone https://github.com/mikemccand/luceneutil.git util
 # 2. Run the setup script
 cd util
 python src/python/setup.py -download
+
+# you can run with -h option for help
+python src/python/setup.py -h
 ```
   
-In the second step, the setup procedure creates all necessary directories in the clones parent directory and downloads a
-6 GB compressed Wikipedia line doc file from an Apache mirror. If you don't want to
-download the large data file just remove the `-download` flag from the commandline. 
+In the second step, the setup procedure creates all necessary directories in the clones parent directory and downloads
+datasets to run the benchmarks on. By default, it downloads a 6 GB compressed Wikipedia line doc file, and a 13 GB vectors
+file from Apache mirrors. If you don't want to download the large data files,
+just remove the `-download` flag from the commandline.
 
-After the download has completed, extract the lzma file in `$LUCENE_BENCH_HOME/data`.
+After the download has completed, extract the lzma file in `$LUCENE_BENCH_HOME/data`. You can do this using the `xz` tool,
+or the `lmza` tool, or any other tool of your choice. For example:
+```bash
+cd $LUCENE_BENCH_HOME/data
+# using xz
+xz -d enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma
+# using lmza
+lzma -d enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma
+```
 
 ### (Optional, for development) set up IntelliJ
 Should be able to open by IntelliJ automatically. The gradle will write a local configuration file `gradle.properties` in

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Adjust the command accordingly for `lucene_candidate`.
 
 `setup.py` has created two files: `localconstants.py`, and `localrun.py` in `$LUCENE_BENCH_HOME/util/src/python/`. 
 
-The file `localconstants.py` should be used to override any existing constants in `constants.py`, for example if you want to change the Java commandline used to run benchmarks. To run an inintal benchmark you don't need to modify this file. 
+The file `localconstants.py` should be used to override any existing constants in `constants.py`, for example if you want to change the Java commandline used to run benchmarks. To run an initial benchmark you don't need to modify this file.
 
 Now you can start editing `localrun.py` to define your comparison, at the
 bottom near its `__main__`:

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -115,9 +115,8 @@ SEGS_PER_LEVEL = 5
 
 def sourceData(key=None):
   if not key:
-    import sys
-    if '-source' in sys.argv:
-      key = sys.argv[1+sys.argv.index('-source')]
+    raise RuntimeError('Data source required for benchmark run. '
+                       'Use "-s/-source/--source" option to provide data source. \nValid options: %s' % DATA.keys())
   if key in DATA:
     return DATA[key]
   raise RuntimeError('unknown data source "%s" (valid keys: %s)' % (key, DATA.keys()))

--- a/src/python/example.py
+++ b/src/python/example.py
@@ -15,13 +15,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import competition
-import sys
 
 # simple example that runs benchmark with WIKI_MEDIUM source and taks files 
 # Baseline here is ../lucene_baseline versus ../lucene_candidate
 if __name__ == '__main__':
-  sourceData = competition.sourceData()
+  parser = argparse.ArgumentParser(prog='Local Benchmark Run',
+                                   description='Run a local benchmark on provided source dataset.')
+  parser.add_argument('-s', '-source', '--source',
+                      help='Data source to run the benchmark on.')
+  parser.add_argument('-c', '-concurrentSearches', '--concurrentSearches', action='store_true',
+                      help='Run concurrent searches')
+  args = parser.parse_args()
+
+  sourceData = competition.sourceData(args.source)
   comp =  competition.Competition()
 
   index = comp.newIndex('lucene_baseline', sourceData,
@@ -35,23 +43,16 @@ if __name__ == '__main__':
                                   ('taxonomy:RandomLabel', 'RandomLabel'),
                                   ('sortedset:RandomLabel', 'RandomLabel')))
 
-  #Warning -- Do not break the order of arguments
-  #TODO -- Fix the following by using argparser
-  if len(sys.argv) > 3 and sys.argv[3] == '-concurrentSearches':
-    concurrentSearches = True
-  else:
-    concurrentSearches = False
-
   # create a competitor named baseline with sources in the ../trunk folder
   comp.competitor('baseline', 'lucene_baseline',
-                  index = index, concurrentSearches = concurrentSearches)
+                  index = index, concurrentSearches = args.concurrentSearches)
 
   # use the same index here
   # create a competitor named my_modified_version with sources in the ../patch folder
   # note that we haven't specified an index here, luceneutil will automatically use the index from the base competitor for searching 
   # while the codec that is used for running this competitor is taken from this competitor.
   comp.competitor('my_modified_version', 'lucene_candidate',
-                  index = index, concurrentSearches = concurrentSearches)
+                  index = index, concurrentSearches = args.concurrentSearches)
 
   # start the benchmark - this can take long depending on your index and machines
   comp.benchmark("baseline_vs_patch")

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import os
 import sys
 try:
@@ -134,9 +135,11 @@ class Downloader:
   
 
 if __name__ == '__main__':
-  if '-help' in sys.argv or '--help' in sys.argv:
-    print(USAGE)
-  else:
-    download = '-download' in sys.argv
-    runSetup(download)
+  parser = argparse.ArgumentParser(prog='luceneutil setup',
+                                   description='Benchmarking setup for lucene')
+  parser.add_argument('-d', '-download', '--download', action='store_true',
+                      help='Download datasets to run benchmarks. A 6 GB compressed Wikipedia line doc file, '
+                           'and a 13 GB vectors file is downloaded from Apache mirrors')
+  args = parser.parse_args()
+  runSetup(args.download)
 


### PR DESCRIPTION
Adds argparse support to `setup.py` and `example.py`, which is used to create `localrun.py`. This removes dependency from positional sys.argv variables. Also updated the README to help with minor surprises I ran into during setup.


#### Usage with argparse
```bash
% python3 src/python/setup.py -h  
usage: luceneutil setup [-h] [-d]

Benchmarking setup for lucene

options:
  -h, --help            show this help message and exit
  -d, -download, --download
                        Download datasets to run benchmarks. A 6 GB compressed Wikipedia line doc file, and a 13 GB vectors file is downloaded from Apache
                        mirrors
```
```bash
% python3 src/python/example.py -h                                  
WARNING: Gnuplot module not present; will not make charts
usage: Local Benchmark Run [-h] [-s SOURCE] [-c]

Run a local benchmark on provided source dataset.

options:
  -h, --help            show this help message and exit
  -s SOURCE, -source SOURCE, --source SOURCE
                        Data source to run the benchmark on.
  -c, -concurrentSearches, --concurrentSearches
                        Run concurrent searches
```

#### Testing
Tested manually through local runs with different arg combinations.
