### PR TITLE
Add more interesting tasks for top-k hits on boolean queries.

### DIFF
--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -1308,6 +1308,13 @@ def writeIndexHTML(searchChartData, days):
     writeOneLine(w, done, 'OrHighMed', 'high-freq medium-freq')
     writeOneLine(w, done, 'AndHighOrMedMed', '+high-freq +(medium-freq medium-freq)')
     writeOneLine(w, done, 'AndMedOrHighHigh', '+medium-freq +(high-freq high-freq)')
+    writeOneLine(w, done, 'Or2Terms2StopWords', 'Disjunction of 2 regular terms and 2 stop words')
+    writeOneLine(w, done, 'And2Terms2StopWords', 'Conjunction of 2 regular terms and 2 stop words')
+    writeOneLine(w, done, 'OrStopWords', 'Disjunction of 2 or more stop words')
+    writeOneLine(w, done, 'AndStopWords', 'Conjunction of 2 or more stop words')
+    writeOneLine(w, done, 'Or3Tems', 'Disjunction of 3 terms')
+    writeOneLine(w, done, 'And3Tems', 'Conjunction of 3 terms')
+    writeOneLine(w, done, 'OrHighRare', 'Disjunction of a very frequent term and a very rare term')
 
     w('<br><br><b>CombinedFieldsQuery:</b>')
     writeOneLine(w, done, 'CombinedTerm', 'Combined high-freq')

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -263,3 +263,46 @@ CountTerm: count(names) # freq=402762
 CountTerm: count(nbsp) # freq=492778
 CountTerm: count(part) # freq=588644
 CountTerm: count(st) # freq=306811
+
+# Disjunction of 2 terms and 2 stop words
+Or2Terms2StopWords: lord of the rings
+Or2Terms2StopWords: the book of life
+Or2Terms2StopWords: the garden of eden
+Or2Terms2StopWords: battle of the bulge
+Or2Terms2StopWords: story of my life
+
+# Conjunction of 2 terms and 2 stop words
+And2Terms2StopWords: +lord +of +the +rings
+And2Terms2StopWords: +the +book +of +life
+And2Terms2StopWords: +the +garden +of +eden
+And2Terms2StopWords: +battle +of +the +bulge
+And2Terms2StopWords: +story +of +a +girl
+
+# Disjunction of terms that are all stop words
+OrStopWords: to be or not to be
+OrStopWords: the who
+
+# Conjunction of terms that are all stop words
+AndStopWords: +to +be +or +not +to +be
+AndStopWords: +the +who
+
+# Disjunction of 3 terms
+Or3Terms: new york population
+Or3Terms: world bank president
+Or3Terms: national book award
+Or3Terms: united states constitution
+Or3Terms: law school rankings
+
+# Conjunction of 3 terms
+And3Terms: +new +york +population
+And3Terms: +world +bank +president
+And3Terms: +national +book +award
+And3Terms: +united +states +constitution
+And3Terms: +law +school +rankings
+
+# Disjunction of a high-frequency term (e.g. stop word) with a very rare term that has a couple 100s
+# hits at most. This is a hard query as it takes time until the top-k-th hit score gets higher than
+# typical scores of the frequent term.
+OrHighRare: the incredibles
+OrHighRare: a horsefly
+OrHighRare: some groundnuts

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -276,7 +276,7 @@ And2Terms2StopWords: +lord +of +the +rings
 And2Terms2StopWords: +the +book +of +life
 And2Terms2StopWords: +the +garden +of +eden
 And2Terms2StopWords: +battle +of +the +bulge
-And2Terms2StopWords: +story +of +a +girl
+And2Terms2StopWords: +story +of +my +life
 
 # Disjunction of terms that are all stop words
 OrStopWords: to be or not to be

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -269,14 +269,14 @@ Or2Terms2StopWords: lord of the rings
 Or2Terms2StopWords: the book of life
 Or2Terms2StopWords: the garden of eden
 Or2Terms2StopWords: battle of the bulge
-Or2Terms2StopWords: story of my life
+Or2Terms2StopWords: story of a girl
 
 # Conjunction of 2 terms and 2 stop words
 And2Terms2StopWords: +lord +of +the +rings
 And2Terms2StopWords: +the +book +of +life
 And2Terms2StopWords: +the +garden +of +eden
 And2Terms2StopWords: +battle +of +the +bulge
-And2Terms2StopWords: +story +of +my +life
+And2Terms2StopWords: +story +of +a +girl
 
 # Disjunction of terms that are all stop words
 OrStopWords: to be or not to be

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -278,13 +278,13 @@ And2Terms2StopWords: +the +garden +of +eden
 And2Terms2StopWords: +battle +of +the +bulge
 And2Terms2StopWords: +story +of +a +girl
 
-# Disjunction of terms that are all stop words
+# Disjunction of 3+ terms that are all stop words
 OrStopWords: to be or not to be
-OrStopWords: the who
+OrStopWords: who are the who
 
-# Conjunction of terms that are all stop words
+# Conjunction of 3+ terms that are all stop words
 AndStopWords: +to +be +or +not +to +be
-AndStopWords: +the +who
+AndStopWords: +who +are +the +who
 
 # Disjunction of 3 terms
 Or3Terms: new york population


### PR DESCRIPTION
Looking into the [Tantivy benchmark](https://tantivy-search.github.io/bench/) highlighted that there are interesting cases that are not covered by our nightly benchmarks. For instance, MAXSCORE splits clauses into essential and non-essential clauses, but our nightly benchmarks only really benchmark the case when there is a single essential clause (with `OrHighMed` because there is one clause whose scores dominates, and with `OrHighHigh` because there are so many documents that have both terms that `MAXSCORE` quickly realizes that the clause with the maximum score is required for a hit to be competitive anyway).

This adds a few more categories whose performance would be interesting to track. I'm expecting the performance of these queries to often react very differently to changes in query evaluation compared to our historic `OrHighHigh`, `OrHighMed`, `AndHighHigh` and `AndHighMed` queries.