### PR TITLE
Add concurrent HNSW merge options to benchmarking & nightly benchmark

### DIFF
--- a/src/main/IndexToFST.java
+++ b/src/main/IndexToFST.java
@@ -1,5 +1,3 @@
-// nocommit temporary tool
-
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -23,41 +21,6 @@ import org.apache.lucene.util.fst.Outputs;
 import org.apache.lucene.util.fst.PositiveIntOutputs;
 import org.apache.lucene.util.fst.Util;
 
-/*
-2
-4
-8
-16
-32
-64
-128
-256
-512
-1024
-2048
-4096
-8192
-16384
-32768
-65536
-131072
-262144
-524288
-1048576
-2097152
-4194304
-8388608
-16777216
-33554432
-67108864
-134217728
-268435456
-536870912
-1073741824
-2147483648
-4294967296
-*/  
-
 // javac -cp lucene/core/build/libs/lucene-core-10.0.0-SNAPSHOT.jar IndexToFST.java; java -cp .:lucene/core/build/libs/lucene-core-10.0.0-SNAPSHOT.jar IndexToFST /l/indices/wikimediumall.trunk.facets.taxonomy:Date.taxonomy:Month.taxonomy:DayOfYear.taxonomy:RandomLabel.taxonomy.sortedset:Date.sortedset:Month.sortedset:DayOfYear.sortedset:RandomLabel.sortedset.Lucene90.Lucene90.dvfields.nd33.3326M/index
 
 public class IndexToFST {
@@ -68,7 +31,7 @@ public class IndexToFST {
   
   public static void main(String[] args) throws Exception {
     if (args.length != 2) {
-      System.err.println("Usage: IndexToFST <path-to-index-dir> <size-of-suffix-hash>");
+      System.err.println("Usage: IndexToFST <path-to-index-dir> <size-of-suffix-hash-in-mb-or-inf>");
       System.exit(1);
     }
 

--- a/src/main/KnnGraphTester.java
+++ b/src/main/KnnGraphTester.java
@@ -345,7 +345,8 @@ public class KnnGraphTester {
   private void forceMerge() throws IOException {
     IndexWriterConfig iwc = new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.APPEND);
     iwc.setCodec(getCodec(maxConn, beamWidth, exec, numMergeWorker));
-    if (!quiet) {
+    if (quiet == false) {
+      // not a quiet place!
       iwc.setInfoStream(new PrintStreamInfoStream(System.out));
     }
     System.out.println("Force merge index in " + indexPath);

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -968,6 +968,9 @@ class RunAlgs:
       if index.rearrange != 0:
         w('-rearrange', index.rearrange)
 
+      w('-hnswThreadsPerMerge', index.hnswThreadsPerMerge)
+      w('-hnswThreadPoolCount', index.hnswThreadPoolCount)
+
       fullLogFile = '%s/%s.%s.log' % (constants.LOGS_DIR, id, index.getName())
 
       print('    log %s' % fullLogFile)

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -161,7 +161,9 @@ class Index(object):
                # (rearrange % 100) / 10 gives how many medium segments desired
                # rearrange % 10 gives how many small segments desired
                # For example, rearrange = 555 means 5 large segments, 5 medium segments and 5 small segments
-               rearrange = 0
+               rearrange = 0,
+               hnswThreadsPerMerge = 1,
+               hnswThreadPoolCount = 1
                ):
     self.checkout = checkout
     self.dataSource = dataSource
@@ -210,6 +212,8 @@ class Index(object):
       raise RuntimeError('SEGS_PER_LEVEL (%s) is greater than mergeFactor (%s)' % (SEGS_PER_LEVEL, mergeFactor))
     self.useCMS = useCMS
     self.rearrange = rearrange
+    self.hnswThreadsPerMerge = hnswThreadsPerMerge
+    self.hnswThreadPoolCount = hnswThreadPoolCount
 
   def getName(self):
     if self.assignedName is not None:

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -458,7 +458,10 @@ def run():
                           addDVFields=True,
                           vectorFile=constants.VECTORS_DOCS_FILE,
                           vectorDimension=constants.VECTORS_DIMENSIONS,
-                          vectorEncoding=constants.VECTORS_TYPE)
+                          vectorEncoding=constants.VECTORS_TYPE,
+                          hnswThreadsPerMerge = constants.HNSW_THREADS_PER_MERGE,
+                          hnswThreadPoolCount = constants.HNSW_THREAD_POOL_COUNT
+                          )
 
     c = comp.competitor(id, NIGHTLY_DIR,
                         index=index,


### PR DESCRIPTION
I added `hnswThreadsPerMerge` and `hnswThreadPoolCount` to `Indexer` and `competition.Index/newIndex`, and fixed nightly to pass these from its local `constants.py` file.

I have yet to disable strict top N checking for KNN hits when concurrency is enabled -- I'll do that as a followon commit after testing on nightly box!

Closes #239.