### PR TITLE
Removing wikibig_tasks references, wikibig is supposed to use the wikimedium tasks

### DIFF
--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -47,10 +47,11 @@ MEME_ALL = Data('memeall',
                 210999824,
                 constants.WIKI_MEDIUM_TASKS_10MDOCS_FILE)
 
-WIKI_BIG = Data('wikibigall', constants.WIKI_BIG_DOCS_LINE_FILE, constants.WIKI_BIG_DOCS_COUNT, constants.WIKI_BIG_TASKS_FILE)
-WIKI_BIG_10K = Data('wikibig10k', constants.WIKI_BIG_DOCS_LINE_FILE, 10000, constants.WIKI_BIG_TASKS_FILE)
-WIKI_BIG_100K = Data('wikibig100k', constants.WIKI_BIG_DOCS_LINE_FILE, 100000, constants.WIKI_BIG_TASKS_FILE)
-WIKI_BIG_1M = Data('wikibig1m', constants.WIKI_BIG_DOCS_LINE_FILE, 1000000, constants.WIKI_BIG_TASKS_FILE)
+# wikibig uses the same task files as wikimedium
+WIKI_BIG = Data('wikibigall', constants.WIKI_BIG_DOCS_LINE_FILE, constants.WIKI_BIG_DOCS_COUNT, constants.WIKI_MEDIUM_TASKS_10MDOCS_FILE)
+WIKI_BIG_10K = Data('wikibig10k', constants.WIKI_BIG_DOCS_LINE_FILE, 10000, constants.WIKI_MEDIUM_TASKS_1MDOCS_FILE)
+WIKI_BIG_100K = Data('wikibig100k', constants.WIKI_BIG_DOCS_LINE_FILE, 100000, constants.WIKI_MEDIUM_TASKS_1MDOCS_FILE)
+WIKI_BIG_1M = Data('wikibig1m', constants.WIKI_BIG_DOCS_LINE_FILE, 1000000, constants.WIKI_MEDIUM_TASKS_1MDOCS_FILE)
 
 EURO_MEDIUM = Data('euromedium', constants.EUROPARL_MEDIUM_DOCS_LINE_FILE, 5000000, constants.EUROPARL_MEDIUM_TASKS_FILE)
 

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -70,7 +70,6 @@ COMBINED_FIELDS_UNEVENLY_WEIGHTED_TASKS_FILE = '%s/tasks/combinedfields.unevenly
 # wget http://home.apache.org/~mikemccand/enwiki-20120502-lines-with-random-label.txt.lzma
 WIKI_BIG_DOCS_LINE_FILE = '%s/data/enwiki-20120502-lines-with-random-label.txt' % BASE_DIR
 #WIKI_BIG_DOCS_LINE_FILE = '%s/data/enwiki-20130102-lines.txt' % BASE_DIR
-WIKI_BIG_TASKS_FILE = '%s/data/wikibig.tasks' % BASE_DIR
 
 # 33332620 docs in enwiki-20120502-lines-1k.txt'
 # 6726515 docs in enwiki-20120502-lines.txt


### PR DESCRIPTION
Removing wikibig_tasks references, wikibig is supposed to use the wikimedium tasks.

Doing the changes to constants.py and competition.py