### PR TITLE
Extracted KnnIndexer class out of KnnGraphTester and moving to a knn package

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -20,7 +20,7 @@
 
     <javac srcdir="src/main"
            destdir="build"
-           includes="KnnGraphTester.java,WikiVectors.java,perf/VectorDictionary.java"
+           includes="knn/KnnGraphTester.java,WikiVectors.java,perf/VectorDictionary.java"
            classpathref="build.classpath"
            includeantruntime="false"/>
 

--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+package knn;
+
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
@@ -88,13 +90,13 @@ import org.apache.lucene.util.hppc.IntIntHashMap;
 /**
  * For testing indexing and search performance of a knn-graph
  *
- * <p>java -cp .../lib/*.jar org.apache.lucene.util.hnsw.KnnGraphTester -ndoc 1000000 -search
+ * <p>java -cp .../lib/*.jar knn.KnnGraphTester -ndoc 1000000 -search
  * .../vectors.bin
  */
 public class KnnGraphTester {
 
-  private static final String KNN_FIELD = "knn";
-  private static final String ID_FIELD = "id";
+  public static final String KNN_FIELD = "knn";
+  public static final String ID_FIELD = "id";
   private static final double WRITER_BUFFER_MB = 1994d;
 
   private int numDocs;
@@ -231,6 +233,9 @@ public class KnnGraphTester {
         case "-docs":
           docVectorsPath = Paths.get(args[++iarg]);
           break;
+        case "-indexPath":
+          indexPath = Paths.get(args[++iarg]);
+          break;
         case "-encoding":
           String encoding = args[++iarg];
           switch (encoding) {
@@ -308,12 +313,15 @@ public class KnnGraphTester {
     if (prefilter && selectivity == 1f) {
       throw new IllegalArgumentException("-prefilter requires filterSelectivity between 0 and 1");
     }
-    indexPath = Paths.get(formatIndexPath(docVectorsPath));
+    if (indexPath == null) {
+      indexPath = Paths.get(formatIndexPath(docVectorsPath)); // derive index path
+    }
     if (reindex) {
       if (docVectorsPath == null) {
         throw new IllegalArgumentException("-docs argument is required when indexing");
       }
-      reindexTimeMsec = createIndex(docVectorsPath, indexPath);
+      reindexTimeMsec = new KnnIndexer(docVectorsPath, indexPath, maxConn, beamWidth, vectorEncoding, dim,
+          similarityFunction, numDocs, quiet).createIndex();
     }
     if (forceMerge) {
       forceMerge();
@@ -347,7 +355,7 @@ public class KnnGraphTester {
   @SuppressForbidden(reason = "Prints stuff")
   private void printFanoutHist(Path indexPath) throws IOException {
     try (Directory dir = FSDirectory.open(indexPath);
-        DirectoryReader reader = DirectoryReader.open(dir)) {
+         DirectoryReader reader = DirectoryReader.open(dir)) {
       for (LeafReaderContext context : reader.leaves()) {
         LeafReader leafReader = context.reader();
         KnnVectorsReader vectorsReader =
@@ -470,7 +478,7 @@ public class KnnGraphTester {
       ThreadMXBean bean = ManagementFactory.getThreadMXBean();
       long cpuTimeStartNs;
       try (Directory dir = FSDirectory.open(indexPath);
-          DirectoryReader reader = DirectoryReader.open(dir)) {
+           DirectoryReader reader = DirectoryReader.open(dir)) {
         IndexSearcher searcher = new IndexSearcher(reader);
         numDocs = reader.maxDoc();
         Query bitSetQuery = prefilter ? new BitSetQuery(matchDocs) : null;
@@ -557,7 +565,22 @@ public class KnnGraphTester {
       totalVisited /= numIters;
       System.out.printf(
           Locale.ROOT,
-          "%5.3f\t%5.2f\t%d\t%d\t%d\t%d\t%d\t%d\t%.2f\t%s\n",
+          "|%s\t|%s\t|%s\t|%s\t|%s\t|%s\t|%s\t|%s\t|%s\t|%s|\n",
+          "recall",
+          "avgCpuTime",
+          "numDocs",
+          "fanout",
+          "maxConn",
+          "beamWidth",
+          "totalVisited",
+          "reindexTimeMsec",
+          "selectivity",
+          "prefilter");
+      System.out.println(
+          "|---|---|---|---|---|---|---|---|---|---|");
+      System.out.printf(
+          Locale.ROOT,
+          "|%5.3f\t|%5.2f\t|%d\t|%d\t|%d\t|%d\t|%d\t|%d\t|%.2f\t|%s|\n",
           recall,
           totalCpuTime / (float) numIters,
           numDocs,
@@ -568,75 +591,6 @@ public class KnnGraphTester {
           reindexTimeMsec,
           selectivity,
           prefilter ? "pre-filter" : "post-filter");
-    }
-  }
-
-  private abstract static class VectorReader {
-    final float[] target;
-    final ByteBuffer bytes;
-    final FileChannel input;
-
-    static VectorReader create(FileChannel input, int dim, VectorEncoding vectorEncoding) {
-      int bufferSize = dim * vectorEncoding.byteSize;
-      return switch (vectorEncoding) {
-        case BYTE -> new VectorReaderByte(input, dim, bufferSize);
-        case FLOAT32 -> new VectorReaderFloat32(input, dim, bufferSize);
-      };
-    }
-
-    VectorReader(FileChannel input, int dim, int bufferSize) {
-      this.bytes = ByteBuffer.wrap(new byte[bufferSize]).order(ByteOrder.LITTLE_ENDIAN);
-      this.input = input;
-      target = new float[dim];
-    }
-
-    void reset() throws IOException {
-      input.position(0);
-    }
-
-    protected final void readNext() throws IOException {
-      this.input.read(bytes);
-      bytes.position(0);
-    }
-
-    abstract float[] next() throws IOException;
-  }
-
-  private static class VectorReaderFloat32 extends VectorReader {
-    VectorReaderFloat32(FileChannel input, int dim, int bufferSize) {
-      super(input, dim, bufferSize);
-    }
-
-    @Override
-    float[] next() throws IOException {
-      readNext();
-      bytes.asFloatBuffer().get(target);
-      return target;
-    }
-  }
-
-  private static class VectorReaderByte extends VectorReader {
-    private final byte[] scratch;
-
-    VectorReaderByte(FileChannel input, int dim, int bufferSize) {
-      super(input, dim, bufferSize);
-      scratch = new byte[dim];
-    }
-
-    @Override
-    float[] next() throws IOException {
-      readNext();
-      bytes.get(scratch);
-      for (int i = 0; i < scratch.length; i++) {
-        target[i] = scratch[i];
-      }
-      return target;
-    }
-
-    byte[] nextBytes() throws IOException {
-      readNext();
-      bytes.get(scratch);
-      return scratch;
     }
   }
 
@@ -763,7 +717,7 @@ public class KnnGraphTester {
       System.out.println("computing true nearest neighbors of " + numIters + " target vectors");
     }
     try (FileChannel in = FileChannel.open(docPath);
-        FileChannel qIn = FileChannel.open(queryPath)) {
+         FileChannel qIn = FileChannel.open(queryPath)) {
       VectorReader docReader = VectorReader.create(in, dim, encoding);
       VectorReader queryReader = VectorReader.create(qIn, dim, encoding);
       for (int i = 0; i < numIters; i++) {
@@ -810,7 +764,7 @@ public class KnnGraphTester {
     }
     long start = System.nanoTime();
     try (FSDirectory dir = FSDirectory.open(indexPath);
-        IndexWriter iw = new IndexWriter(dir, iwc)) {
+         IndexWriter iw = new IndexWriter(dir, iwc)) {
       try (FileChannel in = FileChannel.open(docsPath)) {
         VectorReader vectorReader = VectorReader.create(in, dim, vectorEncoding);
         for (int i = 0; i < numDocs; i++) {
@@ -847,8 +801,8 @@ public class KnnGraphTester {
         @Override
         public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
           return quantize ?
-            new Lucene99HnswScalarQuantizedVectorsFormat(maxConn, beamWidth) :
-            new Lucene99HnswVectorsFormat(maxConn, beamWidth);
+              new Lucene99HnswScalarQuantizedVectorsFormat(maxConn, beamWidth) :
+              new Lucene99HnswVectorsFormat(maxConn, beamWidth);
         }
       };
     } else {
@@ -856,8 +810,8 @@ public class KnnGraphTester {
         @Override
         public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
           return quantize ?
-            new Lucene99HnswScalarQuantizedVectorsFormat(maxConn, beamWidth, numMergeWorker, null, exec) :
-            new Lucene99HnswVectorsFormat(maxConn, beamWidth, numMergeWorker, exec);
+              new Lucene99HnswScalarQuantizedVectorsFormat(maxConn, beamWidth, numMergeWorker, null, exec) :
+              new Lucene99HnswVectorsFormat(maxConn, beamWidth, numMergeWorker, exec);
         }
       };
     }
@@ -927,7 +881,8 @@ public class KnnGraphTester {
     }
 
     @Override
-    public void visit(QueryVisitor visitor) {}
+    public void visit(QueryVisitor visitor) {
+    }
 
     @Override
     public String toString(String field) {

--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -565,22 +565,7 @@ public class KnnGraphTester {
       totalVisited /= numIters;
       System.out.printf(
           Locale.ROOT,
-          "|%s\t|%s\t|%s\t|%s\t|%s\t|%s\t|%s\t|%s\t|%s\t|%s|\n",
-          "recall",
-          "avgCpuTime",
-          "numDocs",
-          "fanout",
-          "maxConn",
-          "beamWidth",
-          "totalVisited",
-          "reindexTimeMsec",
-          "selectivity",
-          "prefilter");
-      System.out.println(
-          "|---|---|---|---|---|---|---|---|---|---|");
-      System.out.printf(
-          Locale.ROOT,
-          "|%5.3f\t|%5.2f\t|%d\t|%d\t|%d\t|%d\t|%d\t|%d\t|%.2f\t|%s|\n",
+          "%5.3f\t%5.2f\t%d\t%d\t%d\t%d\t%d\t%d\t%.2f\t%s\n",
           recall,
           totalCpuTime / (float) numIters,
           numDocs,

--- a/src/main/knn/KnnIndexer.java
+++ b/src/main/knn/KnnIndexer.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package knn;
+
+import knn.KnnGraphTester;
+import knn.VectorReader;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99Codec;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.apache.lucene.document.*;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.PrintStreamInfoStream;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+public class KnnIndexer {
+
+  Path docsPath;
+  Path indexPath;
+  int maxConn;
+  int beamWidth;
+  VectorEncoding vectorEncoding;
+  int dim;
+  VectorSimilarityFunction similarityFunction;
+  int numDocs;
+  int docsStartIndex;
+  boolean quiet;
+
+  public KnnIndexer(Path docsPath, Path indexPath, int maxConn, int beamWidth, VectorEncoding vectorEncoding, int dim,
+                    VectorSimilarityFunction similarityFunction, int numDocs, boolean quiet) {
+    this(docsPath, indexPath, maxConn, beamWidth, vectorEncoding, dim, similarityFunction, numDocs, 0, quiet);
+  }
+
+  public KnnIndexer(Path docsPath, Path indexPath, int maxConn, int beamWidth, VectorEncoding vectorEncoding, int dim,
+                    VectorSimilarityFunction similarityFunction, int numDocs, int docsStartIndex, boolean quiet) {
+    this.docsPath = docsPath;
+    this.indexPath = indexPath;
+    this.maxConn = maxConn;
+    this.beamWidth = beamWidth;
+    this.vectorEncoding = vectorEncoding;
+    this.dim = dim;
+    this.similarityFunction = similarityFunction;
+    this.numDocs = numDocs;
+    this.docsStartIndex = docsStartIndex;
+    this.quiet = quiet;
+  }
+
+  public int createIndex() throws IOException {
+    IndexWriterConfig iwc = new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.CREATE);
+    iwc.setCodec(
+        new Lucene99Codec() {
+          @Override
+          public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+            return new Lucene99HnswVectorsFormat(maxConn, beamWidth);
+          }
+        });
+    // iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+    iwc.setRAMBufferSizeMB(1994d);
+    iwc.setUseCompoundFile(false);
+    // iwc.setMaxBufferedDocs(10000);
+
+    FieldType fieldType =
+        switch (vectorEncoding) {
+          case BYTE -> KnnByteVectorField.createFieldType(dim, similarityFunction);
+          case FLOAT32 -> KnnFloatVectorField.createFieldType(dim, similarityFunction);
+        };
+    if (quiet == false) {
+      iwc.setInfoStream(new PrintStreamInfoStream(System.out));
+      System.out.println("creating index in " + indexPath);
+    }
+
+    if (!indexPath.toFile().exists()) {
+      indexPath.toFile().mkdirs();
+    }
+
+    long start = System.nanoTime();
+    try (FSDirectory dir = FSDirectory.open(indexPath);
+         IndexWriter iw = new IndexWriter(dir, iwc)) {
+      try (FileChannel in = FileChannel.open(docsPath)) {
+        if (docsStartIndex > 0) {
+          seekToStartDoc(in, dim, vectorEncoding, docsStartIndex);
+        }
+        VectorReader vectorReader = VectorReader.create(in, dim, vectorEncoding);
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          switch (vectorEncoding) {
+            case BYTE -> doc.add(
+                new KnnByteVectorField(
+                    KnnGraphTester.KNN_FIELD, ((VectorReaderByte) vectorReader).nextBytes(), fieldType));
+            case FLOAT32 -> doc.add(
+                new KnnFloatVectorField(KnnGraphTester.KNN_FIELD, vectorReader.next(), fieldType));
+          }
+          doc.add(new StoredField(KnnGraphTester.ID_FIELD, i));
+          iw.addDocument(doc);
+
+          if (quiet == false && i % 10000 == 0) {
+            System.out.println("Done indexing " + (i + 1) + " documents.");
+          }
+        }
+        if (quiet == false) {
+          System.out.println("Done indexing " + numDocs + " documents; now flush");
+        }
+      }
+    }
+    long elapsed = System.nanoTime() - start;
+    if (quiet == false) {
+      System.out.println(
+          "Indexed " + numDocs + " documents in " + TimeUnit.NANOSECONDS.toSeconds(elapsed) + "s");
+    }
+    return (int) TimeUnit.NANOSECONDS.toMillis(elapsed);
+  }
+
+  private void seekToStartDoc(FileChannel in, int dim, VectorEncoding vectorEncoding, int docsStartIndex) throws IOException {
+    int startByte = docsStartIndex * dim * vectorEncoding.byteSize;
+    in.position(startByte);
+  }
+}

--- a/src/main/knn/KnnIndexerMain.java
+++ b/src/main/knn/KnnIndexerMain.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package knn;
+
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class KnnIndexerMain {
+  public Path docVectorsPath;
+  public Path indexPath;
+  public int maxConn = 16;
+  public int beamWidth = 100;
+  public VectorEncoding vectorEncoding = VectorEncoding.FLOAT32;
+  public int dimension;
+  public VectorSimilarityFunction similarityFunction = VectorSimilarityFunction.COSINE;
+  public int numDocs;
+
+  public int docStartIndex = 0;
+  boolean quiet = false;
+
+  @Override
+  public String toString() {
+    return "KnnIndexerMain {" +
+        "docVectorsPath='" + docVectorsPath + '\'' +
+        ", indexPath='" + indexPath + '\'' +
+        ", maxConn=" + maxConn +
+        ", beamWidth=" + beamWidth +
+        ", vectorEncoding=" + vectorEncoding +
+        ", dimension=" + dimension +
+        ", similarityFunction=" + similarityFunction +
+        ", numDocs=" + numDocs +
+        ", docStartIndex=" + docStartIndex +
+        ", quiet=" + quiet +
+        '}';
+  }
+
+  public static void main(String[] args) throws IOException {
+    KnnIndexerMain inputs = new KnnIndexerMain();
+
+    try {
+      int i = 0;
+      while (i < args.length) {
+        switch (args[i].toLowerCase()) {
+          case "-docvectorspath" -> inputs.docVectorsPath = Path.of(args[++i]);
+          case "-indexpath" -> inputs.indexPath = Path.of(args[++i]);
+          case "-maxconn" -> inputs.maxConn = Integer.parseInt(args[++i]);
+          case "-beamwidth" -> inputs.beamWidth = Integer.parseInt(args[++i]);
+          case "-vectorencoding" -> inputs.vectorEncoding = VectorEncoding.valueOf(args[++i]);
+          case "-similarityfunction" ->
+              inputs.similarityFunction = VectorSimilarityFunction.valueOf(args[++i].toUpperCase());
+          case "-numdocs" -> inputs.numDocs = Integer.parseInt(args[++i]);
+          case "-docstartindex" -> inputs.docStartIndex = Integer.parseInt(args[++i]);
+          case "-dimension" -> inputs.dimension = Integer.parseInt(args[++i]);
+          case "-quiet" -> inputs.quiet = true;
+          default -> throw new IllegalArgumentException("Cannot recognize the option " + args[i]);
+        }
+        i++;
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      System.out.println("Please follow correct usage guidelines:" + inputs.usage());
+    }
+
+    if (!inputs.quiet) {
+      System.out.println("Creating index with following configurations : " + inputs);
+    }
+
+    new KnnIndexer(inputs.docVectorsPath, inputs.indexPath, inputs.maxConn, inputs.beamWidth, inputs.vectorEncoding,
+        inputs.dimension, inputs.similarityFunction, inputs.numDocs, inputs.docStartIndex, inputs.quiet).createIndex();
+
+    if (!inputs.quiet) {
+      System.out.println("Successfully created index.");
+    }
+  }
+
+  public String usage() {
+    return "KnnIndexerMain \n" +
+        "\t -docVectorsPath : path of the file containing vectors for document. <TODO: what format?>\n" +
+        "\t -indexPath : path of the folder/dir where the index has to be created.\n" +
+        "\t -maxConn : maximum connections per node for HNSW graph\n" +
+        "\t -beamWidth : beam-width at graph creation time. Same as efConstruction in the HNSW paper.\n" +
+        "\t -vectorEncoding: vector encoding. one of constant 'BYTE' or 'FLOAT32'\n" +
+        "\t -dimension : dimension / size of the vectors \n" +
+        "\t -similarityFunction : similarity function for vector comparison. One of ( EUCLIDEAN, DOT_PRODUCT, COSINE, MAXIMUM_INNER_PRODUCT )\n" +
+        "\t -numDocs : number of document vectors to be used from the file\n" +
+        "\t -docStartIndex : Start index of first document vector. This can be helpful when we want to run different with set of documents from within the same file.\n" +
+        "\t -quiet : don't print anything on console if mentioned.\n";
+  }
+}

--- a/src/main/knn/VectorReader.java
+++ b/src/main/knn/VectorReader.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package knn;
+
+import org.apache.lucene.index.VectorEncoding;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+
+public abstract class VectorReader {
+  final float[] target;
+  final ByteBuffer bytes;
+  final FileChannel input;
+
+  static VectorReader create(FileChannel input, int dim, VectorEncoding vectorEncoding) {
+    int bufferSize = dim * vectorEncoding.byteSize;
+    return switch (vectorEncoding) {
+      case BYTE -> new VectorReaderByte(input, dim, bufferSize);
+      case FLOAT32 -> new VectorReaderFloat32(input, dim, bufferSize);
+    };
+  }
+
+  VectorReader(FileChannel input, int dim, int bufferSize) {
+    this.bytes = ByteBuffer.wrap(new byte[bufferSize]).order(ByteOrder.LITTLE_ENDIAN);
+    this.input = input;
+    target = new float[dim];
+  }
+
+  void reset() throws IOException {
+    input.position(0);
+  }
+
+  protected final void readNext() throws IOException {
+    if (this.input.read(bytes) < target.length) {
+      this.input.position(0);
+      this.input.read(bytes);
+    }
+    bytes.position(0);
+  }
+
+  abstract float[] next() throws IOException;
+}

--- a/src/main/knn/VectorReaderByte.java
+++ b/src/main/knn/VectorReaderByte.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package knn;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+public class VectorReaderByte extends VectorReader {
+  private final byte[] scratch;
+
+  VectorReaderByte(FileChannel input, int dim, int bufferSize) {
+    super(input, dim, bufferSize);
+    scratch = new byte[dim];
+  }
+
+  @Override
+  float[] next() throws IOException {
+    readNext();
+    bytes.get(scratch);
+    for (int i = 0; i < scratch.length; i++) {
+      target[i] = scratch[i];
+    }
+    return target;
+  }
+
+  byte[] nextBytes() throws IOException {
+    readNext();
+    bytes.get(scratch);
+    return scratch;
+  }
+}

--- a/src/main/knn/VectorReaderFloat32.java
+++ b/src/main/knn/VectorReaderFloat32.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package knn;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+public class VectorReaderFloat32 extends VectorReader {
+  VectorReaderFloat32(FileChannel input, int dim, int bufferSize) {
+    super(input, dim, bufferSize);
+  }
+
+  @Override
+  float[] next() throws IOException {
+    readNext();
+    bytes.asFloatBuffer().get(target);
+    return target;
+  }
+}

--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -74,7 +74,7 @@ def run_knn_benchmark(checkout, values):
     cmd = [constants.JAVA_EXE, '-cp', cp,
            '--add-modules', 'jdk.incubator.vector',
            '-Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false',
-           'KnnGraphTester']
+           'knn.KnnGraphTester']
     print("recall\tlatency\tnDoc\tfanout\tmaxConn\tbeamWidth\tvisited\tindex ms")
     while advance(indexes, values):
         pv = {}


### PR DESCRIPTION
In this PR
1. moved the current KnnGraphTester to `knn` package.
2. Extracted KnnIndexer class out of KnnGraphTester code so that the logic can be reused.
3. Extracted some more classes from KnnGraphTester to avoid bloating it as a coding best practice.

Tests :
``` 
ant build

python src/python/knnPerfTest.py
```
Also tested by passing the `-indexPath` to KnnGraphTester from knnPerfTest.py. Works fine. 

Was able to run the command correctly and get output like
|recall	|avgCpuTime	|numDocs	|fanout	|maxConn	|beamWidth	|totalVisited	|reindexTimeMsec	|selectivity	|prefilter|
|---|---|---|---|---|---|---|---|---|---|
|0.971	| 0.71	|10000	|0	|16	|100	|1339	|7013	|1.00	|post-filter|


