### PR TITLE
Add Cohere/wikipedia-22-12-en-embeddings dataset for vector search

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,9 @@ By default we use 100 dimension vectors, to use higher dimension vectors, you ne
 1. run `src/python/infer_token_vectors.py` to get `xxx.vec` and `xxx.tok` file, also do not forget to set the model you need by editing `infer_token_vectors.py`, The supported models are listed there in comments. E.g. for 768 dimensions you need `enwiki-20120502-mpnet.vec` and `enwiki-20120502-mpnet.tok` as output file and you need to set the model to `model = SentenceTransformer('all-mpnet-base-v2')` by edit `infer_token_vectors.py` (which is already the default).
 2. run corresponding ant tasks to generate embeddings for docs and queries. E.g. for 768 dimensions you need to run `ant vectors-mpnet-docs` and `vectors-mpnet-tasks`.
 3. run `src/python/localrun.py` (see instructions inside `src/python/vector-test.py`) or `src/python/knnPerTest.py` (see instructions inside the file) of your choice, 
+
+To test vector search with [Cohere/wikipedia-22-12-en-embeddings](https://huggingface.co/datasets/Cohere/wikipedia-22-12-en-embeddings) dataset, you need to do:
+1. run `python src/python/infer_token_vectors_cohere.py ../data/cohere-wikipedia-768.vec 10000000 ../data/cohere-wikipedia-queries-768.vec 10000` to generate vectors
+in the format that luceneutil vector search can understand. Instead of `10000000` increase the number of documents to `100000000` if you want to run vector search on 10M documents.
+2. In `src/python/knnPerTest.py` uncomment lines that define doc and query vectors for cohere dataset.
+3. run `src/python/knnPerTest.py` 

--- a/src/python/infer_token_vectors_cohere.py
+++ b/src/python/infer_token_vectors_cohere.py
@@ -1,0 +1,47 @@
+import datasets
+import numpy as np
+import sys
+
+
+"""
+Generate document and query vectors for the vector search task from 
+the Cohere/wikipedia-22-12-en-embeddings https://huggingface.co/datasets/Cohere/wikipedia-22-12-en-embeddings dataset. 
+
+Usage: 
+
+python src/python/infer_token_vectors_cohere.py <result_docs_vector_file> <num_docs> <result_queries_vector_file> <num_queries>
+
+python src/python/infer_token_vectors_cohere.py ../data/cohere-wikipedia-768.vec 1000000 \
+    ../data/cohere-wikipedia-queries-768.vec 10000
+"""
+
+filename = sys.argv[1]
+num_docs = int(sys.argv[2])
+filename_queries= sys.argv[3]
+num_queries = int(sys.argv[4])
+dims = 768
+
+ds = datasets.load_dataset("Cohere/wikipedia-22-12-en-embeddings", split="train")
+print(f"total number of rows: {len(ds)}")
+print(f"embeddings dims: {len(ds[0]['emb'])}")
+
+ds_embs = ds[0:num_docs]['emb']
+embs = np.array(ds_embs)
+print(f"saving docs of shape: {embs.shape} to file")
+with open(filename, "w") as out_f:
+    embs.tofile(out_f)
+
+ds_embs_queries = ds[num_docs : num_docs + num_queries]['emb']
+embs_queries = np.array(ds_embs_queries)
+print(f"saving queries of shape: {embs_queries.shape} to file")
+with open(filename_queries, "w") as out_f_queries:
+    embs_queries.tofile(out_f_queries)
+
+### check saved datasets
+embs_docs = np.fromfile(filename, dtype=np.float64)
+embs_docs = embs_docs.reshape(num_docs, dims)
+print(f"reading docs of shape: {embs_docs.shape}")
+
+embs_queries = np.fromfile(filename_queries, dtype=np.float64)
+embs_queries = embs_queries.reshape(num_queries, dims)
+print(f"reading queries shape: {embs_queries.shape}")

--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -70,6 +70,11 @@ def run_knn_benchmark(checkout, values):
     #dim = 256
     #doc_vectors = '/d/electronics_asin_emb.bin'
     #query_vectors = '/d/electronics_query_vectors.bin'
+
+    # Cohere dataset
+    #dim = 768
+    #doc_vectors = '%s/data/cohere-wikipedia-768.vec' % constants.BASE_DIR
+    #query_vectors = '%s/data/cohere-wikipedia-queries-768.vec' % constants.BASE_DIR
     cp = benchUtil.classPathToString(benchUtil.getClassPath(checkout))
     cmd = [constants.JAVA_EXE, '-cp', cp,
            '--add-modules', 'jdk.incubator.vector',


### PR DESCRIPTION
This dataset contains vectors of higher dimensions of 768. This dataset contains a pre-processed version from Wikipedia suitable for semantic search.

The problem with current datasets generated by `infer_token_vectors.py` file is that they are generated for single tokens out of context. Thus, they don't represent the true embeddings, and hence the produced recall of vector search on them is not good.

 Cohere/wikipedia-22-12-en-embeddings dataset represent true embeddings and we can
show very good recall of Lucene vector search on them.