### PR TITLE
Use CMS defaults.

### DIFF
--- a/src/main/perf/Args.java
+++ b/src/main/perf/Args.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class Args {
   private final String[] args;
@@ -79,6 +80,10 @@ public class Args {
     return Integer.parseInt(getString(argName));
   }
 
+  public int getInt(String argName, int defaultValue) {
+    return Integer.parseInt(getString(argName, Integer.toString(defaultValue)));
+  }
+
   public double getDouble(String argName) {
     return Double.parseDouble(getString(argName));
   }
@@ -108,6 +113,14 @@ public class Args {
     }
 
     return false;
+  }
+
+  public Optional<Boolean> getOptionalBoolean(String argName) {
+    if (hasArg(argName)) {
+      return Optional.of(Boolean.parseBoolean(argName));
+    } else {
+      return Optional.empty();
+    }
   }
 
   public boolean hasArg(String argName) {

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -894,7 +894,8 @@ class RunAlgs:
       w('-lineDocsFile', index.lineDocSource)
       w('-docCountLimit', index.numDocs)
       w('-threadCount', index.numThreads)
-      w('-maxConcurrentMerges', index.maxConcurrentMerges)
+      if index.maxConcurrentMerges is not None:
+        w('-maxConcurrentMerges', index.maxConcurrentMerges)
 
       if index.addDVFields:
         w('-dvfields')
@@ -959,8 +960,8 @@ class RunAlgs:
       if index.waitForCommit:
         w('-waitForCommit')
 
-      if index.disableIOThrottle:
-        w('-disableIOThrottle')
+      if index.ioThrottle is not None:
+        w('-ioThrottle', str(index.ioThrottle).lower())
 
       if index.indexSort:
         w('-indexSort', index.indexSort)

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -142,7 +142,7 @@ class Index(object):
                printDPS = False,
                waitForMerges = True,
                waitForCommit = True,
-               disableIOThrottle = False,
+               ioThrottle = None,
                bodyTermVectors = False,
                bodyStoredFields = False,
                bodyPostingsOffsets = False,
@@ -150,7 +150,7 @@ class Index(object):
                facets = None,
                extraNamePart = None,
                facetDVFormat = constants.FACET_FIELD_DV_FORMAT_DEFAULT,
-               maxConcurrentMerges = 1,  # use 1 for spinning-magnets and 3 for fast SSD
+               maxConcurrentMerges = None,
                addDVFields = False,
                name = None,
                indexSort = None,
@@ -197,7 +197,7 @@ class Index(object):
     self.printDPS = printDPS
     self.waitForMerges = waitForMerges
     self.waitForCommit = waitForCommit
-    self.disableIOThrottle = disableIOThrottle
+    self.ioThrottle = ioThrottle
     self.idFieldPostingsFormat = idFieldPostingsFormat
     self.bodyTermVectors = bodyTermVectors
     self.bodyStoredFields = bodyStoredFields

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -384,11 +384,9 @@ def run():
                                     ramBufferMB=INDEXING_RAM_BUFFER_MB,
                                     waitForMerges=False,
                                     waitForCommit=False,
-                                    disableIOThrottle=True,
                                     grouping=False,
                                     verbose=False,
                                     mergePolicy='TieredMergePolicy',
-                                    maxConcurrentMerges=12,
                                     useCMS=True)
 
     fastIndexMediumVectors = comp.newIndex(NIGHTLY_DIR, mediumSource,
@@ -400,11 +398,9 @@ def run():
                                            ramBufferMB=INDEXING_RAM_BUFFER_MB,
                                            waitForMerges=False,
                                            waitForCommit=False,
-                                           disableIOThrottle=True,
                                            grouping=False,
                                            verbose=False,
                                            mergePolicy='TieredMergePolicy',
-                                           maxConcurrentMerges=12,
                                            useCMS=True,
                                            vectorFile=constants.VECTORS_DOCS_FILE,
                                            vectorDimension=constants.VECTORS_DIMENSIONS,
@@ -419,11 +415,9 @@ def run():
                                                     ramBufferMB=INDEXING_RAM_BUFFER_MB,
                                                     waitForMerges=False,
                                                     waitForCommit=False,
-                                                    disableIOThrottle=True,
                                                     grouping=False,
                                                     verbose=False,
                                                     mergePolicy='TieredMergePolicy',
-                                                    maxConcurrentMerges=12,
                                                     useCMS=True,
                                                     vectorFile=constants.VECTORS_DOCS_FILE,
                                                     vectorDimension=constants.VECTORS_DIMENSIONS,
@@ -439,11 +433,9 @@ def run():
                                    ramBufferMB=INDEXING_RAM_BUFFER_MB,
                                    waitForMerges=True,
                                    waitForCommit=True,
-                                   disableIOThrottle=True,
                                    grouping=False,
                                    verbose=False,
                                    mergePolicy='TieredMergePolicy',
-                                   maxConcurrentMerges=12,
                                    useCMS=True,
                                    addDVFields=True)
 
@@ -461,11 +453,9 @@ def run():
                                  ramBufferMB=INDEXING_RAM_BUFFER_MB,
                                  waitForMerges=False,
                                  waitForCommit=False,
-                                 disableIOThrottle=True,
                                  grouping=False,
                                  verbose=False,
                                  mergePolicy='TieredMergePolicy',
-                                 maxConcurrentMerges=12,
                                  useCMS=True)
 
     # Must use only 1 thread so we get same index structure, always:


### PR DESCRIPTION
This switches from custom values of `disableIOThrottle` and `maxConcurrentMerges` to CMS's default values.