### PR TITLE
Fix KnnGraphTester compilation with latest lucene changes

### DIFF
--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -837,11 +837,13 @@ public class KnnGraphTester {
             public Scorer get(long leadCost) throws IOException {
               return scorer;
             }
+
             @Override
             public long cost() {
               return cardinality;
             }
           };
+        }
 
         @Override
         public boolean isCacheable(LeafReaderContext ctx) {


### PR DESCRIPTION
One other thing is the transient dependency on hppc. 

It would be really good if luceneutil was updated so it could download and use hppc directly (via ant, or gradle, etc.). But I suck at build systems and they make me want to throw my laptop, so, I didn't bother with that.