### PR TITLE
Run nightly benchmarks with a single thread executor.

### DIFF
--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1129,11 +1129,6 @@ class RunAlgs:
     else:
       doSort = ''
 
-    if c.concurrentSearches:
-      doConcurrentSegmentReads = '-concurrentSearches'
-    else:
-      doConcurrentSegmentReads = ''
-
     command = []
     command += c.javaCommand.split()
 
@@ -1160,8 +1155,7 @@ class RunAlgs:
     w('-tasksPerCat', c.competition.taskCountPerCat)
     if c.doSort:
       w('-sort')
-    if c.concurrentSearches:
-      w('-concurrentSearches')
+    w('-searchConcurrency', c.searchConcurrency)
     w('-staticSeed', staticSeed)
     w('-seed', seed)
     w('-similarity', c.similarity)

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -288,7 +288,7 @@ class Competitor(object):
                vectorScale = None,
                loadStoredFields = False,
                exitable = False,
-               concurrentSearches = False,
+               searchConcurrency = 0,
                javacCommand = constants.JAVAC_EXE,
                topN = 100):
     self.name = name
@@ -313,7 +313,7 @@ class Competitor(object):
     self.vectorDict = vectorDict
     self.vectorScale = vectorScale
     self.javacCommand = javacCommand
-    self.concurrentSearches = concurrentSearches
+    self.searchConcurrency = searchConcurrency
     # TopN: how many hits are retrieved
     self.topN = topN
 

--- a/src/python/example.py
+++ b/src/python/example.py
@@ -25,8 +25,8 @@ if __name__ == '__main__':
                                    description='Run a local benchmark on provided source dataset.')
   parser.add_argument('-s', '-source', '--source',
                       help='Data source to run the benchmark on.')
-  parser.add_argument('-concurrentSearches', '--concurrentSearches', action='store_true',
-                      help='Run concurrent searches')
+  parser.add_argument('-searchConcurrency', '--searchConcurrency',
+                      help='Search concurrency, 0 for disabled, -1 for using all cores')
   parser.add_argument('-b', '--baseline', default='lucene_baseline',
                       help='Path to lucene repo to be used for baseline')
   parser.add_argument('-c', '--candidate', default='lucene_candidate',
@@ -52,7 +52,7 @@ if __name__ == '__main__':
 
   # create a competitor named baseline with sources in the ../trunk folder
   comp.competitor('baseline', args.baseline,
-                  index = index, concurrentSearches = args.concurrentSearches)
+                  index = index, searchConcurrency = args.searchConcurrency)
 
   # use the same index as baseline unless --reindex was passed.
   # create a competitor named my_modified_version (or provided candidate name) with sources in the ../patch folder
@@ -72,7 +72,7 @@ if __name__ == '__main__':
                                   ('taxonomy:RandomLabel', 'RandomLabel'),
                                   ('sortedset:RandomLabel', 'RandomLabel')))
   comp.competitor('my_modified_version', args.candidate,
-                  index = candidate_index, concurrentSearches = args.concurrentSearches)
+                  index = candidate_index, searchConcurrency = args.searchConcurrency)
 
   # start the benchmark - this can take long depending on your index and machines
   comp.benchmark("baseline_vs_patch")

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -76,6 +76,11 @@ else:
 
 DIR_IMPL = 'MMapDirectory'
 
+# Configure a concurrency of 1. This ensures that we exercise code paths for
+# search concurrency while still running searches in a single thread in
+# practice.
+SEARCH_CONCURRENCY = 1
+
 INDEXING_RAM_BUFFER_MB = 2048
 
 # "randomly" pick 5 queries for each category, but see validate_nightly_task_count where we
@@ -487,7 +492,8 @@ def run():
                         index=index,
                         vectorDict=(constants.VECTORS_WORD_TOK_FILE, constants.VECTORS_WORD_VEC_FILE, constants.VECTORS_DIMENSIONS),
                         directory=DIR_IMPL,
-                        commitPoint='multi')
+                        commitPoint='multi',
+                        searchConcurrency=SEARCH_CONCURRENCY)
 
     # c = benchUtil.Competitor(id, 'trunk.nightly', index, DIR_IMPL, 'StandardAnalyzerNoStopWords', 'multi', constants.WIKI_MEDIUM_TASKS_FILE)
 


### PR DESCRIPTION
We're making concurrenty search more of a first-class citizen, and hopefully it will soon even be the default in Lucene. So let's start better exercising code paths for concurrent search in nightly benchmarks by configuring an executor, but bounding it to a single thread for now to contain noise.

Closes #210