### PR TITLE
Enable indexing/searching on pre-computed .vec files like those produced by infer_token_vectors_cohere.py

### DIFF
--- a/src/main/perf/IndexState.java
+++ b/src/main/perf/IndexState.java
@@ -56,6 +56,7 @@ class IndexState {
   public final boolean hasDeletions;
   public final TaxonomyReader taxoReader;
   public final FacetsConfig facetsConfig;
+  public final boolean groupBlocksExist;
   // maps facet dimension to method (sortedset, taxonomy)
   public final Map<String,Integer> facetFields;
   public final Map<Object, ThreadLocal<PKLookupState>> pkLookupStates = new HashMap<>();
@@ -94,6 +95,9 @@ class IndexState {
         pointsPKLookupStates.put(ctx.reader().getCoreCacheHelper().getKey(), new ThreadLocal<PointsPKLookupState>());
         pkLookupWithTermStateStates.put(ctx.reader().getCoreCacheHelper().getKey(), new ThreadLocal<PKLookupWithTermStateState>());
       }
+
+      groupBlocksExist = searcher.count(groupEndQuery) > 0;
+
     } finally {
       mgr.release(searcher);
     }

--- a/src/main/perf/Indexer.java
+++ b/src/main/perf/Indexer.java
@@ -248,13 +248,13 @@ public final class Indexer {
     int vectorDimension;
     VectorEncoding vectorEncoding;
     if (args.hasArg("-vectorFile")) {
-        vectorFile = args.getString("-vectorFile");
-        vectorDimension = args.getInt("-vectorDimension");
-        vectorEncoding = VectorEncoding.valueOf(args.getString("-vectorEncoding"));
+      vectorFile = args.getString("-vectorFile");
+      vectorDimension = args.getInt("-vectorDimension");
+      vectorEncoding = VectorEncoding.valueOf(args.getString("-vectorEncoding"));
     } else {
-        vectorFile = null;
-        vectorDimension = 0;
-        vectorEncoding = null;
+      vectorFile = null;
+      vectorDimension = 0;
+      vectorEncoding = null;
     }
 
     // -1 means all docs in the line file:

--- a/src/main/perf/Indexer.java
+++ b/src/main/perf/Indexer.java
@@ -454,10 +454,6 @@ public final class Indexer {
         System.out.println("Concurrent HNSW merge enabled: " + hnswThreadsPerMerge + " threads per merge, drawing from shared thread pool with " + hnswThreadPoolCount + " fixed threads");
       }
     
-      if (verbose) {
-        InfoStream.setDefault(new PrintStreamInfoStream(System.out));
-      }
-
       // Use Codec at defaults, except possibly for id field, facets, andconcurrency during HNSW merging
       final Codec codec = new Lucene99Codec() {
           @Override
@@ -518,10 +514,12 @@ public final class Indexer {
 
         iwc.setMaxBufferedDocs(maxBufferedDocs);
         iwc.setRAMBufferSizeMB(ramBufferSizeMB);
+        if (verbose) {
+          iwc.setInfoStream(new PrintStreamInfoStream(System.out));
+        }
 
         // So flushed segments do/don't use CFS:
         iwc.setUseCompoundFile(useCFS);
-
 
         iwc.setMergeScheduler(getMergeScheduler(indexingFailed, useCMS, maxConcurrentMerges, ioThrottle));
         iwc.setMergePolicy(getMergePolicy(mergePolicy, useCFS));
@@ -541,7 +539,6 @@ public final class Indexer {
       };
 
       final IndexWriterConfig iwc = getIWC.call();
-
 
       System.out.println("IW config=" + iwc);
 
@@ -686,7 +683,7 @@ public final class Indexer {
         System.out.println("Taxonomy has " + taxoWriter.getSize() + " ords");
         taxoWriter.commit();
         taxoWriter.close();
-        SegmentInfos infos = SegmentInfos.readLatestCommit(dir);
+        SegmentInfos infos = SegmentInfos.readLatestCommit(taxoDir);
         System.out.println("Taxonomy size (as committed) " + sizeInBytes(infos) + " bytes");
         System.out.println("Taxonomy Directory total size " + sizeInBytes(taxoDir) + " bytes");
       }
@@ -699,7 +696,7 @@ public final class Indexer {
       if (waitForCommit) {
         SegmentInfos infos = SegmentInfos.readLatestCommit(dir);
         System.out.println("\nIndex size (as committed): " + sizeInBytes(infos) + " bytes");
-        System.out.println("\nIndexer: at close: " + infos);
+        System.out.println("\nIndexer: at close: " + infos.size() + " segments: " + infos);
         System.out.println("\nIndexer: close took " + (System.currentTimeMillis() - tCloseStart) + " msec");
       }
 

--- a/src/main/perf/LineFileDocs.java
+++ b/src/main/perf/LineFileDocs.java
@@ -50,8 +50,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
@@ -209,7 +209,7 @@ public class LineFileDocs implements Closeable {
       .order(ByteOrder.LITTLE_ENDIAN);
     int n = vectorChannel.read(buffer);
     if (n != count * vectorDimension * Float.BYTES) {
-      throw new RuntimeException("expected " + count * vectorDimension * Float.BYTES + " vector bytes but read " + n);
+      throw new RuntimeException("expected " + count * vectorDimension * Float.BYTES + " vector bytes (count=" + count + " vectorDimension=" + vectorDimension + ") but read " + n);
     }
     buffer.position(0);
     buffer.asFloatBuffer().get(vector);
@@ -564,7 +564,6 @@ public class LineFileDocs implements Closeable {
     if (isBinary) {
 
       float[] vector = new float[vectorDimension];
-      FloatBuffer vectorBuffer = null;
 
       LineFileDoc lfd;
 

--- a/src/main/perf/NRTPerfTest.java
+++ b/src/main/perf/NRTPerfTest.java
@@ -374,7 +374,7 @@ public class NRTPerfTest {
     final DirectSpellChecker spellChecker = new DirectSpellChecker();
     final IndexState indexState = new IndexState(manager, null, field, spellChecker, "FastVectorHighlighter", null, null);
     TaskParserFactory taskParserFactory =
-            new TaskParserFactory(indexState, field, analyzer, field, 10, random, null, true);
+      new TaskParserFactory(indexState, field, analyzer, field, 10, random, null, null, -1, true);
     final TaskSource tasks = new RandomTaskSource(tasksFile, random, taskParserFactory.getTaskParser()) {
         @Override
         public void taskDone(Task task, long queueTimeNS, TotalHits toalHitCount) {

--- a/src/main/perf/RemoteTaskSource.java
+++ b/src/main/perf/RemoteTaskSource.java
@@ -35,15 +35,15 @@ import org.apache.lucene.search.TotalHits;
 // Serves up tasks from remote client
 class RemoteTaskSource extends Thread implements TaskSource {
   private final ServerSocket serverSocket;
-  private final int numThreads;
+  private final int numConcurrentQueries;
   private static final int MAX_BYTES = 70;
   private final TaskParser taskParser;
 
   // nocommit maybe fair=true?
   private final BlockingQueue<Task> queue = new ArrayBlockingQueue<Task>(100000);
 
-  public RemoteTaskSource(String iface, int port, int numThreads, TaskParser taskParser) throws IOException {
-    this.numThreads = numThreads;
+  public RemoteTaskSource(String iface, int port, int numConcurrentQueries, TaskParser taskParser) throws IOException {
+    this.numConcurrentQueries = numConcurrentQueries;
     this.taskParser = taskParser;
     serverSocket = new ServerSocket(port, 50, InetAddress.getByName(iface));
     System.out.println("Waiting for client connection on interface " + iface + ", port " + port);
@@ -111,7 +111,7 @@ class RemoteTaskSource extends Thread implements TaskSource {
 
           String s = new String(buffer, "UTF-8");
           if (s.startsWith("END//")) {
-            for(int threadID=0;threadID<numThreads;threadID++) {
+            for(int threadID=0;threadID<numConcurrentQueries;threadID++) {
               queue.put(Task.END_TASK);
             }
             break;

--- a/src/main/perf/SearchTask.java
+++ b/src/main/perf/SearchTask.java
@@ -344,7 +344,7 @@ final class SearchTask extends Task {
         totalHitCount = new TotalHits(groupsResultBlock.totalHitCount, TotalHits.Relation.EQUAL_TO);
       }
     } catch (Throwable t) {
-      System.out.println("EXC: " + q);
+      System.out.println("EXC: " + this);
       throw new RuntimeException(t);
       //System.out.println("TE: " + TermsEnum.getStats());
     } finally {

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -1,15 +1,5 @@
 package perf;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.apache.lucene.document.IntField;
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -27,6 +17,22 @@ import org.apache.lucene.document.IntField;
  * limitations under the License.
  */
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.KeywordField;
 import org.apache.lucene.document.LongField;
@@ -42,10 +48,10 @@ import org.apache.lucene.queries.spans.SpanTermQuery;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.sandbox.search.CombinedFieldQuery;
-import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery.Builder;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.MultiPhraseQuery;
@@ -56,7 +62,7 @@ import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.TermQuery;
 
-class TaskParser {
+class TaskParser implements Closeable {
 
   private final QueryParser queryParser;
   private final String fieldName;
@@ -69,8 +75,19 @@ class TaskParser {
   private final Random random;
   private final boolean doStoredLoads;
   private final IndexState state;
-  private final VectorDictionary vectorDictionary;
+
+  // non-null if we have vectors to use for KNN search:
   private final String vectorField;
+
+  // these is used when we run search-time inference by tokenizing query text and
+  // summing (averaging? and normalizing) the per-token vectors stored in
+  // vectorDictionary:
+  private final VectorDictionary vectorDictionary;
+  private final int vectorDimension;
+
+  // this is used when we simply use pre-computed (in random order, unassociated
+  // with the specific query text) query vectors.  see src/python/infer_token_vectors_cohere.py:
+  private final SeekableByteChannel vectorChannel;
 
   public TaskParser(IndexState state,
                     QueryParser queryParser,
@@ -78,6 +95,8 @@ class TaskParser {
                     int topN,
                     Random random,
                     VectorDictionary vectorDictionary,
+                    Path vectorFilePath,
+                    int vectorDimension,
                     boolean doStoredLoads) throws IOException {
     this.queryParser = queryParser;
     this.fieldName = fieldName;
@@ -88,14 +107,38 @@ class TaskParser {
     this.vectorDictionary = vectorDictionary;
     if (vectorDictionary != null) {
       vectorField = "vector";
+      vectorChannel = null;
+      if (vectorDimension != -1) {
+        throw new RuntimeException("vectorDimension must be -1 when vectorDictionary is used; got: " + vectorDimension);
+      }
+    } else if (vectorFilePath != null) {
+      vectorField = "vector";
+      vectorChannel = Files.newByteChannel(vectorFilePath, StandardOpenOption.READ);
+      if (vectorDimension < 1) {
+        throw new RuntimeException("vectorDimension must be > 0 when vectorFilePath is non-null; got: " + vectorDimension);
+      }
     } else {
+      vectorChannel = null;
       vectorField = null;
+      if (vectorDimension != -1) {
+        throw new RuntimeException("vectorDimension must be -1 when neither vectorDictionary nor vectorFilePath is used; got: " + vectorDimension);
+      }
     }
+
+    this.vectorDimension = vectorDimension;
+    
     titleDVSort = new Sort(KeywordField.newSortField("title", false, SortedSetSelector.Type.MIN));
     titleBDVSort = new Sort(new SortField("titleBDV", SortField.Type.STRING_VAL));
     monthDVSort = new Sort(KeywordField.newSortField("month", false, SortedSetSelector.Type.MIN));
     dayOfYearSort = new Sort(IntField.newSortField("dayOfYear", false, SortedNumericSelector.Type.MIN));
     lastModSort = new Sort(LongField.newSortField("lastMod", false, SortedNumericSelector.Type.MIN));
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (vectorChannel != null) {
+      vectorChannel.close();
+    }
   }
 
   private final static Pattern filterPattern = Pattern.compile(" \\+filter=([0-9\\.]+)%");
@@ -117,7 +160,7 @@ class TaskParser {
    * Second pass, parsing from UnparsedTask to some concrete tasks, like SearchTask
    * May not be called from the same parser that did the first pass
    */
-  public Task secondPassParse(UnparsedTask unparsedSearchTask) throws ParseException {
+  public Task secondPassParse(UnparsedTask unparsedSearchTask) throws ParseException, IOException {
     return new TaskBuilder(unparsedSearchTask).build();
   }
 
@@ -163,7 +206,7 @@ class TaskParser {
       origText = unparsedSearchTask.getOrigText();
     }
 
-    Task build() throws ParseException {
+    Task build() throws ParseException, IOException {
       if (category.equals("Respell")) {
         return new RespellTask(new Term(fieldName, origText));
       } else {
@@ -174,7 +217,7 @@ class TaskParser {
       }
     }
 
-    SearchTask buildSearchTask(String input) throws ParseException {
+    SearchTask buildSearchTask(String input) throws ParseException, IOException {
       text = input;
       Query filter = parseFilter();
       boolean isCountOnly = parseIsCountOnly();
@@ -330,7 +373,7 @@ class TaskParser {
         text = text.substring(0, i) + text.substring(j);
       }
       return facets;
-   }
+    }
 
     List<String> parseDrillDowns() {
       List<String> drillDowns = new ArrayList<>();
@@ -375,7 +418,7 @@ class TaskParser {
       }
     }
 
-    Query buildQuery(String type, String text, int minShouldMatch, List<FieldAndWeight> fieldAndWeights) throws ParseException {
+    Query buildQuery(String type, String text, int minShouldMatch, List<FieldAndWeight> fieldAndWeights) throws ParseException, IOException {
       Query query;
       switch(type) {
         case "ordered":
@@ -637,8 +680,23 @@ class TaskParser {
       return new DisjunctionMaxQuery(clauses, 0.1f);
     }
 
-    Query parseVectorQuery() {
-      return new KnnFloatVectorQuery(vectorField, vectorDictionary.computeTextVector(text), topN);
+    Query parseVectorQuery() throws IOException {
+      float[] vector;
+      if (vectorChannel != null) {
+        vector = new float[vectorDimension];
+        ByteBuffer buffer = ByteBuffer.allocate(vectorDimension * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        int n = vectorChannel.read(buffer);
+        if (n != vectorDimension * Float.BYTES) {
+          throw new RuntimeException("expected " + (vectorDimension * Float.BYTES) + " vector bytes but read " + n);
+        }
+        buffer.position(0);
+        buffer.asFloatBuffer().get(vector);
+      } else {
+        // search (well, task parsing) time inference from query text
+        vector = vectorDictionary.computeTextVector(text);
+      }
+      
+      return new KnnFloatVectorQuery(vectorField, vector, topN);
     }
   }
 }

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -450,6 +450,12 @@ class TaskParser implements Closeable {
       if (query.toString().equals("")) {
         throw new RuntimeException("query text \"" + text + "\" parsed to empty query");
       }
+      if (group != null && group.equals("groupblock1pass")) {
+        // confirm the index really indexed doc blocks for grouping to avoid scary confusing NPEs
+        if (state.groupBlocksExist == false) {
+          throw new IllegalStateException("cannot execute 'groupblock1pass': index was not built with grouping doc blocks");
+        }
+      }
 
       if (combinedFields != null) {
         CombinedFieldQuery.Builder cfqBuilder = new CombinedFieldQuery.Builder();

--- a/src/main/perf/TaskParserFactory.java
+++ b/src/main/perf/TaskParserFactory.java
@@ -19,6 +19,7 @@ package perf;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.classic.QueryParser;
 
+import java.nio.file.Path;
 import java.io.IOException;
 import java.util.Random;
 
@@ -33,6 +34,8 @@ public class TaskParserFactory {
     private final int topN;
     private final Random random;
     private final VectorDictionary vectorDictionary;
+    private final Path vectorFilePath;
+    private final int vectorDimension;
     private final boolean doStoredLoads;
 
     public TaskParserFactory(IndexState state,
@@ -42,6 +45,8 @@ public class TaskParserFactory {
                              int topN,
                              Random random,
                              VectorDictionary vectorDictionary,
+                             Path vectorFilePath,
+                             int vectorDimension,
                              boolean doStoredLoads) {
         this.indexState = state;
         this.field = field;
@@ -50,11 +55,13 @@ public class TaskParserFactory {
         this.topN = topN;
         this.random = random;
         this.vectorDictionary = vectorDictionary;
+        this.vectorFilePath = vectorFilePath;
+        this.vectorDimension = vectorDimension;
         this.doStoredLoads = doStoredLoads;
     }
 
     public TaskParser getTaskParser() throws IOException {
         QueryParser qp = new QueryParser(fieldForQueryParser, analyzer);
-        return new TaskParser(indexState, qp, field, topN, random, vectorDictionary, doStoredLoads);
+        return new TaskParser(indexState, qp, field, topN, random, vectorDictionary, vectorFilePath, vectorDimension, doStoredLoads);
     }
 }

--- a/src/main/perf/TaskThreads.java
+++ b/src/main/perf/TaskThreads.java
@@ -23,92 +23,92 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TaskThreads {  
 
-	private final Thread[] threads;
-	final CountDownLatch startLatch = new CountDownLatch(1);
-	final CountDownLatch stopLatch;
-	final AtomicBoolean stop;
+  private final Thread[] threads;
+  final CountDownLatch startLatch = new CountDownLatch(1);
+  final CountDownLatch stopLatch;
+  final AtomicBoolean stop;
 
-	public TaskThreads(TaskSource tasks, IndexState indexState, int numThreads, TaskParserFactory taskParserFactory) throws IOException {
-		threads = new Thread[numThreads];
-		stopLatch = new CountDownLatch(numThreads);
-		stop = new AtomicBoolean(false);
-		for(int threadIDX=0;threadIDX<numThreads;threadIDX++) {
-			threads[threadIDX] = new TaskThread(startLatch, stopLatch, stop, tasks, indexState, threadIDX, taskParserFactory.getTaskParser());
-			threads[threadIDX].start();
-		}
-	}
+  public TaskThreads(TaskSource tasks, IndexState indexState, int numConcurrentQueries, TaskParserFactory taskParserFactory) throws IOException {
+    threads = new Thread[numConcurrentQueries];
+    stopLatch = new CountDownLatch(numConcurrentQueries);
+    stop = new AtomicBoolean(false);
+    for(int threadIDX=0;threadIDX<numConcurrentQueries;threadIDX++) {
+      threads[threadIDX] = new TaskThread(startLatch, stopLatch, stop, tasks, indexState, threadIDX, taskParserFactory.getTaskParser());
+      threads[threadIDX].start();
+    }
+  }
 
-	public void start() {
-		startLatch.countDown();
-	}
+  public void start() {
+    startLatch.countDown();
+  }
 
-	public void finish() throws InterruptedException {
-		stopLatch.await();
-	}
+  public void finish() throws InterruptedException {
+    stopLatch.await();
+  }
 
-	public void stop() throws InterruptedException {
-		stop.getAndSet(true);
-		for (Thread t : threads) {
-			t.join();
-		}
-	}
+  public void stop() throws InterruptedException {
+    stop.getAndSet(true);
+    for (Thread t : threads) {
+      t.join();
+    }
+  }
 
-	private static class TaskThread extends Thread {
-		private final CountDownLatch startLatch;
-		private final CountDownLatch stopLatch;
-		private final AtomicBoolean stop;
-		private final TaskSource tasks;
-		private final IndexState indexState;
-		private final int threadID;
-		private final TaskParser taskParser;
+  private static class TaskThread extends Thread {
+    private final CountDownLatch startLatch;
+    private final CountDownLatch stopLatch;
+    private final AtomicBoolean stop;
+    private final TaskSource tasks;
+    private final IndexState indexState;
+    private final int threadID;
+    private final TaskParser taskParser;
 
-		public TaskThread(CountDownLatch startLatch, CountDownLatch stopLatch, AtomicBoolean stop, TaskSource tasks,
-						  IndexState indexState, int threadID, TaskParser taskParser) {
-			this.startLatch = startLatch;
-			this.stopLatch = stopLatch;
-			this.stop = stop;
-			this.tasks = tasks;
-			this.indexState = indexState;
-			this.threadID = threadID;
-			this.taskParser = taskParser;
-		}
+    public TaskThread(CountDownLatch startLatch, CountDownLatch stopLatch, AtomicBoolean stop, TaskSource tasks,
+                      IndexState indexState, int threadID, TaskParser taskParser) {
+      this.startLatch = startLatch;
+      this.stopLatch = stopLatch;
+      this.stop = stop;
+      this.tasks = tasks;
+      this.indexState = indexState;
+      this.threadID = threadID;
+      this.taskParser = taskParser;
+    }
 
-		@Override
-		public void run() {
-			try {
-				startLatch.await();
-			} catch (InterruptedException ie) {
-				Thread.currentThread().interrupt();
-				return;
-			}
+    @Override
+    public void run() {
+      try {
+        startLatch.await();
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        return;
+      }
 
-			try {
-				while (!stop.get()) {
-					final Task task = tasks.nextTask();
-					if (task == null) {
-						// Done
-						break;
-					}
-					final long t0 = System.nanoTime();
-					try {
-						task.go(indexState, taskParser);
-					} catch (IOException ioe) {
-						throw new RuntimeException(ioe);
-					}
-					try {
-						tasks.taskDone(task, t0-task.recvTimeNS, task.totalHitCount);
-					} catch (Exception e) {
-						System.out.println(Thread.currentThread().getName() + ": ignoring exc:");
-						e.printStackTrace();
-					}
-					task.runTimeNanos = System.nanoTime()-t0;
-					task.threadID = threadID;
-				}
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			} finally {
-				stopLatch.countDown();
-			}
-		}
-	}
+      try {
+        while (!stop.get()) {
+          final Task task = tasks.nextTask();
+          if (task == null) {
+            // Done
+            break;
+          }
+          final long t0 = System.nanoTime();
+          try {
+            task.go(indexState, taskParser);
+          } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+          }
+          try {
+            tasks.taskDone(task, t0-task.recvTimeNS, task.totalHitCount);
+          } catch (Exception e) {
+            System.out.println(Thread.currentThread().getName() + ": ignoring exc:");
+            e.printStackTrace();
+          }
+          task.runTimeNanos = System.nanoTime()-t0;
+          task.threadID = threadID;
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      } finally {
+        stopLatch.countDown();
+      }
+    }
+  }
 }

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1155,7 +1155,7 @@ class RunAlgs:
 
     w('-analyzer', c.analyzer)
     w('-taskSource', c.tasksFile)
-    w('-searchThreadCount', c.numThreads)
+    w('-numConcurrentQueries', c.numConcurrentQueries)
     w('-taskRepeatCount', c.competition.taskRepeatCount)
     w('-field', 'body')
     w('-tasksPerCat', c.competition.taskCountPerCat)

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1005,17 +1005,23 @@ class RunAlgs:
     
     for mode in 'cpu', 'heap':
       for stackSize in profilerStackSize:
-        result = subprocess.run(index.javaCommand.split(' ') +
+        profileCommand = index.javaCommand.split(' ') + \
                                 ['-cp',
-                                 f'{checkoutToPath(index.checkout)}/buildSrc/build/classes/java/main',
+                                 f'{checkoutToPath(index.checkout)}/build-tools/build-infra/build/classes/java/main',
                                  f'-Dtests.profile.mode={mode}',
                                  f'-Dtests.profile.count={profilerCount}',
                                  f'-Dtests.profile.stacksize={stackSize}',
                                  'org.apache.lucene.gradle.ProfileResults',
-                                 jfrOutput],
-                                stdout = subprocess.PIPE,
-                                stderr = subprocess.STDOUT,
-                                check = True)
+                                 jfrOutput]
+        print(f'profile command: {profileCommand}')
+        try:
+          result = subprocess.run(profileCommand,
+                                  stdout = subprocess.PIPE,
+                                  stderr = subprocess.STDOUT,
+                                  check = True)
+        except subprocess.CalledProcessError as e:
+          print(f'command failed:\n  stderr:\n{e.stderr}\n  stdout:\n{e.stdout}')
+          raise
         output = f'\nProfiler for {mode}:\n{result.stdout.decode("utf-8")}'
         print(output)
         profilerResults.append((mode, stackSize, output))

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1179,6 +1179,9 @@ class RunAlgs:
       w('-loadStoredFields')
     if c.vectorDict:
       w('-vectorDict', c.vectorDict)
+    elif c.vectorFileName is not None:
+      w('-vectorFile', c.vectorFileName)
+      w('-vectorDimension', c.vectorDimension)
     if c.vectorScale:
       w('-vectorScale', c.vectorScale)
     if c.exitable:

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -332,7 +332,7 @@ class Competitor(object):
 
       command = constants.JAVA_COMMAND.split(' ') + \
         ['-cp',
-         f'{benchUtil.checkoutToPath(index.checkout)}/build-tools/build-infra/build/classes/java/main',
+         f'{benchUtil.checkoutToPath(self.checkout)}/build-tools/build-infra/build/classes/java/main',
          f'-Dtests.profile.mode={mode}',
          f'-Dtests.profile.stacksize={size}',
          f'-Dtests.profile.count={count}',

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -211,6 +211,8 @@ class Index(object):
     self.indexSort = indexSort
     self.vectorFile = vectorFile
     self.vectorDimension = vectorDimension
+    if vectorEncoding not in ('FLOAT32', 'BYTE'):
+      raise RuntimeError(f'vectorEncoding must be FLOAT32 or BYTE; got: {vectorEncoding}')
     self.vectorEncoding = vectorEncoding
     self.mergeFactor = 10
     if SEGS_PER_LEVEL >= self.mergeFactor:
@@ -287,8 +289,10 @@ class Competitor(object):
                printHeap = False,
                hiliteImpl = 'FastVectorHighlighter',
                pk = True,
-               vectorDict = None,
-               vectorScale = None,
+               vectorDict = None,     # query time vectors
+               vectorFileName = None, # query time vectors
+               vectorDimension = -1,  # query time vectors
+               vectorScale = None,    # query time vectors
                loadStoredFields = False,
                exitable = False,
                searchConcurrency = 0,
@@ -312,7 +316,15 @@ class Competitor(object):
     self.pk = pk
     self.loadStoredFields = loadStoredFields
     self.exitable = exitable
+    if vectorDict is not None and vectorFileName is not None:
+      raise RuntimeError('specify either vectorDict or vectorFileName, not both')
+    if vectorFileName is not None and vectorDimension < 1:
+      raise RuntimeError(f'with vectorFileNamee you must specific vectorDimension > 0 (got: {vectorDimension})')
+    if vectorDict is not None and vectorDimension != -1:
+      raise RuntimeError(f'with vectorDict, vectorDimension should be -1 (got: {vectorDimension})')
     self.vectorDict = vectorDict
+    self.vectorFileName = vectorFileName
+    self.vectorDimension = vectorDimension
     self.vectorScale = vectorScale
     self.javacCommand = javacCommand
 

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -332,19 +332,24 @@ class Competitor(object):
 
       command = constants.JAVA_COMMAND.split(' ') + \
         ['-cp',
-         f'{benchUtil.checkoutToPath(self.checkout)}/buildSrc/build/classes/java/main',
+         f'{benchUtil.checkoutToPath(index.checkout)}/build-tools/build-infra/build/classes/java/main',
          f'-Dtests.profile.mode={mode}',
          f'-Dtests.profile.stacksize={size}',
          f'-Dtests.profile.count={count}',
          'org.apache.lucene.gradle.ProfileResults'] + \
          glob.glob(f'{constants.LOGS_DIR}/bench-search-{id}-{self.name}-*.jfr')
 
-      # print(f'JFR aggregation command: {" ".join(command)}')
+      print(f'JFR aggregation command: {" ".join(command)}')
       t0 = time.time()
-      result = subprocess.run(command,
-                              stdout = subprocess.PIPE,
-                              stderr = subprocess.STDOUT,
-                              check = True)
+      try:
+        result = subprocess.run(command,
+                                stdout = subprocess.PIPE,
+                                stderr = subprocess.STDOUT,
+                                check = True)
+      except subprocess.CalledProcessError as e:
+        print(f'command failed:\n  stderr:\n{e.stderr}\n  stdout:\n{e.stdout}')
+        raise
+        
       t1 = time.time()
       print(f'Took {t1-t0:.2f} seconds')
       results.append((size, result.stdout.decode('utf-8')))

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import multiprocessing
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -109,7 +110,10 @@ else:
 
 JRE_SUPPORTS_SERVER_MODE = True
 INDEX_NUM_THREADS = 1
-SEARCH_NUM_THREADS = 2
+
+# when testing natural query latency we do not want to saturate CPU:
+SEARCH_NUM_CONCURRENT_QUERIES = max(2, int(multiprocessing.cpu_count()/3))
+
 # geonames: http://download.geonames.org/export/dump/
 
 REPRO_COMMAND_START = 'python -u %s/repeatLuceneTest.py -once -verbose -nolog' % BENCH_BASE_DIR

--- a/src/python/example.py
+++ b/src/python/example.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
                                    description='Run a local benchmark on provided source dataset.')
   parser.add_argument('-s', '-source', '--source',
                       help='Data source to run the benchmark on.')
-  parser.add_argument('-searchConcurrency', '--searchConcurrency', default='-1',
+  parser.add_argument('-searchConcurrency', '--searchConcurrency', default='-1', type=int,
                       help='Search concurrency, 0 for disabled, -1 for using all cores')
   parser.add_argument('-b', '--baseline', default='lucene_baseline',
                       help='Path to lucene repo to be used for baseline')
@@ -37,10 +37,13 @@ if __name__ == '__main__':
   print('Running benchmarks with the following args: %s' % args)
 
   sourceData = competition.sourceData(args.source)
-  comp =  competition.Competition()
+  countsAreCorrect = args.searchConcurrency != 0
+  comp =  competition.Competition(verifyCounts = not countsAreCorrect)
 
   index = comp.newIndex(args.baseline, sourceData,
                         addDVFields = True,
+                        useCMS = True,
+                        mergePolicy = 'TieredMergePolicy',
                         facets = (('taxonomy:Date', 'Date'),
                                   ('taxonomy:Month', 'Month'),
                                   ('taxonomy:DayOfYear', 'DayOfYear'),

--- a/src/python/infer_token_vectors_cohere.py
+++ b/src/python/infer_token_vectors_cohere.py
@@ -32,16 +32,6 @@ print(f'features: {ds.features}')
 print(f"total number of rows: {len(ds)}")
 print(f"embeddings dims: {len(ds[0]['emb'])}")
 
-# ds = ds[:num_docs]
-
-if False:
-  # we just want the vector embeddings:
-  for feature_name in ds.features.keys():
-    if feature_name != 'emb':
-      ds = ds.remove_columns(feature_name)
-
-  ds = ds.cast(datasets.Features({'emb': datasets.Sequence(feature=datasets.Value("float32"))}))
-
 # do this in windows, else the RAM usage is crazy (OOME even with 256
 # GB RAM since I think this step makes 2X copy of the dataset?)
 doc_upto = 0
@@ -50,22 +40,22 @@ while doc_upto < num_docs:
   next_doc_upto = min(doc_upto + window_num_docs, num_docs)
   ds_embs = ds[doc_upto:next_doc_upto]['emb']
   embs = np.array(ds_embs, dtype=np.single)
-  print(f"saving docs[{doc_upto}:{next_doc_upto} of shape: {embs.shape} to file")
+  print(f"saving docs[{doc_upto}:{next_doc_upto}] of shape: {embs.shape} to file")
   with open(filename, "ab") as out_f:
       embs.tofile(out_f)
   doc_upto = next_doc_upto
 
 ds_embs_queries = ds[num_docs : num_docs + num_queries]['emb']
-embs_queries = np.array(ds_embs_queries)
+embs_queries = np.array(ds_embs_queries, dtype=np.single)
 print(f"saving queries of shape: {embs_queries.shape} to file")
 with open(filename_queries, "w") as out_f_queries:
     embs_queries.tofile(out_f_queries)
 
 ### check saved datasets
-embs_docs = np.fromfile(filename, dtype=np.float64)
+embs_docs = np.fromfile(filename, dtype=np.float32)
 embs_docs = embs_docs.reshape(num_docs, dims)
 print(f"reading docs of shape: {embs_docs.shape}")
 
-embs_queries = np.fromfile(filename_queries, dtype=np.float64)
+embs_queries = np.fromfile(filename_queries, dtype=np.float32)
 embs_queries = embs_queries.reshape(num_queries, dims)
 print(f"reading queries shape: {embs_queries.shape}")


### PR DESCRIPTION
I added command-line options to Indexer and SearchPerfTest to take `.vec` file and dimension and index/search precomputed vectors e.g. as produced by the `infer_token_vectors_cohere.py`.  I've also successfully run that tool to create the `.vec` files (I'll upload these to `home.apache.org` soon).

I'm currently trying to run a simple A/A benchmark that indexes and searches these vectors (test the end-to-end path of these changes) and if that works well, once we get this merged, I'll turn these on in nightlies ...

I'm not sure what to expect about these Cohere vectors vs the vectors the nightlies now use.  How exactly are they different?