### PR TITLE
Provide a default value for searchConcurrency in example.py

### DIFF
--- a/src/python/example.py
+++ b/src/python/example.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
                                    description='Run a local benchmark on provided source dataset.')
   parser.add_argument('-s', '-source', '--source',
                       help='Data source to run the benchmark on.')
-  parser.add_argument('-searchConcurrency', '--searchConcurrency',
+  parser.add_argument('-searchConcurrency', '--searchConcurrency', default='-1',
                       help='Search concurrency, 0 for disabled, -1 for using all cores')
   parser.add_argument('-b', '--baseline', default='lucene_baseline',
                       help='Path to lucene repo to be used for baseline')


### PR DESCRIPTION
After #271 we now see a `NumberFormatException` if `-searchConcurrency` isn't specified when running benchmarks through `localrun.py`. This proposes specifying `-1` as a default value.