### PR TITLE
Improve vector-test run options using arg parse and env vars

### DIFF
--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-import multiprocessing
-
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -17,10 +15,15 @@ import multiprocessing
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import multiprocessing
+import os
+
+from localconstants import *
+
+
 # NOTE: you must have a localconstants.py that, minimally, defines
 # BASE_DIR; all your checkouts should be under BASE_DIR, ie
 # BASE_DIR/aaa BASE_DIR/bbb etc.
-from localconstants import *
 
 if 'BENCH_BASE_DIR' not in globals():
   BENCH_BASE_DIR = '%s/util' % BASE_DIR
@@ -99,10 +102,15 @@ INDEX_DIR_BASE = '%s/indices' % BASE_DIR
 
 GIT_EXE = 'git'
 
+# configure java executables
+JAVA_HOME = os.environ.get('JAVA_HOME')
+java_bin = JAVA_HOME + '/bin/' if JAVA_HOME else ''
+if java_bin:
+  print('Using java from: %s' % java_bin)
 if 'JAVA_EXE' not in globals():
-  JAVA_EXE = 'java'
+  JAVA_EXE = '{}java'.format(java_bin)
 if 'JAVAC_EXE' not in globals():
-  JAVAC_EXE = 'javac'
+  JAVAC_EXE = '{}javac'.format(java_bin)
 if 'JAVA_COMMAND' not in globals():
   JAVA_COMMAND = '%s -server -Xms2g -Xmx2g --add-modules jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC' % JAVA_EXE
 else:

--- a/src/python/example.py
+++ b/src/python/example.py
@@ -17,6 +17,7 @@
 
 import argparse
 import competition
+import os
 
 # simple example that runs benchmark with WIKI_MEDIUM source and taks files 
 # Baseline here is ../lucene_baseline versus ../lucene_candidate
@@ -27,9 +28,9 @@ if __name__ == '__main__':
                       help='Data source to run the benchmark on.')
   parser.add_argument('-searchConcurrency', '--searchConcurrency', default='-1', type=int,
                       help='Search concurrency, 0 for disabled, -1 for using all cores')
-  parser.add_argument('-b', '--baseline', default='lucene_baseline',
+  parser.add_argument('-b', '--baseline', default=os.environ.get('BASELINE') or 'lucene_baseline',
                       help='Path to lucene repo to be used for baseline')
-  parser.add_argument('-c', '--candidate', default='lucene_candidate',
+  parser.add_argument('-c', '--candidate', default=os.environ.get('CANDIDATE') or 'lucene_candidate',
                       help='Path to lucene repo to be used for candidate')
   parser.add_argument('-r', '--reindex', action='store_true',
                       help='Reindex data for candidate run')

--- a/src/python/vector-test.py
+++ b/src/python/vector-test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -15,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import competition
 import sys
 import constants
@@ -34,36 +36,43 @@ MPNET_VECTOR_DOCS_FILE = '%s/data/enwiki-20120502-lines-1k-mpnet.vec' % constant
 # simple example that runs benchmark with WIKI_MEDIUM source and task files 
 # Baseline here is ../lucene_baseline versus ../lucene_candidate
 if __name__ == '__main__':
+  # TODO: Move to competition.DATA ?
   #sourceData = Data('wikivector1m-minilm', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 1000000, constants.WIKI_VECTOR_TASKS_FILE)
   #sourceData = competition.Data('wikivector1m-mpnet', constants.WIKI_MEDIUM_DOCS_LINE_FILE, 1000000, constants.WIKI_VECTOR_TASKS_FILE)
-  sourceData = competition.sourceData('wikivector1m')
-  #sourceData = competition.sourceData('wikivector10k')
-  #sourceData = competition.sourceData('wikimedium10k')
   comp =  competition.Competition(taskCountPerCat=20)
 
   #(vectorFile, vectorDimension, vectorDict) = (GLOVE_VECTOR_DOCS_FILE, 300, GLOVE_WORD_VECTORS_FILE)
   #(vectorFile, vectorDimension, vectorDict) = (MINILM_VECTOR_DOCS_FILE, 384, (MINILM_WORD_TOK_FILE, MINILM_WORD_VEC_FILE, 384))
   (vectorFile, vectorDimension, vectorDict) = (MPNET_VECTOR_DOCS_FILE, 768, (MPNET_WORD_TOK_FILE, MPNET_WORD_VEC_FILE, 768))
 
-  index = comp.newIndex('baseline', sourceData,
+  parser = argparse.ArgumentParser(prog='Local Vector Benchmark Run',
+                                   description='Run a local vector test benchmark on provided source dataset.')
+  parser.add_argument('-s', '-source', '--source', default='wikivector1m',
+                      help='Data source to run the benchmark on.')
+  parser.add_argument('-searchConcurrency', '--searchConcurrency', default='0', type=int,
+                      help='Search concurrency, 0 for disabled, -1 for using all cores')
+  parser.add_argument('-b', '--baseline', default=os.environ.get('BASELINE') or 'lucene_baseline',
+                      help='Path to lucene repo to be used for baseline')
+  parser.add_argument('-c', '--candidate', default=os.environ.get('CANDIDATE') or 'lucene_candidate',
+                      help='Path to lucene repo to be used for candidate')
+  # parser.add_argument('-r', '--reindex', action='store_true',
+  #                     help='Reindex data for candidate run')
+  args = parser.parse_args()
+  print('Running vector-test benchmarks with the following args: %s' % args)
+
+  sourceData = competition.sourceData(args.source)
+  index = comp.newIndex(args.baseline, sourceData,
                         vectorFile=vectorFile,
                         vectorDimension=vectorDimension,
                         vectorEncoding='FLOAT32')
 
-  #Warning -- Do not break the order of arguments
-  #TODO -- Fix the following by using argparser
-  if len(sys.argv) > 3 and sys.argv[3] == '-concurrentSearches':
-    concurrentSearches = True
-  else:
-    concurrentSearches = False
-
   # create a competitor named baseline with sources in the ../trunk folder
-  comp.competitor('baseline', 'baseline',
+  comp.competitor('baseline', args.baseline,
                   vectorDict=vectorDict,
-                  index = index, concurrentSearches = concurrentSearches)
+                  index = index, searchConcurrency = args.searchConcurrency)
 
   # use a different index 
-  # index = comp.newIndex('candidate', sourceData,
+  # index = comp.newIndex(args.candidate, sourceData,
   #                       vectorFile=constants.GLOVE_VECTOR_DOCS_FILE,
   #                       vectorDimension=100,
   #                       vectorEncoding='FLOAT32',
@@ -78,10 +87,10 @@ if __name__ == '__main__':
   JAVA_EXE = '/usr/lib/jvm/jdk-20.0.1/bin/java'
   JAVA_COMMAND = '%s -server -Xms2g -Xmx2g --add-modules jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC' % JAVA_EXE
 
-  comp.competitor('candidate', 'candidate',
+  comp.competitor('candidate', args.candidate,
                   javaCommand=JAVA_COMMAND,
                   vectorDict=vectorDict,
-                  index = index, concurrentSearches = concurrentSearches)
+                  index = index, searchConcurrency = args.searchConcurrency)
 
   # start the benchmark - this can take long depending on your index and machines
   comp.benchmark("baseline_vs_candidate")


### PR DESCRIPTION
Changes to make it easier to run `vector-test.py` for knn benchmarks. Includes the following:
1. Picks `java` exec path from `$JAVA_HOME` if configured.
2. Uses `argparse` for `vector-test.py` configurations
3. Allows setting `baseline` and `candidate` repository locations via env variables.

__

```bash
% python src/python/vector-test.py -h
Using java from: /home/vigyas/openjdk/jdk-22/bin/
WARNING: Gnuplot module not present; will not make charts
no perf executable; will not collect aggregate CPU profiling data
usage: Local Vector Benchmark Run [-h] [-s SOURCE] [-searchConcurrency SEARCHCONCURRENCY] [-b BASELINE] [-c CANDIDATE]

Run a local vector test benchmark on provided source dataset.

options:
  -h, --help            show this help message and exit
  -s SOURCE, -source SOURCE, --source SOURCE
                        Data source to run the benchmark on.
  -searchConcurrency SEARCHCONCURRENCY, --searchConcurrency SEARCHCONCURRENCY
                        Search concurrency, 0 for disabled, -1 for using all cores
  -b BASELINE, --baseline BASELINE
                        Path to lucene repo to be used for baseline
  -c CANDIDATE, --candidate CANDIDATE
                        Path to lucene repo to be used for candidate

```

.
I think the README can also use more details on how to configure and run a knn benchmark. I'll raise a separate PR for it, as it needs some orthogonal refactoring.