### PR TITLE
Fix bug in generating QPS diff chart

### DIFF
--- a/src/python/QPSChart.py
+++ b/src/python/QPSChart.py
@@ -43,7 +43,7 @@ class QPSChart:
   def __init__(self, data, fileOut):
     self.maxQPS = -math.inf
     for tup in data:
-      self.maxQPS = max(self.maxQPS, data[2], data[4])
+      self.maxQPS = max(self.maxQPS, tup[2], tup[4])
 
     if self.maxQPS > 100:
       qpsInc = 20


### PR DESCRIPTION
Minor bug fix in comparing tuple values within an array. 

Fixes exception:
```python
WARNING: failed to generate QPS diff chart chartData=[('LowTermVector', 222.18008690965422, 230.1825676551332, 204.2715128301673, 234.3230073144681, 0.04771273811822019), ('Med
TermVector', 236.89980286169003, 246.16356758844938, 217.39604810565294, 252.6236556383957, 0.10927867133559532), ('AndHighLowVector', 203.28180349595337, 210.37278966183842, 189.33638831630697, 213.65397665540257, 0.05972814797216097), ('HighTermVector', 212.3340958310362, 219.9530466061183, 197.4996169350486, 225.19411984655903, 0.13526436593711066
), ('AndHighHighVector', 182.4618977509103, 189.22062876057603, 170.19781709851654, 194.3188476521071, 0.20078875662911377), ('AndHighMedVector', 201.97941896307853, 210.327913
30775328, 189.13832935657194, 215.92225042497438, 0.24801619028627686), ('PKLookup', 270.73481227220896, 294.58028922116773, 254.4056016326068, 305.23949519148283, 0.6515543657
100913)]; skipping
Traceback (most recent call last):
  File "/local/home/vigyas/lucene_bench/util/src/python/benchUtil.py", line 1571, in simpleReport
    QPSChart.QPSChart(chartData, 'out.png')
  File "/local/home/vigyas/lucene_bench/util/src/python/QPSChart.py", line 46, in __init__
    self.maxQPS = max(self.maxQPS, data[2], data[4])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'tuple' and 'float'
```