### PR TITLE
Various byte vector benchmark fixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -20,7 +20,7 @@
 
     <javac srcdir="src/main"
            destdir="build"
-           includes="knn/KnnGraphTester.java,WikiVectors.java,perf/VectorDictionary.java"
+           includes="knn/*.java,WikiVectors.java,perf/VectorDictionary.java"
            classpathref="build.classpath"
            includeantruntime="false"/>
 

--- a/src/main/knn/VectorReader.java
+++ b/src/main/knn/VectorReader.java
@@ -48,7 +48,8 @@ public abstract class VectorReader {
   }
 
   protected final void readNext() throws IOException {
-    if (this.input.read(bytes) < target.length) {
+    int bytesRead = this.input.read(bytes);
+    if (bytesRead < bytes.capacity()) {
       this.input.position(0);
       this.input.read(bytes);
     }

--- a/src/main/knn/VectorReaderByte.java
+++ b/src/main/knn/VectorReaderByte.java
@@ -21,26 +21,22 @@ import java.io.IOException;
 import java.nio.channels.FileChannel;
 
 public class VectorReaderByte extends VectorReader {
-  private final byte[] scratch;
 
   VectorReaderByte(FileChannel input, int dim, int bufferSize) {
     super(input, dim, bufferSize);
-    scratch = new byte[dim];
   }
 
   @Override
   float[] next() throws IOException {
     readNext();
-    bytes.get(scratch);
-    for (int i = 0; i < scratch.length; i++) {
-      target[i] = scratch[i];
+    for (int i = 0; i < bytes.array().length; i++) {
+      target[i] = bytes.array()[i];
     }
     return target;
   }
 
   byte[] nextBytes() throws IOException {
     readNext();
-    bytes.get(scratch);
-    return scratch;
+    return bytes.array();
   }
 }

--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -44,7 +44,7 @@ VALUES = {
     #'fanout': (20, 100, 250)
     'fanout': (20,),
     #'quantize': None,
-    'quantizeBits': (32, 4, 7, 8),
+    'quantizeBits': (4, 7, 8),
     'numMergeWorker': (12,),
     'numMergeThread': (4,),
     'encoding': ('float32',),
@@ -76,7 +76,6 @@ def run_knn_benchmark(checkout, values):
     dim = 768
     doc_vectors = '%s/data/enwiki-20120502-lines-1k-mpnet.vec' % constants.BASE_DIR
     query_vectors = '%s/luceneutil/tasks/vector-task-mpnet.vec' % constants.BASE_DIR
-    query_vectors = doc_vectors
     #dim = 384
     #doc_vectors = '%s/data/enwiki-20120502-lines-1k-minilm.vec' % constants.BASE_DIR
     #query_vectors = '%s/luceneutil/tasks/vector-task-minilm.vec' % constants.BASE_DIR


### PR DESCRIPTION
While benchmarking already quantized or `byte` vectors, I ran into various bugs. 

This pr fixes them.

 - Corrects true nearest-neighbor calculation to use the `byte` comparator as our score transformations are different between bytes and floats
 - Adds a knn byte query (previous we always tried a float query, which would just break)
 - Fixed another weird vector reader bug which would always read just the first vector as calling `bytes.get` resets the bytes read.