### PR TITLE
Run search tasks in IndexSearcher's executor.

### DIFF
--- a/src/main/perf/IndexState.java
+++ b/src/main/perf/IndexState.java
@@ -22,6 +22,8 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.facet.FacetsConfig;
@@ -46,6 +48,7 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 
 class IndexState {
+  public final ExecutorService executor;
   public final ReferenceManager<IndexSearcher> mgr;
   public final DirectSpellChecker spellChecker;
   public final Query groupEndQuery;
@@ -63,8 +66,9 @@ class IndexState {
   public final Map<Object, ThreadLocal<PointsPKLookupState>> pointsPKLookupStates = new HashMap<>();
   public final Map<Object, ThreadLocal<PKLookupWithTermStateState>> pkLookupWithTermStateStates = new HashMap<>();
 
-  public IndexState(ReferenceManager<IndexSearcher> mgr, TaxonomyReader taxoReader, String textFieldName, DirectSpellChecker spellChecker,
-                    String hiliteImpl, FacetsConfig facetsConfig, Map<String,Integer> facetFields) throws IOException {
+  public IndexState(ExecutorService executor, ReferenceManager<IndexSearcher> mgr, TaxonomyReader taxoReader, String textFieldName,
+                    DirectSpellChecker spellChecker, String hiliteImpl, FacetsConfig facetsConfig, Map<String,Integer> facetFields) throws IOException {
+    this.executor = executor;
     this.mgr = mgr;
     this.spellChecker = spellChecker;
     this.textFieldName = textFieldName;

--- a/src/main/perf/NRTPerfTest.java
+++ b/src/main/perf/NRTPerfTest.java
@@ -373,7 +373,7 @@ public class NRTPerfTest {
     }
 
     final DirectSpellChecker spellChecker = new DirectSpellChecker();
-    final IndexState indexState = new IndexState(manager, null, field, spellChecker, "FastVectorHighlighter", null, null);
+    final IndexState indexState = new IndexState(null, manager, null, field, spellChecker, "FastVectorHighlighter", null, null);
     TaskParserFactory taskParserFactory =
       new TaskParserFactory(indexState, field, analyzer, field, 10, random, null, null, -1, true);
     final TaskSource tasks = new RandomTaskSource(tasksFile, random, taskParserFactory.getTaskParser()) {

--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -573,7 +573,7 @@ public class SearchPerfTest {
     final Random random = new Random(randomSeed);
 
     final DirectSpellChecker spellChecker = new DirectSpellChecker();
-    final IndexState indexState = new IndexState(mgr, taxoReader, fieldName, spellChecker, hiliteImpl, facetsConfig, facetDimMethods);
+    final IndexState indexState = new IndexState(executorService, mgr, taxoReader, fieldName, spellChecker, hiliteImpl, facetsConfig, facetDimMethods);
 
     VectorDictionary vectorDictionary;
     if (vectorDict != null) {


### PR DESCRIPTION
IndexSearcher was recently updated to make the calling thread contribute to search execution. This means that searching with an executor of 8 threads uses 9 threads in practice if `IndexSearcher#search` is called from outside of the executor. This change moves the `IndexSearcher#search` call to the executor to better honor luceneutil's `-searchConcurrency` parameter.