### PR TITLE
Migrate KnnGraphTester workflow to gradle, plus some misc upgrades and optimize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ build/
 work/
 .DS_Store
 node_modules/
+knnIndices/
 
 # emacs temporary files
 *~

--- a/README.md
+++ b/README.md
@@ -171,9 +171,8 @@ how to run it in its comments.
 
 By default we use 100/300 dimension vectors, to use higher dimension vectors (more than 384, check `highDimDataSets` in `gradle/knn.gradle`), you need to:
 
-1. set the model you need by editing `infer_token_vectors.py`, The supported models are listed there in comments. E.g. for 768 dimensions you need `enwiki-20120502-mpnet.vec` and `enwiki-20120502-mpnet.tok` as output file and you need to set the model to `model = SentenceTransformer('all-mpnet-base-v2')` by edit `infer_token_vectors.py` (which is already the default).
-2. run `./gradlew vectors-mpnet` or `./gradlew vectors-minilm` depend on your needs (this step will run `infer_token_vectors.py` for you, and then generate task and document vectors)
-3. run `src/python/localrun.py` (see instructions inside `src/python/vector-test.py`) or `src/python/knnPerTest.py` (see instructions inside the file) of your choice, 
+1. run `./gradlew vectors-mpnet` or `./gradlew vectors-minilm` depend on your needs (this step will run `infer_token_vectors.py` for you, and then generate task and document vectors)
+2. run `src/python/localrun.py` (see instructions inside `src/python/vector-test.py`) or `src/python/knnPerTest.py` (see instructions inside the file) of your choice, 
 
 To test vector search with [Cohere/wikipedia-22-12-en-embeddings](https://huggingface.co/datasets/Cohere/wikipedia-22-12-en-embeddings) dataset, you need to do:
 1. run `python src/python/infer_token_vectors_cohere.py ../data/cohere-wikipedia-768.vec 10000000 ../data/cohere-wikipedia-queries-768.vec 10000` to generate vectors

--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ how to run it in its comments.
 
 ## Testing with higher dimension vectors
 
-By default we use 100 dimension vectors, to use higher dimension vectors, you need to:
+By default we use 100/300 dimension vectors, to use higher dimension vectors (more than 384, check `highDimDataSets` in `gradle/knn.gradle`), you need to:
 
-1. run `src/python/infer_token_vectors.py` to get `xxx.vec` and `xxx.tok` file, also do not forget to set the model you need by editing `infer_token_vectors.py`, The supported models are listed there in comments. E.g. for 768 dimensions you need `enwiki-20120502-mpnet.vec` and `enwiki-20120502-mpnet.tok` as output file and you need to set the model to `model = SentenceTransformer('all-mpnet-base-v2')` by edit `infer_token_vectors.py` (which is already the default).
-2. run corresponding ant tasks to generate embeddings for docs and queries. E.g. for 768 dimensions you need to run `ant vectors-mpnet-docs` and `vectors-mpnet-tasks`.
+1. set the model you need by editing `infer_token_vectors.py`, The supported models are listed there in comments. E.g. for 768 dimensions you need `enwiki-20120502-mpnet.vec` and `enwiki-20120502-mpnet.tok` as output file and you need to set the model to `model = SentenceTransformer('all-mpnet-base-v2')` by edit `infer_token_vectors.py` (which is already the default).
+2. run `./gradlew vectors-mpnet` or `./gradlew vectors-minilm` depend on your needs (this step will run `infer_token_vectors.py` for you, and then generate task and document vectors)
 3. run `src/python/localrun.py` (see instructions inside `src/python/vector-test.py`) or `src/python/knnPerTest.py` (see instructions inside the file) of your choice, 
 
 To test vector search with [Cohere/wikipedia-22-12-en-embeddings](https://huggingface.co/datasets/Cohere/wikipedia-22-12-en-embeddings) dataset, you need to do:

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+apply from:"gradle/knn.gradle"
+
 def hasDefaults = rootProject.file("gradle.properties").exists()
 
 configure(rootProject) {
@@ -12,6 +14,7 @@ configure(rootProject) {
                 rootProject.file("gradle.properties").write("""
 # These settings have been generated automatically on the first run.
 external.lucene.repo=$parentDir
+lucene.version=10.0.0
 """, "UTF-8")
                 logger.log(LogLevel.WARN, "\nIMPORTANT. This is the first time you ran the build. " +
                         "I wrote some sane defaults (for this machine) to 'gradle.properties', " +
@@ -28,6 +31,14 @@ if (hasDefaults == false) {
             if (task != rootProject.localSettings) {
                 task.dependsOn rootProject.localSettings
             }
+        }
+    }
+}
+
+allprojects {
+    tasks.withType(Exec) {
+        doFirst {
+            println "cmd: $commandLine"
         }
     }
 }

--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,7 @@
 
   <property name="data.dir" value="${basedir}/../data"/>
   <property name="tasks.dir" value="${basedir}/tasks"/>
-  <property name="lucene.checkout" value="${basedir}/../lucene_baseline"/>
+  <property name="lucene.checkout" value="${basedir}/../candidate"/>
 
   <target name="build">
 

--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,7 @@
 
   <property name="data.dir" value="${basedir}/../data"/>
   <property name="tasks.dir" value="${basedir}/tasks"/>
-  <property name="lucene.checkout" value="${basedir}/../candidate"/>
+  <property name="lucene.checkout" value="${basedir}/../lucene_baseline"/>
 
   <target name="build">
 

--- a/gradle/knn.gradle
+++ b/gradle/knn.gradle
@@ -66,7 +66,8 @@ for (entry in baseDataSets) {
         dependsOn compileKnn
         dependsOn extractVectorTasks
 
-        classpath = luceneFT
+        classpath luceneFT
+        classpath buildDir
         mainClass = 'WikiVectors'
 
         args(attachQuantizeArgs(
@@ -81,7 +82,8 @@ for (entry in baseDataSets) {
     task "vector-${entry.key}-docVec" (type: JavaExec) {
         dependsOn compileKnn
 
-        classpath = luceneFT
+        classpath luceneFT
+        classpath buildDir
         mainClass = 'WikiVectors'
 
         args(attachQuantizeArgs(
@@ -120,7 +122,8 @@ for (entry in highDimDataSets) {
         dependsOn extractVectorTasks
         dependsOn "infer-vector-${entry.value.codename}"
 
-        classpath = luceneFT
+        classpath luceneFT
+        classpath buildDir
         mainClass = 'WikiVectors'
 
         args(attachQuantizeArgs(
@@ -137,7 +140,8 @@ for (entry in highDimDataSets) {
         dependsOn compileKnn
         dependsOn "infer-vector-${entry.value.codename}"
 
-        classpath = luceneFT
+        classpath luceneFT
+        classpath buildDir
         mainClass = 'WikiVectors'
 
         args(attachQuantizeArgs(

--- a/gradle/knn.gradle
+++ b/gradle/knn.gradle
@@ -15,9 +15,9 @@ def baseDataSets = [
         "300-8bit": new VectorDataSet("300d", "glove.6B.300d.txt", "300", "8bit"),
 ]
 def highDimDataSets = [
-        "minilm": new VectorDataSet("minilm", null, "384"),
+        "minilm": new VectorDataSet("minilm", "all-MiniLM-L6-v2", "384"),
         "minilm-8bit": new VectorDataSet("minilm", null, "384", "8bit"),
-        "mpnet": new VectorDataSet("mpnet", null, "768"),
+        "mpnet": new VectorDataSet("mpnet", "all-mpnet-base-v2", "768"),
         "mpnet-8bit": new VectorDataSet("mpnet", null, "768", "8bit")
 ]
 
@@ -94,23 +94,31 @@ for (entry in baseDataSets) {
 }
 
 for (entry in highDimDataSets) {
-    def tokFile = "enwiki-20120502.all-${entry.key}.tok"
-    def vecFile = "enwiki-20120502.all-${entry.key}.vec"
-    task "infer-vector-${entry.key}" (type: Exec) {
-        workingDir rootProject.getRootDir()
+    def tokFile = "enwiki-20120502-${entry.value.codename}.tok"
+    def vecFile = "enwiki-20120502-${entry.value.codename}.vec"
+    if (entry.value.quantized == false) {
+        // only define once
+        task "infer-vector-${entry.value.codename}" (type: Exec) {
+            workingDir rootProject.getRootDir()
 
-        commandLine('python3',
-                'src/python/infer_token_vectors.py',
-                "$dataDir/$textDocFileName",
-                "$dataDir/$tokFile",
-                "$dataDir/$vecFile"
-        )
+            commandLine('python3',
+                    'src/python/infer_token_vectors.py',
+                    "$dataDir/$textDocFileName",
+                    "$dataDir/$tokFile",
+                    "$dataDir/$vecFile",
+                    "${entry.value.dictFileName}"
+            )
+
+            onlyIf("the file has not been generated") {
+                (file("$dataDir/$tokFile").exists() == false) || (file("$dataDir/$vecFile").exists() == false)
+            }
+        }
     }
 
     task "vector-${entry.key}-taskVec" (type: JavaExec) {
         dependsOn compileKnn
         dependsOn extractVectorTasks
-        dependsOn "infer-vector-${entry.key}"
+        dependsOn "infer-vector-${entry.value.codename}"
 
         classpath = luceneFT
         mainClass = 'WikiVectors'
@@ -127,7 +135,7 @@ for (entry in highDimDataSets) {
 
     task "vector-${entry.key}-docVec" (type: JavaExec) {
         dependsOn compileKnn
-        dependsOn "infer-vector-${entry.key}"
+        dependsOn "infer-vector-${entry.value.codename}"
 
         classpath = luceneFT
         mainClass = 'WikiVectors'
@@ -175,7 +183,7 @@ task "vectors-mpnet" {
 
 class VectorDataSet {
     String codename
-    String dictFileName
+    String dictFileName // we use it as model name in high dimension vector data
     String taskVecFileName
     String docVecFileName
     String dimension

--- a/gradle/knn.gradle
+++ b/gradle/knn.gradle
@@ -1,0 +1,201 @@
+apply plugin: 'java'
+
+
+def srcDir = "${rootProject.getRootDir()}/src/main"
+def buildDir = "${rootProject.getRootDir()}/build"
+def taskDir = "${rootProject.getRootDir()}/tasks"
+def dataDir = "${rootProject.getRootDir()}/../data"
+def textDocFileName = "enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt"
+def copiedTaskName = "vector.task.txt"
+
+def baseDataSets = [
+        "100": new VectorDataSet("100d", "glove.6B.100d.txt", "100"),
+        "100-8bit": new VectorDataSet("100d", "glove.6B.100d.txt", "100", "8bit"),
+        "300": new VectorDataSet("300d", "glove.6B.300d.txt", "300"),
+        "300-8bit": new VectorDataSet("300d", "glove.6B.300d.txt", "300", "8bit"),
+]
+def highDimDataSets = [
+        "minilm": new VectorDataSet("minilm", null, "384"),
+        "minilm-8bit": new VectorDataSet("minilm", null, "384", "8bit"),
+        "mpnet": new VectorDataSet("mpnet", null, "768"),
+        "mpnet-8bit": new VectorDataSet("mpnet", null, "768", "8bit")
+]
+
+
+def luceneDir = (String) findProperty("external.lucene.repo") + '/lucene'
+def luceneVersion = (String) findProperty("lucene.version")
+def luceneFT = fileTree(dir: luceneDir, include: "**/*$luceneVersion-SNAPSHOT.jar")
+
+task compileKnn (type: JavaCompile) {
+    source = [srcDir]
+    include "knn/KnnGraphTester.java", "WikiVectors.java", "perf/VectorDictionary.java"
+    classpath = luceneFT
+    getDestinationDirectory().set(file(buildDir))
+    getOptions().sourcepath = files(srcDir)
+}
+
+task runKnnPerfTest (type: Exec) {
+    dependsOn compileKnn
+
+    workingDir rootProject.getRootDir()
+
+    commandLine 'python3', 'src/python/knnPerfTest.py'
+}
+
+task extractVectorTasks (type: Copy) {
+    from "$taskDir/vector.tasks"
+    into "$taskDir"
+    rename {
+        any -> copiedTaskName
+    }
+
+    filter {
+        line -> line.replaceAll(".*//(.*) # .*", '$1')
+    }
+}
+
+static def attachQuantizeArgs(quantized, argList) {
+    if (quantized) {
+        return ['-scale', '256'] + argList
+    }
+    return argList
+}
+
+for (entry in baseDataSets) {
+    task "vector-${entry.key}-taskVec" (type: JavaExec) {
+        dependsOn compileKnn
+        dependsOn extractVectorTasks
+
+        classpath = luceneFT
+        mainClass = 'WikiVectors'
+
+        args(attachQuantizeArgs(
+                entry.value.quantized,
+                ["$dataDir/${entry.value.dictFileName}",
+                 "$taskDir/$copiedTaskName",
+                 "$taskDir/${entry.value.taskVecFileName}"
+        ]))
+
+    }
+
+    task "vector-${entry.key}-docVec" (type: JavaExec) {
+        dependsOn compileKnn
+
+        classpath = luceneFT
+        mainClass = 'WikiVectors'
+
+        args(attachQuantizeArgs(
+                entry.value.quantized,
+                ["$dataDir/${entry.value.dictFileName}",
+                "$taskDir/$textDocFileName",
+                "$taskDir/${entry.value.docVecFileName}"
+        ]))
+    }
+}
+
+for (entry in highDimDataSets) {
+    def tokFile = "enwiki-20120502.all-${entry.key}.tok"
+    def vecFile = "enwiki-20120502.all-${entry.key}.vec"
+    task "infer-vector-${entry.key}" (type: Exec) {
+        workingDir rootProject.getRootDir()
+
+        commandLine('python3',
+                'src/python/infer_token_vectors.py',
+                "$dataDir/$textDocFileName",
+                "$dataDir/$tokFile",
+                "$dataDir/$vecFile"
+        )
+    }
+
+    task "vector-${entry.key}-taskVec" (type: JavaExec) {
+        dependsOn compileKnn
+        dependsOn extractVectorTasks
+        dependsOn "infer-vector-${entry.key}"
+
+        classpath = luceneFT
+        mainClass = 'WikiVectors'
+
+        args(attachQuantizeArgs(
+                entry.value.quantized,
+                ["$dataDir/$tokFile",
+                 "$dataDir/$vecFile",
+                 entry.value.dimension,
+                 "$taskDir/$copiedTaskName",
+                 "$taskDir/${entry.value.taskVecFileName}"
+        ]))
+    }
+
+    task "vector-${entry.key}-docVec" (type: JavaExec) {
+        dependsOn compileKnn
+        dependsOn "infer-vector-${entry.key}"
+
+        classpath = luceneFT
+        mainClass = 'WikiVectors'
+
+        args(attachQuantizeArgs(
+                entry.value.quantized,
+                ["$dataDir/$tokFile",
+                 "$dataDir/$vecFile",
+                 entry.value.dimension,
+                 "$taskDir/$textDocFileName",
+                 "$taskDir/${entry.value.docVecFileName}"
+                ]))
+    }
+}
+
+task "vectors-100" {
+    dependsOn "vector-100-taskVec"
+    dependsOn "vector-100-docVec"
+    dependsOn "vector-100-8bit-taskVec"
+    dependsOn "vector-100-8bit-docVec"
+}
+
+task "vectors-300" {
+    dependsOn "vector-300-taskVec"
+    dependsOn "vector-300-docVec"
+    dependsOn "vector-300-8bit-taskVec"
+    dependsOn "vector-300-8bit-docVec"
+}
+
+task "vectors-minilm" {
+    dependsOn "vector-minilm-taskVec"
+    dependsOn "vector-minilm-docVec"
+    dependsOn "vector-minilm-8bit-taskVec"
+    dependsOn "vector-minilm-8bit-docVec"
+}
+
+task "vectors-mpnet" {
+    dependsOn "vector-mpnet-taskVec"
+    dependsOn "vector-mpnet-docVec"
+    dependsOn "vector-mpnet-8bit-taskVec"
+    dependsOn "vector-mpnet-8bit-docVec"
+}
+
+
+
+class VectorDataSet {
+    String codename
+    String dictFileName
+    String taskVecFileName
+    String docVecFileName
+    String dimension
+    boolean quantized
+
+    VectorDataSet(codename, dictFileName, dimension) {
+        this.codename = codename
+        this.dictFileName = dictFileName
+        this.dimension = dimension
+        this.taskVecFileName = "vector-task-${codename}.vec"
+        this.docVecFileName = "enwiki-20120502-lines-1k-${codename}.vec"
+        this.quantized = false
+    }
+
+    VectorDataSet(codename, dictFileName, dimension, quantize) {
+        this.codename = codename
+        this.dictFileName = dictFileName
+        this.dimension = dimension
+        this.taskVecFileName = "vector-task-${codename}-${quantize}.vec"
+        this.docVecFileName = "enwiki-20120502-lines-1k-${codename}-${quantize}.vec"
+        this.quantized = true
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.
@@ -80,13 +80,11 @@ do
     esac
 done
 
-APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
-
-APP_NAME="Gradle"
+# This is normally unused
+# shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
-
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+# Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
+APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -133,22 +131,29 @@ location of your Java installation."
     fi
 else
     JAVACMD=java
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    if ! command -v java >/dev/null 2>&1
+    then
+        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
+    fi
 fi
 
 # Increase the maximum file descriptors if we can.
 if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
+        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
     case $MAX_FD in  #(
       '' | soft) :;; #(
       *)
+        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -193,11 +198,15 @@ if "$cygwin" || "$msys" ; then
     done
 fi
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -26,6 +26,7 @@ if "%OS%"=="Windows_NT" setlocal
 
 set DIRNAME=%~dp0
 if "%DIRNAME%"=="" set DIRNAME=.
+@rem This is normally unused
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
@@ -42,11 +43,11 @@ set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
 if %ERRORLEVEL% equ 0 goto execute
 
-echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -56,11 +57,11 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
-echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 

--- a/src/main/build.gradle
+++ b/src/main/build.gradle
@@ -7,8 +7,9 @@ sourceSets {
 }
 
 def luceneDir = (String) findProperty("external.lucene.repo") + '/lucene'
+def luceneVersion = (String) findProperty("lucene.version")
 
 dependencies {
-  implementation fileTree(dir: luceneDir, include: '**/*.jar')
+  implementation fileTree(dir: luceneDir, include: "**/*$luceneVersion-SNAPSHOT.jar")
 }
 

--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -103,6 +103,7 @@ public class KnnGraphTester {
 
   public static final String KNN_FIELD = "knn";
   public static final String ID_FIELD = "id";
+  private static final String INDEX_DIR = "knnIndices";
 
   private int numDocs;
   private int dim;
@@ -349,6 +350,7 @@ public class KnnGraphTester {
         0,
         quiet
       ).createIndex();
+      System.out.println("reindex takes " + reindexTimeMsec + " ms");
     }
     if (forceMerge) {
       forceMerge();
@@ -377,9 +379,10 @@ public class KnnGraphTester {
 
   private String formatIndexPath(Path docsPath) {
     if (quantize) {
-      return docsPath.getFileName() + "-" + maxConn + "-" + beamWidth + "-" + quantizeBits + (quantizeCompress ? "-compressed" : "" ) + ".index";
+      return INDEX_DIR + "/" + docsPath.getFileName() + "-" + maxConn + "-" + beamWidth + "-"
+              + quantizeBits + (quantizeCompress ? "-compressed" : "" ) + ".index";
     }
-    return docsPath.getFileName() + "-" + maxConn + "-" + beamWidth + ".index";
+    return INDEX_DIR + "/" + docsPath.getFileName() + "-" + maxConn + "-" + beamWidth + ".index";
   }
 
   @SuppressForbidden(reason = "Prints stuff")

--- a/src/python/common.py
+++ b/src/python/common.py
@@ -205,3 +205,6 @@ def getLuceneDirFromGradleProperties():
   except FileNotFoundError as e:
     print("gradle.properties not found, try run ./gradlew :localSettings")
     raise e
+
+  raise ValueError("Cannot find lucene repo, please define 'external.lucene.repo' in gradle.properties")
+

--- a/src/python/common.py
+++ b/src/python/common.py
@@ -192,3 +192,16 @@ def getLatestModTime(path, extension=None):
           modTime = max(os.path.getmtime(fullPath), modTime)
   return modTime
   
+def getLuceneDirFromGradleProperties():
+  try:
+    with open(os.path.join(constants.BENCH_BASE_DIR, "gradle.properties"), "r") as f:
+      for line in f:
+        if line.find("=") == -1:
+          continue
+
+        key, value = line.strip().split("=")
+        if key == "external.lucene.repo":
+          return value
+  except FileNotFoundError as e:
+    print("gradle.properties not found, try run ./gradlew :localSettings")
+    raise e

--- a/src/python/infer_token_vectors.py
+++ b/src/python/infer_token_vectors.py
@@ -13,17 +13,23 @@ EG:
 
 python src/python/infer_token_vectors.py ../data/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt \
     ../data/enwiki-20120502.all-MiniLM-L6-v2.tok \
-    ../data/enwiki-20120502.all-MiniLM-L6-v2.vec
+    ../data/enwiki-20120502.all-MiniLM-L6-v2.vec \
+    all-MiniLM-L6-v2
 
 
 Here we just get embeddings for single tokens out of context. This is kind of abusive use of
 sentence transformers which use sliding "attention" windows to take context into account, but
 for our performance-testing it seems adequate.
+
+known models: 
+all-MiniLM-L6-v2 -> 384 dimension
+all-mpnet-base-v2 -> 768 dimension
  """
 
 input_file = sys.argv[1]
 token_file = sys.argv[2]
 vector_file = sys.argv[3]
+model_name = sys.argv[4]
 
 dic = dict()
 TOKENIZE_RE = re.compile('[][ \t,\-()!@#$%^&*\'"{}<>/?\\|+=_:;.]+')
@@ -40,8 +46,7 @@ with open(input_file, 'rt') as input:
                 dic[tl] = 1
 
 BATCH_SIZE = 256
-#model = SentenceTransformer('all-MiniLM-L6-v2')
-model = SentenceTransformer('all-mpnet-base-v2')
+model = SentenceTransformer(model_name)
 model.eval()
 
 with open(token_file, 'wt') as tokens_out:

--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -3,6 +3,7 @@
 import subprocess
 import benchUtil
 import constants
+from common import getLuceneDirFromGradleProperties
 
 # Measure vector search recall and latency while exploring hyperparameters
 
@@ -13,17 +14,17 @@ import constants
 # unzip glove.6B.zip
 # unlzma enwiki-20120502-lines-1k.txt.lzma
 ### Create document and task vectors
-# ant vectors100
+# ./gradlew vectors-100
 #
-# then run this file: python src/python/knnPerfTest.py
+# change the parameters below and then run (you can still manually run this file, but using gradle command
+# below will auto recompile if you made any changes to java files in luceneutils)
+# ./gradlew runKnnPerfTest
 #
 # you may want to modify the following settings:
 
 
-# Where the version of Lucene is that will be tested. Expected to be in the base dir above luceneutil.
-#LUCENE_CHECKOUT = 'baseline'
-# LUCENE_CHECKOUT = 'candidate'
-LUCENE_CHECKOUT = 'trunk'
+# Where the version of Lucene is that will be tested. Now this will be sourced from gradle.properties
+LUCENE_CHECKOUT = getLuceneDirFromGradleProperties()
 
 # e.g. to compile KnnIndexer:
 #
@@ -31,7 +32,7 @@ LUCENE_CHECKOUT = 'trunk'
 #
 
 # test parameters. This script will run KnnGraphTester on every combination of these parameters
-VALUES = {
+PARAMS = {
     #'ndoc': (10000, 100000, 1000000),
     #'ndoc': (10000, 100000, 200000, 500000),
     #'ndoc': (10000, 100000, 200000, 500000),
@@ -96,7 +97,6 @@ def run_knn_benchmark(checkout, values):
            '--add-modules', 'jdk.incubator.vector',
            '-Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false',
            'knn.KnnGraphTester']
-    print("recall\tlatency\tnDoc\tfanout\tmaxConn\tbeamWidth\tvisited\tindex ms")
     while advance(indexes, values):
         print('\nNEXT:')
         pv = {}
@@ -128,7 +128,8 @@ def run_knn_benchmark(checkout, values):
             # '-forceMerge',
             '-quiet']
         print(f'  cmd: {this_cmd}')
+        print("recall\tlatency\tnDoc\tfanout\tmaxConn\tbeamWidth\tvisited\tindex ms")
         subprocess.run(this_cmd, check=True)
 
 
-run_knn_benchmark(LUCENE_CHECKOUT, VALUES)
+run_knn_benchmark(LUCENE_CHECKOUT, PARAMS)


### PR DESCRIPTION
### Major changes
* Move all tasks previously in ant to gradle (not yet deleted build.xml so ant is still usable)
* Have a wrapper task which run `python src/python/knnPerfTest.py`, the benefit being it will recompile automatically
* `knnPerfTest.py` will now figure out lucene directory (used for class path when executing java class) using `gradle.properties`, also compilation time is using the same property
* Better integrate higher dimension vectors workflow in gradle, people should be able to only use gradle to finish all set ups

### Minor changes
* Upgrade gradle to support java21
* let user able to specify lucene version intend to use, to avoid the situation where multiple version of lucene jar exist in same dir and it will load a random one for use
* Move knn index to a specified dir and ignore it in git