### PR TITLE
add a few numeric range faceting tasks to wikimedium*

### DIFF
--- a/tasks/wikimedium.10M.nostopwords.tasks
+++ b/tasks/wikimedium.10M.nostopwords.tasks
@@ -14411,7 +14411,9 @@ BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
 BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
 BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
 BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
-
+range:dayOfYear:0-50,50-100,100-150,150-200,200-250,250-300,300-350,350-400
+range:dayOfYear:0-100,50-150,100-200,150-250,200-300,250-350,300-400
+range:dayOfYear:0-10,10-20,20-30,30-40,40-50,50-60,60-70,70-80,80-90,90-100,100-110,110-120,120-130,130-140,140-150,150-160,160-170,170-180,180-190,190-200,200-210,210-220,220-230,230-240,240-250,250-260,260-270,270-280,280-290,290-300,300-310,310-320,320-330,330-340,340-350,350-360,360-370,370-380,380-390
 HighTermDayOfYearSort: dayofyeardvsort//ref # freq=3793973
 HighTermDayOfYearSort: dayofyeardvsort//http # freq=3493581
 HighTermDayOfYearSort: dayofyeardvsort//from # freq=3224339

--- a/tasks/wikimedium.1M.nostopwords.tasks
+++ b/tasks/wikimedium.1M.nostopwords.tasks
@@ -11271,6 +11271,9 @@ BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
 BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
 BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
 BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
+range:dayOfYear:0-50,50-100,100-150,150-200,200-250,250-300,300-350,350-400
+range:dayOfYear:0-100,50-150,100-200,150-250,200-300,250-350,300-400
+range:dayOfYear:0-10,10-20,20-30,30-40,40-50,50-60,60-70,70-80,80-90,90-100,100-110,110-120,120-130,130-140,140-150,150-160,160-170,170-180,180-190,190-200,200-210,210-220,220-230,230-240,240-250,250-260,260-270,270-280,280-290,290-300,300-310,310-320,320-330,330-340,340-350,350-360,360-370,370-380,380-390
 HighTermDayOfYearSort: dayofyeardvsort//ref # freq=541190
 HighTermDayOfYearSort: dayofyeardvsort//http # freq=389790
 HighTermDayOfYearSort: dayofyeardvsort//from # freq=359428


### PR DESCRIPTION
I discovered that we already [have support](https://github.com/mikemccand/luceneutil/blob/bdc762a7225792e457ad0c9e65b194535c910a8b/src/main/perf/SearchTask.java#L248) for numeric range faceting tasks but don't seem to be using them in any of our task files. Let's add a few tasks to the wikimedium* benchmarks?

I'm not sure if there's a better way to do this. It's kind of confusing that this just shows up as "range" in the benchmark task output. It might be nice to make this a little easier to understand?