### PR TITLE
Remove unnecessary enableMemorySegments from KnnPerfTest

### DIFF
--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -99,7 +99,7 @@ def run_knn_benchmark(checkout, values):
     cp = benchUtil.classPathToString(benchUtil.getClassPath(checkout))
     cmd = constants.JAVA_EXE.split(' ') + ['-cp', cp,
            '--add-modules', 'jdk.incubator.vector',
-           '-Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false',
+           '--enable-native-access=ALL-UNNAMED',
            'knn.KnnGraphTester']
     all_results = []
     while advance(indexes, values):


### PR DESCRIPTION
I'm not sure why KnnPerfTest ever set `enableMemorySegments`, but I don't see any valid reason to do so. The property selects whether or not to use the "newer" MMapDirectory implementation based on the JDK's `MemorySegment`. This implementation is the default in 9x and is actually the only prod impl in Lucene 10. We should remove the prop that disables it.

Additionally, and since KnnPerfTest runs lucene on the classpath, then  we should enable native access to remove the warning from it's usage (lucene uses native access to call madvise) 