### PR TITLE
Improve gradle compileKnn task error output when external dir not found

### DIFF
--- a/gradle/knn.gradle
+++ b/gradle/knn.gradle
@@ -27,6 +27,10 @@ def luceneVersion = (String) findProperty("lucene.version")
 def luceneFT = fileTree(dir: luceneDir, include: "**/*$luceneVersion-SNAPSHOT.jar")
 
 task compileKnn (type: JavaCompile) {
+    if (luceneFT.empty) {
+        throw new GradleException('compile classpath is empty. Please check external.lucene.repo:"'
+                + luceneDir + '", and lucene.version:"' + luceneVersion + '"')
+    }
     source = [srcDir]
     include "knn/KnnGraphTester.java", "WikiVectors.java", "perf/VectorDictionary.java"
     classpath = luceneFT


### PR DESCRIPTION
This commit improves the error output of the gradle compileKnn task when the external lucene build is not found, rather results in a slue of compile errors.

I find this more useful when I make silly mistakes by not updating `external.lucene.repo`, or forgetting to build lucene itself.