### PR TITLE
fix textDocFileName location in knn.gradle

### DIFF
--- a/gradle/knn.gradle
+++ b/gradle/knn.gradle
@@ -89,7 +89,7 @@ for (entry in baseDataSets) {
         args(attachQuantizeArgs(
                 entry.value.quantized,
                 ["$dataDir/${entry.value.dictFileName}",
-                "$taskDir/$textDocFileName",
+                "$dataDir/$textDocFileName",
                 "$taskDir/${entry.value.docVecFileName}"
         ]))
     }
@@ -149,7 +149,7 @@ for (entry in highDimDataSets) {
                 ["$dataDir/$tokFile",
                  "$dataDir/$vecFile",
                  entry.value.dimension,
-                 "$taskDir/$textDocFileName",
+                 "$dataDir/$textDocFileName",
                  "$taskDir/${entry.value.docVecFileName}"
                 ]))
     }


### PR DESCRIPTION
This commit fixes the location of the `textDocFileName` (enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt), file location in knn.gradle. It's in the dataDir not the taskDir - at least for me, no?