### PR TITLE
Use sample-stddev instead of population-stddev in t-test

### DIFF
--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -36,6 +36,7 @@ import QPSChart
 import IndexChart
 import subprocess
 import shlex
+import statistics
 
 try:
   import distutils
@@ -837,17 +838,12 @@ def sum_hit_count(hc1, hc2):
   return str(hc1+hc2) + (lower_bound and "+" or "")
 
 def stats(l):
-  sum = 0
-  sumSQ = 0
-  for v in l:
-    sum += v
-    sumSQ += v*v
-
   # min, max, mean, stddev
   if len(l) == 0:
     return 0.0, 0.0, 0.0, 0.0
   else:
-    return min(l), max(l), sum/len(l), math.sqrt(len(l)*sumSQ - sum*sum)/len(l)
+    mu = mean(l)
+    return min(l), max(l), mu, stdev(l, mu=mu)
 
 def run(cmd, logFile=None, indent='    ', vmstatLogFile=None):
   #print('%s[RUN: %s, cwd=%s]' % (indent, cmd, os.getcwd()))

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -842,8 +842,8 @@ def stats(l):
   if len(l) == 0:
     return 0.0, 0.0, 0.0, 0.0
   else:
-    mu = mean(l)
-    return min(l), max(l), mu, stdev(l, mu=mu)
+    mu = statistics.mean(l)
+    return min(l), max(l), mu, statistics.stdev(l) if len(l) > 1 else 0
 
 def run(cmd, logFile=None, indent='    ', vmstatLogFile=None):
   #print('%s[RUN: %s, cwd=%s]' % (indent, cmd, os.getcwd()))


### PR DESCRIPTION
We shouldn't use the population variance when we're clearly sampling. This massively underestimates the variance in some cases, leading to a number of nightlies showing p-values of 0 in the absence of code changes.
Implemented this by using python statistics, should be ok to rely on python 3.8 at this point right?
