### PR TITLE
Add leniency to filtered KNN search.

### DIFF
--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -182,7 +182,7 @@ class SearchTask:
   isCountOnly = False
   
   def verifySame(self, other, verifyScores, verifyCounts):
-    if re.match('^Knn(Float|Byte)VectorQuery:', self.query) is not None:
+    if re.match('.*Knn(Float|Byte)VectorQuery:', self.query) is not None:
       # While KNN search is statically randomized (seed 42?), the concurrent HNSW merge alters the order of results
       return
     if not isinstance(other, SearchTask):


### PR DESCRIPTION
The current regexp only matches top-level KNN queries, not post-filtered KNN queries.