### PR TITLE
Change the way how combined field queries are parsed.

### DIFF
--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -1410,10 +1410,12 @@ def writeIndexHTML(searchChartData, days):
     writeOneLine(w, done, 'OrHighRare', 'Disjunction of a very frequent term and a very rare term')
     writeOneLine(w, done, 'OrMany', 'Disjunction of many terms')
 
-    w('<br><br><b>CombinedFieldsQuery:</b>')
+    w('<br><br><b>CombinedFieldQuery:</b>')
     writeOneLine(w, done, 'CombinedTerm', 'Combined high-freq')
-    writeOneLine(w, done, 'CombinedHighMed', 'Combined high-freq medium-freq')
-    writeOneLine(w, done, 'CombinedHighHigh', 'Combined high-freq high-freq')
+    writeOneLine(w, done, 'CombinedOrHighMed', 'Combined OR high-freq medium-freq')
+    writeOneLine(w, done, 'CombinedOrHighHigh', 'Combined OR high-freq high-freq')
+    writeOneLine(w, done, 'CombinedAndHighMed', 'Combined AND high-freq medium-freq')
+    writeOneLine(w, done, 'CombinedAndHighHigh', 'Combined AND high-freq high-freq')
 
     w('<br><br><b>DisjunctionMaxQuery to combine scores across the title and body fields:</b>')
     writeOneLine(w, done, 'DismaxTerm', 'Term queries combined via dismax')

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -230,17 +230,29 @@ CombinedTerm: nbsp +combinedFields=titleTokenized^8.0,body
 CombinedTerm: part +combinedFields=titleTokenized^8.0,body
 CombinedTerm: st +combinedFields=titleTokenized^8.0,body
 
-CombinedHighMed: at mostly +combinedFields=titleTokenized^8.0,body
-CombinedHighMed: his interview +combinedFields=titleTokenized^8.0,body
-CombinedHighMed: http 9 +combinedFields=titleTokenized^8.0,body
-CombinedHighMed: they hard +combinedFields=titleTokenized^8.0,body
-CombinedHighMed: title bay +combinedFields=titleTokenized^8.0,body
+CombinedOrHighMed: at mostly +combinedFields=titleTokenized^8.0,body
+CombinedOrHighMed: his interview +combinedFields=titleTokenized^8.0,body
+CombinedOrHighMed: http 9 +combinedFields=titleTokenized^8.0,body
+CombinedOrHighMed: they hard +combinedFields=titleTokenized^8.0,body
+CombinedOrHighMed: title bay +combinedFields=titleTokenized^8.0,body
 
-CombinedHighHigh: are last +combinedFields=titleTokenized^8.0,body
-CombinedHighHigh: at united +combinedFields=titleTokenized^8.0,body
-CombinedHighHigh: but year +combinedFields=titleTokenized^8.0,body
-CombinedHighHigh: name its +combinedFields=titleTokenized^8.0,body
-CombinedHighHigh: to but +combinedFields=titleTokenized^8.0,body
+CombinedOrHighHigh: are last +combinedFields=titleTokenized^8.0,body
+CombinedOrHighHigh: at united +combinedFields=titleTokenized^8.0,body
+CombinedOrHighHigh: but year +combinedFields=titleTokenized^8.0,body
+CombinedOrHighHigh: name its +combinedFields=titleTokenized^8.0,body
+CombinedOrHighHigh: to but +combinedFields=titleTokenized^8.0,body
+
+CombinedAndHighMed: +at +mostly +combinedFields=titleTokenized^8.0,body
+CombinedAndHighMed: +his +interview +combinedFields=titleTokenized^8.0,body
+CombinedAndHighMed: +http +9 +combinedFields=titleTokenized^8.0,body
+CombinedAndHighMed: +they +hard +combinedFields=titleTokenized^8.0,body
+CombinedAndHighMed: +title +bay +combinedFields=titleTokenized^8.0,body
+
+CombinedAndHighHigh: +are +last +combinedFields=titleTokenized^8.0,body
+CombinedAndHighHigh: +at +united +combinedFields=titleTokenized^8.0,body
+CombinedAndHighHigh: +but +year +combinedFields=titleTokenized^8.0,body
+CombinedAndHighHigh: +name +its +combinedFields=titleTokenized^8.0,body
+CombinedAndHighHigh: +to +but +combinedFields=titleTokenized^8.0,body
 
 # DisjunctionMaxQuery across the body and text field. Even though this may not
 # be the most effective way to combine scores across fields, it's been used and


### PR DESCRIPTION
Today a query like
`CombinedHighMed: his interview +combinedFields=titleTokenized^8.0,body` is parsed as a single `CombinedFieldQuery` query that computes scores by summing up the frequencies and document lengths across 4 terms: `title:his^4`, `title:interview^4`, `body:his`, `body:interview`.

This is not what I would like it to do. Instead, I would like it to compute the score of `his` by summing up frequencies and lengths across the `title^8` and `body` fields, compute the score of `interview` likewise, and finally sum up these two scores via a `BooleanQuery`. Said otherwise both `his` and `interview` are each scored with BM25F, but then their BM25F scores are summed up.