### PR TITLE
Fix gradle configs so that gradle build works in a fresh workspace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@ configure(rootProject) {
 external.lucene.repo=$parentDir
 lucene.version=11.0.0
 """, "UTF-8")
-                logger.log(LogLevel.WARN, "\nIMPORTANT. This is the first time you ran the build. " +
-                        "I wrote some sane defaults (for this machine) to 'gradle.properties', " +
-                        "they will be picked up on consecutive gradle invocations (not this one).\n\n")
+                throw new GradleException("IMPORTANT. This is the first time you ran the build. " +
+                        "I wrote some sane defaults (for this machine) to 'gradle.properties'. " +
+                        "Rerun the command to apply the properties.")
             }
         }
     }

--- a/gradle/knn.gradle
+++ b/gradle/knn.gradle
@@ -24,8 +24,8 @@ def highDimDataSets = [
 
 def luceneDir = (String) findProperty("external.lucene.repo") + '/lucene'
 // def luceneDir = "/l/trunk/lucene"
-// def luceneVersion = (String) findProperty("lucene.version")
-def luceneVersion = "11.0.0"
+def luceneVersion = (String) findProperty("lucene.version")
+// def luceneVersion = "11.0.0"
 def luceneFT = fileTree(dir: luceneDir, include: "**/*$luceneVersion-SNAPSHOT.jar")
 
 task compileKnn (type: JavaCompile) {

--- a/gradle/knn.gradle
+++ b/gradle/knn.gradle
@@ -29,9 +29,11 @@ def luceneVersion = "11.0.0"
 def luceneFT = fileTree(dir: luceneDir, include: "**/*$luceneVersion-SNAPSHOT.jar")
 
 task compileKnn (type: JavaCompile) {
-    if (luceneFT.empty) {
-        throw new GradleException('compile classpath is empty. Please check external.lucene.repo:"'
-                + luceneDir + '", and lucene.version:"' + luceneVersion + '"')
+    doFirst {
+        if (luceneFT.empty) {
+            throw new GradleException('compile classpath is empty. Please check external.lucene.repo:"'
+                    + luceneDir + '", and lucene.version:"' + luceneVersion + '"')
+        }
     }
     source = [srcDir]
     include "knn/KnnGraphTester.java", "WikiVectors.java", "perf/VectorDictionary.java"

--- a/src/main/build.gradle
+++ b/src/main/build.gradle
@@ -3,7 +3,10 @@ plugins {
 }
 
 sourceSets {
-  main.java.srcDirs = ['knn', 'perf']
+  main.java {
+    srcDir '.'
+    include 'perf', 'knn'
+  }
 }
 
 def luceneDir = (String) findProperty("external.lucene.repo") + '/lucene'


### PR DESCRIPTION
I've noticed that when I follow the README and create a fresh workspace it requires some manual gradle changes before build works and Intellij doesn't complain about wrong package names and missing imports.

Following changes streamline the process:
- `src/main/build.gradle`: current setup adds `perf` and `knn` directories themselvs as source dirs, as a result Intellij complains for classes that use "package perf" that they are not in the right place. With this change, main directory "." is added instead, including its perf and knn subdirectories
- `gradle/knn.gradle`: move `luceneFT` check to `doFirst`, to do it as part of the task execution, not parsing. Otherwise it runs before `gradle.properties` file is created in `localSettings` task
- `build.gradle`: throw exception when `gradle.properties` is just created so that other tasks don't attempt to run with missing properties