### PR TITLE
Turn off debug mode for stale PR workflow

### DIFF
--- a/.github/workflows/mark-stale-PRs.yml
+++ b/.github/workflows/mark-stale-PRs.yml
@@ -34,7 +34,7 @@ jobs:
             If the PR is waiting for review, notify the dev@lucene.apache.org list.
             Thank you for your contribution!
 
-          debug-only: true              # turn on to run the action without applying changes
+          debug-only: false             # turn on to run the action without applying changes
           operations-per-run: 500       # operations budget
 
 # The table shows the cost in operations of all combinations of stale / not-stale for a PR.


### PR DESCRIPTION
We've had the workflow [run](https://github.com/mikemccand/luceneutil/actions/runs/13533496740/job/37820696420) and the logs look correct. We can disable `debug-only` to have it start labeling PRs.