### PR TITLE
Add a simple python CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,28 @@
+name: Python checks
+
+on:
+  # explicitly requested via UI
+  workflow_dispatch:
+  # pull requests
+  pull_request:
+    branches:
+      - '*'
+  # pushes to main
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12.6'
+
+      - name: Lint python
+        run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ build/
 .classpath
 .settings
 .pydevproject
+.venv
+.ruff_cache
 *.sublime_session
 
 ## generated files

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,67 @@
+# basic make safety: if error happens, delete output
+.DELETE_ON_ERROR:
+
+# explicitly declare shell used
+SHELL := /bin/bash
+
+# enforce that shell is picky
+.SHELLFLAGS := -norc -euo pipefail -c
+
+# don't litter up repo with bytecode
+export PYTHONDONTWRITEBYTECODE=true
+
+# don't self-check, don't ask questions
+PIP_INSTALL_ARGS=--disable-pip-version-check --no-input --upgrade
+
+# venv with dependencies in the standard location
+VENV=${PWD}/.venv
+
+# don't behave strangely if these files exist
+.PHONY: lint format reformat ruff pyright env clean
+
+# list of directories we check
+SOURCES=src/python
+
+# check formatting, linting, and types
+#lint: format ruff pyright
+lint: ruff pyright
+
+# check all formatting
+format: env
+	# validate imports: if this fails, please run "make reformat" and commit changes.
+	$(VENV)/bin/ruff check --select I $(SOURCES)
+	# validate formatting: if this fails, please run "make reformat" and commit changes.
+	$(VENV)/bin/ruff format --diff $(SOURCES)
+
+# reformat code to conventions
+reformat: env
+	# organize imports
+	$(VENV)/bin/ruff check --select I --fix $(SOURCES)
+	# reformat sources
+	$(VENV)/bin/ruff format $(SOURCES)
+
+# lints sources
+ruff: env
+	# validate sources with ruff linter
+	$(VENV)/bin/ruff check $(SOURCES)
+
+# checks types
+pyright: env
+	# type-check sources with basedpyright
+	$(VENV)/bin/basedpyright $(SOURCES)
+
+# rebuild venv if dependencies change
+env: $(VENV)/bin/activate
+$(VENV)/bin/activate: requirements.txt
+	# remove any existing venv
+	rm -rf $(VENV)
+	# create new venv
+	python3 -m venv $(VENV)
+	# install dependencies into venv
+	$(VENV)/bin/pip install $(PIP_INSTALL_ARGS) -r requirements.txt
+	# adjust timestamp for safety
+	touch $(VENV)/bin/activate
+
+# nuke venv
+clean:
+	rm -rf $(VENV)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,89 @@
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+include = [ "src/python" ]
+# TODO: improve!
+# typeCheckingMode = "strict"
+typeCheckingMode = "off"
+
+# disabling for entire files: these are broken at a syntax level
+exclude = [
+  # files appear to be using python2 syntax
+  "src/python/ToHGRM.py",
+  "src/python/createMinShouldMatchTasks.py",
+  "src/python/latencyOverTimeGraph.py",
+  "src/python/loadGraph.py",
+  "src/python/loadGraphActualQPS.py",
+  "src/python/makeGraphs.py",
+  "src/python/makeHGPatch.py",
+  "src/python/makeNRTGraph.py",
+  "src/python/mergeFacets.py",
+  "src/python/mergeViz.py",
+  "src/python/nightlyCompile.py",
+  "src/python/nrtPerf.py",
+  "src/python/remoteTestServer.py",
+  "src/python/responseTimeGraph.py",
+  "src/python/responseTimeTests.py",
+  "src/python/runAllTests.py",
+  "src/python/runRemoteTests.py",
+  "src/python/sendTasks.py",
+  "src/python/skipper.py",
+]
+
+[tool.ruff]
+line-length = 200
+indent-width = 2
+
+[tool.ruff.lint]
+# TODO: improve!
+# select = ["ALL"]
+
+# disabling/enabling of rules
+ignore = [
+  # These rules are disabled because they have violations, we should fix those!
+  "E402",    # Module level import not at top of file
+  "E703",    # Unnecessary semicolon
+  "E701",    # Multiple statements on one line (colon)
+  "E711",    # Comparison to None should be "is None"
+  "E722",    # Bare except
+  "E731",    # Do not assign a "lambda" use a "def"
+  "E741",    # Ambiguous variable name
+  "F401",    # Imported but unused
+  "F403",    # star imports prevent detection of undefined names
+  "F405",    # Possibly undefined, or defined from star imports
+  "F507",    # Wrong number of arguments to format string
+  "F541",    # F-string without placeholders
+  "F633",    # Use of '>>' is invalid with print function
+  "F811",    # Redefinition of unused
+  "F821",    # Undefined name
+  "F841",    # Local variable assigned but never used
+
+  # These rules are always disabled: conflict with the formatter
+  # don't enable! https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+  "W191", "E111", "E114", "E117", "D206", "D300", "Q000", "Q001",
+  "Q002", "Q003", "COM812", "COM819", "ISC001", "ISC002", "E501",
+]
+
+# disabling for entire files: these are broken at a syntax level
+exclude = [
+  # files appear to be using python2 syntax
+  "src/python/ToHGRM.py",
+  "src/python/createMinShouldMatchTasks.py",
+  "src/python/latencyOverTimeGraph.py",
+  "src/python/loadGraph.py",
+  "src/python/loadGraphActualQPS.py",
+  "src/python/makeGraphs.py",
+  "src/python/makeHGPatch.py",
+  "src/python/makeNRTGraph.py",
+  "src/python/mergeFacets.py",
+  "src/python/mergeViz.py",
+  "src/python/nightlyCompile.py",
+  "src/python/nrtPerf.py",
+  "src/python/remoteTestServer.py",
+  "src/python/responseTimeGraph.py",
+  "src/python/responseTimeTests.py",
+  "src/python/runAllTests.py",
+  "src/python/runRemoteTests.py",
+  "src/python/sendTasks.py",
+  "src/python/skipper.py",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# used by segments-to-html
+graphviz
+intervaltree
+
+# linter and formatter
+ruff
+# type checker
+basedpyright


### PR DESCRIPTION
There is a lot of python here! We can't be outdone by any fancy gradle build for the java stuff.

Get the basic project dependencies in requirements files, setup formatting, linting, type-checking.

Run these checks to validate PRs and pushes to main branch.

NOTE: basically all lint checks are disabled. Many files are totally disabled due to serious syntax problems: those are on a bad list and should get addressed first. Then checks can be gradually increased.

NOTE: formatting is currently disabled, I'd recommend to decide when to do it and run 'make reformat', uncomment the check in Makefile, and commit the results. Before doing this, I'd really recommend to fix syntax issues first.