### PR TITLE
partial migration to python3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ indent-width = 2
 ignore = [
   # These rules are disabled because they have violations, we should fix those!
   "E402",    # Module level import not at top of file
-  "E703",    # Unnecessary semicolon
   "E701",    # Multiple statements on one line (colon)
   "E711",    # Comparison to None should be "is None"
   "E722",    # Bare except

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ ignore = [
   "E722",    # Bare except
   "E731",    # Do not assign a "lambda" use a "def"
   "E741",    # Ambiguous variable name
-  "F401",    # Imported but unused
   "F403",    # star imports prevent detection of undefined names
   "F405",    # Possibly undefined, or defined from star imports
   "F507",    # Wrong number of arguments to format string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,25 @@ venv = ".venv"
 include = [ "src/python" ]
 # TODO: improve!
 # typeCheckingMode = "strict"
-typeCheckingMode = "off"
+typeCheckingMode = "basic"
+reportArgumentType = "none"
+reportAssignmentType = "none"
+reportAttributeAccessIssue = "none"
+reportCallIssue = "none"
+reportGeneralTypeIssues = "none"
+reportIndexIssue = "none"
+reportInvalidStringEscapeSequence = "none"
+# this is really important to fix
+reportMissingImports = "none"
+reportUnusedExpression = "none"
+reportOptionalMemberAccess = "none"
+reportOptionalContextManager = "none"
+reportOptionalIterable = "none"
+reportOperatorIssue = "none"
+reportOptionalOperand = "none"
+reportOptionalSubscript = "none"
+reportRedeclaration = "none"
+reportUndefinedVariable = "none"
 
 [tool.ruff]
 line-length = 200

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,30 +6,6 @@ include = [ "src/python" ]
 # typeCheckingMode = "strict"
 typeCheckingMode = "off"
 
-# disabling for entire files: these are broken at a syntax level
-exclude = [
-  # files appear to be using python2 syntax
-  "src/python/ToHGRM.py",
-  "src/python/createMinShouldMatchTasks.py",
-  "src/python/latencyOverTimeGraph.py",
-  "src/python/loadGraph.py",
-  "src/python/loadGraphActualQPS.py",
-  "src/python/makeGraphs.py",
-  "src/python/makeHGPatch.py",
-  "src/python/makeNRTGraph.py",
-  "src/python/mergeFacets.py",
-  "src/python/mergeViz.py",
-  "src/python/nightlyCompile.py",
-  "src/python/nrtPerf.py",
-  "src/python/remoteTestServer.py",
-  "src/python/responseTimeGraph.py",
-  "src/python/responseTimeTests.py",
-  "src/python/runAllTests.py",
-  "src/python/runRemoteTests.py",
-  "src/python/sendTasks.py",
-  "src/python/skipper.py",
-]
-
 [tool.ruff]
 line-length = 200
 indent-width = 2
@@ -62,28 +38,4 @@ ignore = [
   # don't enable! https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
   "W191", "E111", "E114", "E117", "D206", "D300", "Q000", "Q001",
   "Q002", "Q003", "COM812", "COM819", "ISC001", "ISC002", "E501",
-]
-
-# disabling for entire files: these are broken at a syntax level
-exclude = [
-  # files appear to be using python2 syntax
-  "src/python/ToHGRM.py",
-  "src/python/createMinShouldMatchTasks.py",
-  "src/python/latencyOverTimeGraph.py",
-  "src/python/loadGraph.py",
-  "src/python/loadGraphActualQPS.py",
-  "src/python/makeGraphs.py",
-  "src/python/makeHGPatch.py",
-  "src/python/makeNRTGraph.py",
-  "src/python/mergeFacets.py",
-  "src/python/mergeViz.py",
-  "src/python/nightlyCompile.py",
-  "src/python/nrtPerf.py",
-  "src/python/remoteTestServer.py",
-  "src/python/responseTimeGraph.py",
-  "src/python/responseTimeTests.py",
-  "src/python/runAllTests.py",
-  "src/python/runRemoteTests.py",
-  "src/python/sendTasks.py",
-  "src/python/skipper.py",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # used by segments-to-html
 graphviz
 intervaltree
+# used by infer-token-vectors
+# FIXME: HMM this is an 800MB download?
+# sentence-transformers
 
 # linter and formatter
 ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,13 @@
 # used by segments-to-html
 graphviz
 intervaltree
+
 # used by infer-token-vectors
 # FIXME: HMM this is an 800MB download?
 # sentence-transformers
+
+# used by index-chart
+PyGnuplot
 
 # linter and formatter
 ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,16 @@ intervaltree
 # sentence-transformers
 
 # used by index-chart
-PyGnuplot
+py-gnuplot
+
+# used by qps-chart
+pillow
+
+# used by mergeviz
+iso8601
+
+# used by indexosm
+rtree
 
 # linter and formatter
 ruff

--- a/src/python/IndexChart.py
+++ b/src/python/IndexChart.py
@@ -13,11 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-  from pygnuplot import gnuplot as Gnuplot
-except ImportError:
-  print('WARNING: Gnuplot module not present; will not make charts')
-  Gnuplot = None
+from pygnuplot import gnuplot as Gnuplot
 
 class IndexChart(object):
   
@@ -67,7 +63,7 @@ class IndexChart(object):
 
   def buildStats(self, meta=None):
     raw_data, raw_flush = self.buildRaw(meta)
-    start = 0;
+    start = 0
     last_window_start = 0
     docs_per_second = []
     flush_stats = []
@@ -134,7 +130,7 @@ class IndexChart(object):
         #gp('set style fill pattern 2')
         gp('set xrange [%d : %d]' % (self.start_sec, self.end_sec))
         gp('set yrange [0 : 50]')
-        gp.replot(data);
+        gp.replot(data)
        
 
       gp.hardcopy(filename="%s/%s_flush.png" % (self.out_base, self.competitor), terminal=self.terminal)  

--- a/src/python/ToHGRM.py
+++ b/src/python/ToHGRM.py
@@ -44,7 +44,7 @@ if os.system('javac -cp .:%s/src ToHGRM.java' % HDR_HISTOGRAM_PATH):
   raise RuntimeError('compile failed')
 
 p = subprocess.Popen('java -cp .:%s/src ToHGRM %g > out.hgrm 2>&1' % (HDR_HISTOGRAM_PATH, maxLatencyMS/1000.), shell=True, stdin=subprocess.PIPE)
-print '%d queries' % len(allMS)
+print('%d queries' % len(allMS))
 for ms in allMS:
   p.stdin.write('%g\n' % (ms/1000.0))
 p.stdin.close()

--- a/src/python/WikipediaExtractor.py
+++ b/src/python/WikipediaExtractor.py
@@ -58,9 +58,7 @@ Options:
 
 import sys
 
-import gc
 import getopt
-import urllib
 import re
 import bz2
 import os.path

--- a/src/python/autoPrefixPerf.py
+++ b/src/python/autoPrefixPerf.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import time
 import re
 
 # run from lucene subdir in trunk checkout

--- a/src/python/backTestGeo.py
+++ b/src/python/backTestGeo.py
@@ -1,4 +1,3 @@
-import sys
 import shutil
 import datetime
 import os

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -32,12 +32,9 @@ import IndexChart
 import subprocess
 import statistics
 import ps_head
+from shutil import which
 
-try:
-  import distutils
-  PERF_EXE = distutils.spawn.find_executable('perf')
-except:
-  PERF_EXE = None
+PERF_EXE = which('perf')
 
 if PERF_EXE is None:
   print(f'no perf executable; will not collect aggregate CPU profiling data')

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -24,19 +24,12 @@ import os
 import pwd
 import shutil
 import sys
-try:
-  import cPickle as pickle  # python2
-except ImportError:
-  import pickle
-import datetime
+import pickle
 import constants
 import common
-import random
-import signal
 import QPSChart
 import IndexChart
 import subprocess
-import shlex
 import statistics
 import ps_head
 

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1086,7 +1086,7 @@ class RunAlgs:
       return self.antCompile(competitor)
     try:
       if competitor.checkout not in self.compiledCheckouts:
-        self.compiledCheckouts.add(competitor.checkout);
+        self.compiledCheckouts.add(competitor.checkout)
         # for core we build a JAR in order to benefit from the MR JAR stuff
         os.chdir(checkoutPath)
         for module in ['core']:
@@ -1120,7 +1120,7 @@ class RunAlgs:
     checkoutPath = checkoutToPath(competitor.checkout)
     try:
       if competitor.checkout not in self.compiledCheckouts:
-        self.compiledCheckouts.add(competitor.checkout);
+        self.compiledCheckouts.add(competitor.checkout)
         # for core we build a JAR in order to benefit from the MR JAR stuff
         for module in ['core']:
           modulePath = '%s/lucene/%s' % (checkoutPath, module)

--- a/src/python/blunders.py
+++ b/src/python/blunders.py
@@ -17,7 +17,6 @@ import base64
 import json
 import os
 import time
-import sys
 import urllib.request
 import constants
 

--- a/src/python/buildAndCheckIndexForeverUntilCorrumption.py
+++ b/src/python/buildAndCheckIndexForeverUntilCorrumption.py
@@ -1,7 +1,6 @@
 import shutil
 import datetime
 import os
-import sys
 
 import constants
 import competition

--- a/src/python/buildTaxisCSV.py
+++ b/src/python/buildTaxisCSV.py
@@ -3,7 +3,6 @@ import sys
 import datetime
 import os
 import csv
-import json
 
 # Directory where the original .csv files were downloaded to, using downloadTaxisCSVs.py:
 CSV_DIR = '/lucenedata/nyc-taxi-data'

--- a/src/python/buildTaxisCSVConcurrent.py
+++ b/src/python/buildTaxisCSVConcurrent.py
@@ -1,10 +1,8 @@
 import multiprocessing
 import time
-import sys
 import datetime
 import os
 import csv
-import json
 
 # Directory where the original .csv files were downloaded to, using downloadTaxisCSVs.py:
 CSV_DIR = '/lucenedata/nyc-taxi-data'

--- a/src/python/common.py
+++ b/src/python/common.py
@@ -1,4 +1,3 @@
-import re
 import sys
 import os
 import constants

--- a/src/python/createEnglishWikipediaLineDocsFile.py
+++ b/src/python/createEnglishWikipediaLineDocsFile.py
@@ -2,7 +2,6 @@ import os
 import sys
 import setup
 import time
-import tempfile
 import urllib.parse
 import subprocess
 import wikiXMLToText

--- a/src/python/createMinShouldMatchTasks.py
+++ b/src/python/createMinShouldMatchTasks.py
@@ -28,7 +28,7 @@ while True:
     break
   startIndex += 1
 
-print 'startIndex %s' % startIndex
+print('startIndex %s' % startIndex)
 
 topFreq = terms[startIndex][1]
 byCat = {}
@@ -41,7 +41,7 @@ for term, freq in terms[startIndex:]:
 keys = byCat.keys()
 keys.sort()
 for key in keys:
-  print '%s: %d terms' % (key, len(byCat[key]))
+  print('%s: %d terms' % (key, len(byCat[key])))
 
 if True:
   for i in xrange(10000):
@@ -61,4 +61,4 @@ if True:
     random.shuffle(terms)
 
     label = '%dTerms%dHigh%dMSM' % (numTerms, numHighFreqTerms, minShouldMatch)
-    print '%s: %s +minShouldMatch=%d' % (label, ' '.join([x[0] for x in terms]), minShouldMatch)
+    print('%s: %s +minShouldMatch=%d' % (label, ' '.join([x[0] for x in terms]), minShouldMatch))

--- a/src/python/diffBinaryFiles.py
+++ b/src/python/diffBinaryFiles.py
@@ -17,7 +17,6 @@
 
 import struct
 import sys
-import datetime
 import io
 
 def read_exact_byte_count(file_name, f, byte_count):

--- a/src/python/docsToBlocks.py
+++ b/src/python/docsToBlocks.py
@@ -1,5 +1,4 @@
 import sys
-import os
 
 pending = []
 pendingDocCount = 0

--- a/src/python/fstApp.py
+++ b/src/python/fstApp.py
@@ -2,7 +2,6 @@ import base64
 import cgi
 import subprocess
 import wsgiref.simple_server
-import socket
 
 import sys
 sys.path.insert(0, '/home/changingbits/webapps/examples/htdocs')

--- a/src/python/geoShapeVideo.py
+++ b/src/python/geoShapeVideo.py
@@ -1,7 +1,6 @@
 from PIL import Image, ImageDraw
 import sys
 import os
-import shutil
 
 # rm -rf /x/tmp/frames; python3 -u /l/util/src/python/geoShapeVideo.py /x/tmp/londonBG2.png /x/tmp/london.poly /x/tmp/frames /x/tmp/bkd.shapes.txt /x/tmp/out.avi
 

--- a/src/python/infer_token_vectors.py
+++ b/src/python/infer_token_vectors.py
@@ -1,7 +1,5 @@
 import sys
-import numpy as np
 import re
-import torch
 # from https://www.sbert.net/
 # to install: pip install -U sentence-transformers
 from sentence_transformers import SentenceTransformer

--- a/src/python/infostream_to_segments.py
+++ b/src/python/infostream_to_segments.py
@@ -20,7 +20,6 @@ import bisect
 import sys
 import re
 import os
-import math
 import datetime
 
 def parse_timestamp(s):

--- a/src/python/iwLogToGraphs.py
+++ b/src/python/iwLogToGraphs.py
@@ -56,7 +56,7 @@ class RollingTimeWindow:
   def __init__(self, windowTime):
     self.window = []
     self.windowTime = windowTime
-    self.pruned = False;
+    self.pruned = False
     
   def add(self, t, value):
     self.window.append((t, value))

--- a/src/python/iwLogToGraphs.py
+++ b/src/python/iwLogToGraphs.py
@@ -2,7 +2,6 @@ import time
 import sys
 import re
 import datetime
-import math
 
 # see http://home.apache.org/~mikemccand/lucenebench/iw.html as an example
 

--- a/src/python/lastNightlyRun.py
+++ b/src/python/lastNightlyRun.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import re
-import pickle
 
 reDateTime = re.compile('^(\d\d\d\d).(\d\d).(\d\d).(\d\d).(\d\d).(\d\d)$')
 

--- a/src/python/latencyOverTimeGraph.py
+++ b/src/python/latencyOverTimeGraph.py
@@ -100,7 +100,7 @@ for t, msec in graphData:
 w(chartFooter)
 
 open(htmlOut, 'wb').write(''.join(chart))
-print 'Saved to %s' % htmlOut
+print('Saved to %s' % htmlOut)
     
 
 

--- a/src/python/loadGraph.py
+++ b/src/python/loadGraph.py
@@ -18,7 +18,6 @@
 import sys
 import os
 import re
-import cPickle
 import responseTimeGraph
 
 logPoints = ((50, 2),
@@ -52,7 +51,7 @@ def graph(rowPoint, logsDir, warmupSec, names, fileName, maxQPS=None):
       if m is not None and os.path.exists(resultsFile):
         qps = int(m.group(1))
         if maxQPS is not None and qps > maxQPS:
-          print 'SKIPPING %s qps' % qps
+          print('SKIPPING %s qps' % qps)
           continue
 
         allQPS.add(qps)
@@ -92,7 +91,7 @@ def graph(rowPoint, logsDir, warmupSec, names, fileName, maxQPS=None):
                'OracleCMSMMap': 'CMS + MMap',
                'OracleCMSMMapDir': 'CMS + MMap'}
 
-  print 'names: %s; cleaned %s' % (names, (', '.join("'%s'" % cleanName.get(x, x) for x in names)))
+  print('names: %s; cleaned %s' % (names, (', '.join("'%s'" % cleanName.get(x, x) for x in names))))
   
   l = []
   w = l.append
@@ -116,7 +115,7 @@ def graph(rowPoint, logsDir, warmupSec, names, fileName, maxQPS=None):
     
   html = graphHeader + ''.join(l) + graphFooter % p
   open(fileName, 'wb').write(html)
-  print '  saved %s' % fileName
+  print('  saved %s' % fileName)
 
 graphHeader = '''<html>
   <head>

--- a/src/python/loadGraphActualQPS.py
+++ b/src/python/loadGraphActualQPS.py
@@ -72,7 +72,7 @@ def graph(rowPoint, logsDir, warmupSec, names, fileName, maxQPS=None):
           continue
         
         if maxQPS is not None and qps > maxQPS:
-          print 'SKIPPING %s qps' % qps
+          print('SKIPPING %s qps' % qps)
           continue
 
         # qps is the "target", ie the rate at which we sent the
@@ -80,7 +80,7 @@ def graph(rowPoint, logsDir, warmupSec, names, fileName, maxQPS=None):
         # achieved overall:
         pctPoints, actualQPS, endTimeSec = responseTimeGraph.getPctPoints(resultsFile, name, warmupSec)
 
-        print '%s: qps %s, actualQPS %s' % (name, qps, actualQPS)
+        print('%s: qps %s, actualQPS %s' % (name, qps, actualQPS))
 
         if rowPoint == 'min':
           t = pctPoints[0]
@@ -93,12 +93,12 @@ def graph(rowPoint, logsDir, warmupSec, names, fileName, maxQPS=None):
 
         if sla is not None and t <= sla:
           passesSLA.add((qps, name))
-          print '  PASS'
+          print('  PASS')
 
         if True or t < 30000:
           graphData.append((qps, actualQPS, name, t))
         else:
-          print '%s: drop data point qps=%s t=%s: t is >= 30000' % (name, qps, t)
+          print('%s: drop data point qps=%s t=%s: t is >= 30000' % (name, qps, t))
 
         if name not in maxActualQPS:
           maxActualQPS[name] = actualQPS
@@ -129,7 +129,7 @@ def graph(rowPoint, logsDir, warmupSec, names, fileName, maxQPS=None):
     
   html = graphHeader + ''.join(l) + graphFooter % p
   open(fileName, 'wb').write(html)
-  print '  saved %s' % fileName
+  print('  saved %s' % fileName)
   if sla is None:
     return None, maxActualQPS
   else:

--- a/src/python/makeGraphs.py
+++ b/src/python/makeGraphs.py
@@ -14,10 +14,10 @@ def main(maxQPS = None):
 
   if maxQPS is None:
     if os.path.exists(reportsDir):
-      print 'ERROR: please move existing reportsDir (%s) out of the way' % reportsDir
+      print('ERROR: please move existing reportsDir (%s) out of the way' % reportsDir)
       sys.exit(1)
 
-      print 'getInterpValue: list=%s interpDate=%s' % (valueList, interpDate)
+      print('getInterpValue: list=%s interpDate=%s' % (valueList, interpDate))
 
     os.makedirs(reportsDir)
 
@@ -45,7 +45,7 @@ def main(maxQPS = None):
       
       if name.lower().find('warmup') == -1:
         names.add(name)
-        if not name in byName:
+        if name not in byName:
           byName[name] = []
         byName[name].append((qpsValue, qpsString, f))
 
@@ -66,7 +66,7 @@ def main(maxQPS = None):
         if dirName.find('.pct') == -1:
           os.rename('%s/%s' % (logsDir, dirName),
                     '%s/%s.pct%s' % (logsDir, dirName, pcts[idx]))
-      print '%s -> %s' % (name, l)
+      print('%s -> %s' % (name, l))
 
   if maxQPS is None:
     indexOut = open('%s/index.html' % reportsDir, 'wb')
@@ -102,8 +102,8 @@ def main(maxQPS = None):
           if len(d) == 0:
             raise RuntimeError('nothing matches pct=%d' % pct)
 
-          print
-          print 'Create response-time graph @ pct=%d: d=%s' % (pct, d)
+          print()
+          print('Create response-time graph @ pct=%d: d=%s' % (pct, d))
 
           if len(d) != 0:
             try:
@@ -134,8 +134,8 @@ def main(maxQPS = None):
             #raise RuntimeError('nothing matches qps=%s' % qpsString)
             continue
 
-          print
-          print 'Create response-time graph @ qps=%s: d=%s' % (qps, d)
+          print()
+          print('Create response-time graph @ qps=%s: d=%s' % (qps, d))
 
           if len(d) != 0:
             try:
@@ -155,8 +155,8 @@ def main(maxQPS = None):
 
     for idx in xrange(len(loadGraphActualQPS.logPoints)):
 
-      print
-      print 'Create pct graph @ %s%%' % loadGraphActualQPS.logPoints[idx][0]
+      print()
+      print('Create pct graph @ %s%%' % loadGraphActualQPS.logPoints[idx][0])
 
       if maxQPS is not None:
         fileName = 'load%spct_max%s.html' % (loadGraphActualQPS.logPoints[idx][0], maxQPS)
@@ -198,15 +198,15 @@ def main(maxQPS = None):
     l = [(y, x) for x, y in highest.items()]
     l.sort()
 
-    print
-    print 'Max actual QPS:'
+    print()
+    print('Max actual QPS:')
     for name, qps in maxActualQPS.items():
-      print '  %s: %.1f QPS' % (name, qps)
+      print('  %s: %.1f QPS' % (name, qps))
 
-    print
-    print 'Highest QPS w/ SLA met:'
+    print()
+    print('Highest QPS w/ SLA met:')
     for qps, name in l:
-      print '  %s: %s QPS' % (responseTimeGraph.cleanName(name), qps)
+      print('  %s: %s QPS' % (responseTimeGraph.cleanName(name), qps))
 
     w('<a href="loadmax.html">100%%</a>')
     w('<br>')

--- a/src/python/makeHGPatch.py
+++ b/src/python/makeHGPatch.py
@@ -48,4 +48,4 @@ if '-check' in sys.argv:
 
 patchOut = '/x/tmp/patch/LUCENE-%s.patch' % issueNumber
 shutil.copy2('diffs.x', patchOut)
-print 'Saved patch to %s' % patchOut
+print('Saved patch to %s' % patchOut)

--- a/src/python/makeNRTGraph.py
+++ b/src/python/makeNRTGraph.py
@@ -35,8 +35,8 @@ for line in open(sys.argv[1], 'rb').readlines():
       sumSQ += reopen*reopen
       count += 1
 
-print 'reopen: mean %.2f stddev %.2f' % \
-      (sum/count, math.sqrt(count*sumSQ - sum*sum)/count)
+print('reopen: mean %.2f stddev %.2f' % \
+      (sum/count, math.sqrt(count*sumSQ - sum*sum)/count))
 
 # discard warmup
 results = results[10:]

--- a/src/python/mergeFacets.py
+++ b/src/python/mergeFacets.py
@@ -52,7 +52,7 @@ def randomString(r):
     
 def merge(shards, topN):
   if VERBOSE:
-    print '  merge topN=%s' % topN
+    print('  merge topN=%s' % topN)
 
   mult = 3
   values = None
@@ -65,7 +65,7 @@ def merge(shards, topN):
 
   while True:
     if VERBOSE:
-      print '    cycle mult=%s' % mult
+      print('    cycle mult=%s' % mult)
 
     iterCount += 1
 
@@ -75,7 +75,7 @@ def merge(shards, topN):
       specificValues = None
 
     if VERBOSE:
-      print '    query shards'
+      print('    query shards')
     for i in xrange(len(shards)):
       exhausted, shardValues, lowestCount = shardHits[i]
       if specificValues is not None:
@@ -110,18 +110,18 @@ def merge(shards, topN):
             shardValues[value] = count
 
         if VERBOSE:
-          print '      shard %d: totalHits=%s len(hits)=%s exhausted=%s lowestCount=%d values=%s' % \
-                (i, totalHitCount, len(hits), exhausted, lowestCount, shardMissingValues)
+          print('      shard %d: totalHits=%s len(hits)=%s exhausted=%s lowestCount=%d values=%s' % \
+                (i, totalHitCount, len(hits), exhausted, lowestCount, shardMissingValues))
           for value, count in hits:
-            print '        %s: count=%s' % (value, count)
+            print('        %s: count=%s' % (value, count))
           if newValues is not None:
             for value, count in newValues:
-              print '       *%s: count=%d' % (value, count)
+              print('       *%s: count=%d' % (value, count))
         shardHits[i] = (exhausted, shardValues, lowestCount)
       else:
         if VERBOSE:
-          print '      shard %d: skip exhausted=%s len(shardMissingValues)=%s' % \
-                (i, exhausted, len(shardMissingValues))
+          print('      shard %d: skip exhausted=%s len(shardMissingValues)=%s' % \
+                (i, exhausted, len(shardMissingValues)))
 
     # nocommit must handle the "all shards have 0 facets" case ... we
     # will exc below
@@ -170,21 +170,21 @@ def merge(shards, topN):
       break
     
     if VERBOSE:
-      print '    merged:'
+      print('    merged:')
     sawNone = False
     for value, (count, someMissing) in lTopN:
       if value is None:
         sawNone = True
       if VERBOSE:
-        print '      %s: count=%d, someMissing=%s' % (value, count, someMissing)
+        print('      %s: count=%d, someMissing=%s' % (value, count, someMissing))
       if someMissing:
         if VERBOSE:
-          print '        retry'
+          print('        retry')
         retry = True
     if VERBOSE:
       for value, (count, someMissing) in l[topN:]:
         if VERBOSE:
-          print '    **%s: count=%d, someMissing=%s' % (value, count, someMissing)
+          print('    **%s: count=%d, someMissing=%s' % (value, count, someMissing))
 
     if retry:
       # nocommit sometimes ... we don't need to increase mult, ie, we
@@ -193,7 +193,7 @@ def merge(shards, topN):
       if sawNone:
         mult *= 2
       if VERBOSE:
-        print '  run again with mult=%s' % mult
+        print('  run again with mult=%s' % mult)
       continue
     else:
       break
@@ -220,8 +220,8 @@ def test(staticSeedIn, seedIn):
   cycles = 0
   while True:
     if VERBOSE:
-      print
-      print 'Test: cycle'
+      print()
+      print('Test: cycle')
 
     if seedIn is None:
       seed = random.randint(-sys.maxint-1, sys.maxint)
@@ -241,7 +241,7 @@ def test(staticSeedIn, seedIn):
       numShards = r.randint(1, 100)
       
     if True or VERBOSE:
-      print '  seed %s:%s, %d shards, %d values' % (staticSeed, seed, numShards, numFacetValues)
+      print('  seed %s:%s, %d shards, %d values' % (staticSeed, seed, numShards, numFacetValues))
       
     shards = []
 
@@ -252,10 +252,10 @@ def test(staticSeedIn, seedIn):
       shard = FacetShard(model.getShardValues(i))
 
       if VERBOSE:
-        print '  shard %d: %d values' % (i, len(shard.results))
+        print('  shard %d: %d values' % (i, len(shard.results)))
         for value, count in shard.results:
 
-          print '    %s: count=%d' % (value, count)
+          print('    %s: count=%d' % (value, count))
       shards.append(shard)
 
     # Get correct fully merged result:
@@ -276,19 +276,19 @@ def test(staticSeedIn, seedIn):
       #topN = r.randint(1, 1000)
       #topN = 2
       if VERBOSE:
-        print '  iter: topN=%d' % topN
+        print('  iter: topN=%d' % topN)
 
       expected = allResults[:topN]
       actual, iterCount = merge(shards, topN)
       assert iterCount > 0
       
       if VERBOSE:
-        print '    expected'
+        print('    expected')
         for value, count in expected:
-          print '      %s: count=%d' % (value, count)
-        print '    actual [%d iters]' % iterCount
+          print('      %s: count=%d' % (value, count))
+        print('    actual [%d iters]' % iterCount)
         for value, count in actual:
-          print '      %s: count=%d' % (value, count)
+          print('      %s: count=%d' % (value, count))
 
       iterCounts[topN] = iterCounts.get(topN, 0) + iterCount
 
@@ -299,9 +299,9 @@ def test(staticSeedIn, seedIn):
       break
 
     if cycles > 0 and cycles % 10 == 0:
-      print '  iterCounts:'
+      print('  iterCounts:')
       for topN in xrange(1, numFacetValues+3):
-        print '    %d: %.1f' % (topN, float(iterCounts[topN])/cycles)
+        print('    %d: %.1f' % (topN, float(iterCounts[topN])/cycles))
 
     cycles += 1
 
@@ -371,7 +371,7 @@ if __name__ == '__main__':
     raise RuntimeError('please run python without -O')
   VERBOSE = '-verbose' in sys.argv
   staticSeed = seed = None
-  print 'argv %s' % sys.argv
+  print('argv %s' % sys.argv)
   for i in xrange(len(sys.argv)):
     if sys.argv[i] == '-seed':
       staticSeed, seed = sys.argv[1+1].split(':')

--- a/src/python/mergeViz.py
+++ b/src/python/mergeViz.py
@@ -82,8 +82,8 @@ def main():
   MAX_SEG_COUNT += 2
   MAX_SEG_SIZE_MB = 100*math.ceil((MAX_SEG_SIZE_MB*1.1)/100.0) + 50.0
 
-  print 'MAX seg MB %s' % MAX_SEG_SIZE_MB
-  print '%d events' % len(merges)
+  print('MAX seg MB %s' % MAX_SEG_SIZE_MB)
+  print('%d events' % len(merges))
     
   mergeToColor = {}
   segToMBAndDel = {}
@@ -102,22 +102,22 @@ def main():
     if lastT is not None:
       gap = t - lastT
       if gap > 2 and len(merges)-i < 6:
-        print 'FILL gap=%s' % gap
+        print('FILL gap=%s' % gap)
         delta = (t-lastT)/(gap*5.0)
         t0 = lastT
-        for x in xrange(gap*5):
+        for _ in xrange(gap*5):
           t0 += delta
-          print ' fake t %s' % (t0-minT)
+          print(' fake t %s' % (t0-minT))
           img, mergeToColor = draw(t0, segs, mergeToColor, newestSeg, totMergeMB)
           img.save('%s/%08d.png' % (TMP_DIR, upto))
           upto += 1
     lastT = t
     
-    print '%s: %s/%s' % (t-minT, i, len(merges))
+    print('%s: %s/%s' % (t-minT, i, len(merges)))
     #print ev
     if ev[0] == 'index':
       segs = ev[2]
-      for seg, fullMB, delPCT in segs:
+      for seg, fullMB, _ in segs:
         if seg not in segToMBAndDel:
           newestSeg = seg
         segToMBAndDel[seg] = (fullMB, delPct)
@@ -164,7 +164,7 @@ def main():
          '-o',
          '%s' % outputFile]
   os.spawnvp(os.P_WAIT, 'mencoder', cmd)
-  print 'DONE'
+  print('DONE')
 
 tMin = None
 def draw(t, segs, mergeToColor, rightSegment, totMergeMB):
@@ -284,7 +284,7 @@ def parse(fileName):
                 fullSize = undelSize / (1.0 - delRatio)
               else:
                 # total guess!
-                print 'WARNING: total guess!'
+                print('WARNING: total guess!')
                 fullSize = 0.1
             else:
               fullSize = undelSize

--- a/src/python/mergeViz.py
+++ b/src/python/mergeViz.py
@@ -15,11 +15,9 @@
 
 import os
 import math
-import ImageDraw
-import Image
+from PIL import ImageDraw, Image, ImageFont
 import sys
 import re
-import ImageFont
 
 #install using pip: sudo pip install iso8601
 import iso8601

--- a/src/python/nightlyCompile.py
+++ b/src/python/nightlyCompile.py
@@ -73,7 +73,7 @@ def main():
     os.chdir(constants.BENCH_BASE_DIR)
     for _ in range(30):
       try:
-        runCommand('hg pull -u > hgupdate.log');
+        runCommand('hg pull -u > hgupdate.log')
       except RuntimeError:
         message('  retry...')
         time.sleep(60.0)

--- a/src/python/nightlyCompile.py
+++ b/src/python/nightlyCompile.py
@@ -54,7 +54,7 @@ def toSeconds(td):
   return td.days * 86400 + td.seconds + td.microseconds/1000000.
 
 def message(s):
- print '[%s] %s' % (now(), s)
+ print('[%s] %s' % (now(), s))
 
 def runCommand(command):
   if REAL:
@@ -71,7 +71,7 @@ def main():
   
   if True:
     os.chdir(constants.BENCH_BASE_DIR)
-    for i in range(30):
+    for _ in range(30):
       try:
         runCommand('hg pull -u > hgupdate.log');
       except RuntimeError:
@@ -90,7 +90,7 @@ def main():
 
     runCommand('svn cleanup')
     open('update.log', 'ab').write('\n\n[%s]: update' % datetime.datetime.now())
-    for i in range(30):
+    for _ in range(30):
       try:
         runCommand('svn update > update.log 2>&1')
       except RuntimeError:
@@ -98,7 +98,7 @@ def main():
         time.sleep(60.0)
       else:
         svnRev = int(reSVNRev.search(open('update.log', 'rb').read()).group(1))
-        print 'SVN rev is %s' % svnRev
+        print('SVN rev is %s' % svnRev)
         break
     else:
       raise RuntimeError('svn update failed')
@@ -122,7 +122,7 @@ def main():
 
 def sendEmail(emailAddress, message):
   if localpass is None:
-    print 'WARNING: no smtp password; skipping email'
+    print('WARNING: no smtp password; skipping email')
     return
   SMTP_SERVER = localpass.SMTP_SERVER
   SMTP_PORT = localpass.SMTP_PORT

--- a/src/python/nrtPerf.py
+++ b/src/python/nrtPerf.py
@@ -45,7 +45,7 @@ def runOne(classpath, data, docsPerSec, reopensPerSec, fullIndexPath,
            statsEverySec=1,
            commit="no"):
   logFileName = '%s/%s_dps%s_reopen%s.txt' % (constants.LOGS_DIR, mode, docsPerSec, reopensPerSec)
-  print 'log: %s' % logFileName
+  print('log: %s' % logFileName)
   
   command = constants.JAVA_COMMAND
   command += ' -cp "%s"' % classpath
@@ -68,13 +68,13 @@ def runOne(classpath, data, docsPerSec, reopensPerSec, fullIndexPath,
   command += ' > %s 2>&1' % logFileName
 
   if VERBOSE:
-    print
-    print 'run: %s' % command
+    print()
+    print('run: %s' % command)
   
   os.system(command)
   result = open(logFileName, 'rb').read()
   if VERBOSE:
-    print result
+    print(result)
 
   try:
     reopenStats = ReopenStats()
@@ -104,23 +104,23 @@ def runOne(classpath, data, docsPerSec, reopensPerSec, fullIndexPath,
     times.sort()
     numDrop = len(times)/50
     if numDrop > 0:
-      print 'drop: %s' % ' '.join(['%.1f' % x for x in times[-numDrop:]])
+      print('drop: %s' % ' '.join(['%.1f' % x for x in times[-numDrop:]]))
       times = times[:-numDrop]
     if VERBOSE:
-      print 'times: %s' % ' '.join(['%.1f' % x for x in times])
+      print('times: %s' % ' '.join(['%.1f' % x for x in times]))
   
     minVal, maxVal, mean, stdDev = stats.getStats(times)
     reopenStats.meanReopenTime = mean
     reopenStats.stddevReopenTime = stdDev
 
     if VERBOSE:
-      print 'reopen stats:'
+      print('reopen stats:')
       reopenStats.toString()
       print
     
     return reopenStats
   except:
-    print 'FAILED -- output:\n%s' % result
+    print('FAILED -- output:\n%s' % result)
     raise
 
 class ReopenStats:
@@ -135,14 +135,14 @@ class ReopenStats:
     self.qtCount = 0
 
   def toString(self):
-    print 'meanReopenTime=%s stdReopenTime=%s qtCount=%s totalDocs=%s totalReopen=%s totalSearches=%s totalUpdateTime=%s' % \
+    print('meanReopenTime=%s stdReopenTime=%s qtCount=%s totalDocs=%s totalReopen=%s totalSearches=%s totalUpdateTime=%s' % \
             (self.meanReopenTime,
              self.stddevReopenTime,
              self.qtCount,
              self.totalDocs,
              self.totalReopens,
              self.totalSearches,
-             self.totalUpdateTime)
+             self.totalUpdateTime))
     
 if __name__ == '__main__':
     
@@ -180,9 +180,9 @@ if __name__ == '__main__':
     allStats = []
     for dps in docsPerSec.split(','):
       for rps in reopenPerSec.split(','):
-        print
-        print 'params: mode=%s docs/sec=%s reopen/sec=%s runTime(s)=%s searchThreads=%s indexThreads=%s' \
-                % (mode, dps, rps, runTimeSec, numSearchThreads, numIndexThreads)
+        print()
+        print('params: mode=%s docs/sec=%s reopen/sec=%s runTime(s)=%s searchThreads=%s indexThreads=%s' \
+                % (mode, dps, rps, runTimeSec, numSearchThreads, numIndexThreads))
         reopenStats = runOne(classpath=cp,
                              mode=mode,
                              data=sourceData,
@@ -197,8 +197,8 @@ if __name__ == '__main__':
 
     print
     header = 'docs/s reopen/s reopen(ms) update(ms)  total(ms) perdoc(ms) query/s run(sec)'
-    print '%s' % mode.center(len(header))
-    print header
+    print('%s' % mode.center(len(header)))
+    print(header)
     for s in allStats:
       reopenStats = s[3]
       meanReopenMS = reopenStats.meanReopenTime
@@ -206,7 +206,7 @@ if __name__ == '__main__':
       totalPerReopen = meanReopenMS + meanUpdateMS
       avgPerDoc = 0 if reopenStats.totalReopens == 0 else totalPerReopen / (float(reopenStats.totalDocs) / reopenStats.totalReopens)
       qps = 0 if int(numSearchThreads) == 0 else (float(reopenStats.totalSearches) / reopenStats.qtCount) / int(numSearchThreads)
-      print '%6s %8s %10s %10s %10s %10s %7s %8s' % \
+      print('%6s %8s %10s %10s %10s %10s %7s %8s' % \
             (s[0],
              s[1],
              "{:,.2f}".format(meanReopenMS),
@@ -214,4 +214,4 @@ if __name__ == '__main__':
              "{:,.2f}".format(totalPerReopen),
              "{:,.2f}".format(avgPerDoc),
              "{:,.2f}".format(qps),
-             s[2])
+             s[2]))

--- a/src/python/regold_nightly.py
+++ b/src/python/regold_nightly.py
@@ -3,8 +3,6 @@ import shutil
 import os
 import constants
 import nightlyBench
-import glob
-import re
 import sys
 
 # Simple tool that attempts to regold the last (partially failed) nightly benchy run.  It can

--- a/src/python/remoteTestServer.py
+++ b/src/python/remoteTestServer.py
@@ -163,7 +163,7 @@ class Parent:
     self.children = []
     self.jobLock = threading.Lock()
 
-    print 'REMOTE SERVER STARTED'
+    print('REMOTE SERVER STARTED')
     #self.remotePrint('python version is %s' % sys.version)
 
     for childID in xrange(processCount):

--- a/src/python/remoteTestServer.py
+++ b/src/python/remoteTestServer.py
@@ -1,9 +1,7 @@
 import copy
 import os
 import codecs
-import random
 import time
-import socket
 import threading
 import subprocess
 import cPickle

--- a/src/python/repeatLuceneTest.py
+++ b/src/python/repeatLuceneTest.py
@@ -21,7 +21,6 @@ import time
 import datetime
 import os
 import sys
-import random
 import common
 import constants
 import re

--- a/src/python/responseTimeGraph.py
+++ b/src/python/responseTimeGraph.py
@@ -76,7 +76,7 @@ def loadResults(file, sort=True):
 
   actualQPS = len(results) / endTime
 
-  print '%s: actualQPS=%s endTime=%s len(results)=%d netHitCount=%s' % (file, actualQPS, endTime, len(results), netHitCount)
+  print('%s: actualQPS=%s endTime=%s len(results)=%d netHitCount=%s' % (file, actualQPS, endTime, len(results), netHitCount))
   return results, actualQPS
 
 pctPointsCache = {}
@@ -93,8 +93,8 @@ def getPctPoints(fileName, name, warmupSec):
       upto += 1
 
     # TODO: use HdrHisto to get all pct points?
-    print '%s: %d results (less %d = first %.1f seconds warmup); %.1f sec' % \
-          (name, len(results), upto, warmupSec, results[-1][0]-warmupSec)
+    print('%s: %d results (less %d = first %.1f seconds warmup); %.1f sec' % \
+          (name, len(results), upto, warmupSec, results[-1][0]-warmupSec))
     results = results[upto:]
 
     # Find time when test finally finished:
@@ -106,7 +106,7 @@ def getPctPoints(fileName, name, warmupSec):
     col = []
     col.append(responseTimes[0])
     didMax = False
-    for row, (pct, minCount) in enumerate(logPoints):
+    for _, (pct, minCount) in enumerate(logPoints):
       if len(responseTimes) < minCount:
         break
       idx = int(((100.0-pct)/100.0)*len(responseTimes))
@@ -120,8 +120,8 @@ def getPctPoints(fileName, name, warmupSec):
     if not didMax:
       #print 'max %s vs %s' % (responseTimes[-1], col[-1])
       col.append(responseTimes[-1])
-    print '  %d pct points' % len(col)
-    print '  %s' % col
+    print('  %d pct points' % len(col))
+    print('  %s' % col)
     pctPointsCache[fileName] = col, actualQPS, endTimeSec
     
   return pctPointsCache[fileName]
@@ -141,7 +141,7 @@ def createGraph(fileNames, warmupSec, title=None):
     col = getPctPoints(file, name, warmupSec)[0]
 
     if False and col[-1] > 100000 and len(fileNames) > 1:
-      print '  skip: max responseTime=%s' % col[-1]
+      print('  skip: max responseTime=%s' % col[-1])
       continue
 
     cols.append(col)
@@ -228,11 +228,11 @@ if __name__ == '__main__':
     upto = 0
     while results[upto][0] < 300.0:
       upto += 1
-    print 'upto %s' % upto
+    print('upto %s' % upto)
     for tup in results[upto:]:
-      print tup
+      print(tup)
       if tup[2] > 50000:
-        print '  ***'
+        print('  ***')
     sys.exit(0)
 
   logsDir = sys.argv[1]
@@ -248,5 +248,5 @@ if __name__ == '__main__':
 
   html = createGraph(d, warmupSec)
   open(fileNameOut, 'wb').write(html)
-  print 'Saved to %s' % fileNameOut
+  print('Saved to %s' % fileNameOut)
     

--- a/src/python/responseTimeTests.py
+++ b/src/python/responseTimeTests.py
@@ -31,7 +31,7 @@ import smtplib
 
 def usage():
   print
-  print 'Usage: python -u %s -config <config>.py [-smoke]' % sys.argv[0]
+  print('Usage: python -u %s -config <config>.py [-smoke]' % sys.argv[0])
   print
   sys.exit(1)
 
@@ -73,60 +73,60 @@ class Tee(object):
     self.orig.write(data)
 
 def captureEnv(logsDir):
-  print
-  print 'Started: %s' % datetime.datetime.now()
-  print 'Python version: %s' % sys.version
+  print()
+  print('Started: %s' % datetime.datetime.now())
+  print('Python version: %s' % sys.version)
   svnRev = os.popen('svnversion %s' % LUCENE_HOME).read().strip()
-  print 'Lucene svn rev is %s (%s)' % (svnRev, LUCENE_HOME)
+  print('Lucene svn rev is %s (%s)' % (svnRev, LUCENE_HOME))
   if svnRev.endswith('M'):
     if system('svn diff %s > %s/lucene.diffs 2>&1' % (LUCENE_HOME, logsDir)):
       raise RuntimeError('svn diff failed')
-    os.chmod('%s/lucene.diffs' % logsDir, 0444)
+    os.chmod('%s/lucene.diffs' % logsDir, o0444)
 
   luceneUtilDir = os.path.abspath(os.path.split(sys.argv[0])[0])
 
   luceneUtilRev = os.popen('hg id %s' % luceneUtilDir).read().strip()  
-  print 'Luceneutil hg rev is %s (%s)' % (luceneUtilRev, luceneUtilDir)
+  print('Luceneutil hg rev is %s (%s)' % (luceneUtilRev, luceneUtilDir))
   if luceneUtilRev.find('+') != -1:
     if system('hg diff %s > %s/luceneutil.diffs 2>&1' % (luceneUtilDir, logsDir)):
       raise RuntimeError('hg diff failed')
-    os.chmod('%s/luceneutil.diffs' % logsDir, 0444)
+    os.chmod('%s/luceneutil.diffs' % logsDir, o0444)
 
   for fileName in ('responseTimeTests.py', TASKS_FILE, configFile):
     shutil.copy('%s/%s' % (luceneUtilDir, fileName),
                 '%s/%s' % (logsDir, fileName))
-    os.chmod('%s/%s' % (logsDir, fileName), 0444)
+    os.chmod('%s/%s' % (logsDir, fileName), o0444)
 
   for fileName in ('/sys/kernel/mm/transparent_hugepage/enabled',
                    '/sys/kernel/mm/redhat_transparent_hugepage/enabled'):
     if os.path.exists(fileName):
       s = open(fileName, 'rb').read().strip()
-      print 'Transparent huge pages @ %s: currently %s' % (fileName, s)
+      print('Transparent huge pages @ %s: currently %s' % (fileName, s))
       if not ENABLE_THP:
         if s.find('[never]') == -1:
           open(fileName, 'wb').write('never')
-          print '  now setting to [never]...'
+          print('  now setting to [never]...')
         else:
-          print '  already disabled'
+          print('  already disabled')
       else:
         if s.find('[always]') == -1:
           open(fileName, 'wb').write('always')
-          print '  now setting to [always]...'
+          print('  now setting to [always]...')
         else:
-          print '  already enabled'
+          print('  already enabled')
         
 def kill(name, p):
   while True:
     for l in os.popen('ps ww | grep %s | grep -v grep | grep -v /bin/sh' % name).readlines():
       l2 = l.strip().split()
       pid = int(l2[0])
-      print '  stop %s process %s: %s' % (name, pid, l.strip())
+      print('  stop %s process %s: %s' % (name, pid, l.strip()))
       try:
         os.kill(pid, signal.SIGKILL)
-      except OSError, e:
-        print '    OSError: %s' % str(e)
+      except OSError as e:
+        print('    OSError: %s' % str(e))
     if p.poll() is not None:
-      print '  done killing "%s"' % name
+      print('  done killing "%s"' % name)
       return
     time.sleep(2.0)
     
@@ -146,7 +146,7 @@ class TopThread(threading.Thread):
         # ps axuw | sed "1 d" | sort -n -r -k3 | head
 
         # Run top every 3 sec:
-        for i in xrange(6):
+        for _ in xrange(6):
           if self.stop:
             break
           time.sleep(0.5)
@@ -187,7 +187,7 @@ def system(command):
   p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
   output = p.communicate()[0].strip()
   if len(output) > 0:
-    print '  %s' % output.replace('\n', '\n  ')
+    print('  %s' % output.replace('\n', '\n  '))
   return p.returncode
 
 def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
@@ -197,9 +197,9 @@ def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
   else:
     details = ''
 
-  print
-  print '%s: config=%s, dir=%s, postingsFormat=%s, QPS=%s %s' % \
-        (datetime.datetime.now(), desc, dirImpl, postingsFormat, targetQPS, details)
+  print()
+  print('%s: config=%s, dir=%s, postingsFormat=%s, QPS=%s %s' % \
+        (datetime.datetime.now(), desc, dirImpl, postingsFormat, targetQPS, details))
 
   logsDir = '%s/%s.%s.%s.qps%s' % (LOGS_DIR, desc, dirImpl, postingsFormat, targetQPS)
   if pct is not None:
@@ -218,7 +218,7 @@ def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
     if DO_STOP_START_ZST:
       while True:
         if system('sudo service zing-memory start 2>&1'):
-          print 'Failed to start zing-memory... retry; java processes:'
+          print('Failed to start zing-memory... retry; java processes:')
           system('ps axuw | grep java')
           time.sleep(2.0)
         else:
@@ -228,7 +228,7 @@ def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
     if DO_STOP_START_ZST:
       while True:
         if system('sudo service zing-memory stop 2>&1'):
-          print 'Failed to stop zing-memory... retry; java processes:'
+          print('Failed to stop zing-memory... retry; java processes:')
           system('ps axuw | grep java')
           time.sleep(2.0)
         else:
@@ -336,28 +336,28 @@ def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
     touchCmd = '%s -Xmx1g -cp .:$LUCENE_HOME/build/core/classes/java:$LUCENE_HOME/build/codecs/classes/java:$LUCENE_HOME/build/highlighter/classes/java:$LUCENE_HOME/build/test-framework/classes/java:$LUCENE_HOME/build/queryparser/classes/java:$LUCENE_HOME/build/suggest/classes/java:$LUCENE_HOME/build/analysis/common/classes/java:$LUCENE_HOME/build/grouping/classes/java perf.OpenCloseIndexWriter %s 2>&1'.replace('$LUCENE_HOME', LUCENE_HOME) % (javaCommand, indexPath)
     #print '  run %s' % touchCmd
     while True:
-      print '  clean index'
+      print('  clean index')
       if system(touchCmd):
-        print '   failed .. retry'
+        print('   failed .. retry')
         time.sleep(2.0)
       else:
         break
 
     t0 = time.time()
     vmstatProcess = subprocess.Popen('vmstat 1 > %s/vmstat.log 2>&1' % logsDir, shell=True)
-    print '  server command: %s' % command
+    print('  server command: %s' % command)
     p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
 
     if DO_ZV_ROBOT and desc.startswith('Zing'):
       cmd = '%s -Xmx1g -jar %s %s/ZVRobot %s/ZVRobot.prop > %s/ZVRobot.log 2>&1' % \
             (ORACLE_JVM, ZV_ROBOT_JAR, logsDir, os.path.split(ZV_ROBOT_JAR)[0], logsDir)
-      print '  ZVRobot command: %s' % cmd
+      print('  ZVRobot command: %s' % cmd)
       zvRobotProcess = subprocess.Popen(cmd, shell=True)
       del cmd
     else:
       zvRobotProcess = None
 
-    print '  wait for server startup...'
+    print('  wait for server startup...')
 
     time.sleep(2.0)
 
@@ -372,7 +372,7 @@ def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
         pass
       time.sleep(1.0)
 
-    print '  %.1f sec to start; start test now' % (time.time()-t0)
+    print('  %.1f sec to start; start test now' % (time.time()-t0))
 
     time.sleep(2.0)
 
@@ -387,15 +387,15 @@ def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
                 (REMOTE_CLIENT, TASKS_FILE, SERVER_HOST, SERVER_PORT, targetQPS, TASKS_PER_CAT, RUN_TIME_SEC)
       command = 'ssh %s@%s %s > %s/client.log 2>&1' % (CLIENT_USER, CLIENT_HOST, command, logsDir)
 
-      print '  client command: %s' % command
+      print('  client command: %s' % command)
       clientProcess = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
       output = clientProcess.communicate()[0].strip()
       if len(output) > 0:
-        print '  %s' % output.replace('\n', '\n  ')
+        print('  %s' % output.replace('\n', '\n  '))
       if clientProcess.returncode:
         raise RuntimeError('client failed; see %s/client.log' % logsDir)
 
-      print '  copy results.bin back...'
+      print('  copy results.bin back...')
       if system('scp %s@%s:results.bin %s > /dev/null 2>&1' % (CLIENT_USER, CLIENT_HOST, logsDir)):
         raise RuntimeError('scp results.bin failed')
 
@@ -409,10 +409,10 @@ def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
       f.close()
 
     t1 = time.time()
-    print '  test done (%.1f total sec)' % (t1-t0)
+    print('  test done (%.1f total sec)' % (t1-t0))
 
     if not SMOKE_TEST and (t1 - t0) > RUN_TIME_SEC * 1.30:
-      print '  marking this job finished'
+      print('  marking this job finished')
       finished = True
 
   finally:
@@ -422,7 +422,7 @@ def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
     if clientProcess is not None:
       kill('sendTasks.py', clientProcess)
       if not os.path.exists('%s/results.bin' % logsDir):
-        print '  copy results.bin back...'
+        print('  copy results.bin back...')
         system('scp %s@%s:results.bin %s > /dev/null 2>&1' % (CLIENT_USER, CLIENT_HOST, logsDir))
       
     if DO_ZV_ROBOT and zvRobotProcess is not None:
@@ -430,21 +430,21 @@ def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
     if topThread is not None:
       topThread.stop = True
       topThread.join()
-      print '  done stopping top'
+      print('  done stopping top')
 
   try:
     printAvgCPU('%s/top.log' % logsDir)
   except:
-    print 'WARNING: failed to compute avg CPU usage:'
+    print('WARNING: failed to compute avg CPU usage:')
     traceback.print_exc()
 
-  print '  done'
+  print('  done')
   open('%s/done' % logsDir, 'wb').close()
   if DO_EMAIL and os.path.getsize('%s/log.txt' % LOGS_DIR) < 5*1024*1024:
     try:
       emailResult(open('%s/log.txt' % LOGS_DIR).read(), 'Test RUNNING [%s]' % (datetime.datetime.now() - startTime))
     except:
-      print '  send email failed'
+      print('  send email failed')
       traceback.print_exc()
 
   return logsDir, finished
@@ -453,13 +453,13 @@ def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
 def run():
 
   if SMOKE_TEST:
-    print
-    print '***SMOKE_TEST***'
-    print
+    print()
+    print('***SMOKE_TEST***')
+    print()
 
   captureEnv(LOGS_DIR)
 
-  print 'Compile java sources...'
+  print('Compile java sources...')
   cmd = '%sc -Xlint -Xlint:deprecation -cp $LUCENE_HOME/build/core/classes/java:$LUCENE_HOME/build/highlighter/classes/java:$LUCENE_HOME/build/codecs/classes/java:$LUCENE_HOME/build/test-framework/classes/java:$LUCENE_HOME/build/queryparser/classes/java:$LUCENE_HOME/build/suggest/classes/java:$LUCENE_HOME/build/analysis/common/classes/java:$LUCENE_HOME/build/grouping/classes/java perf/Args.java perf/IndexThreads.java perf/OpenCloseIndexWriter.java perf/Task.java perf/CreateQueries.java perf/LineFileDocs.java perf/PKLookupPerfTest.java perf/RandomQuery.java perf/SearchPerfTest.java perf/TaskParser.java perf/Indexer.java perf/LocalTaskSource.java perf/PKLookupTask.java perf/RemoteTaskSource.java perf/SearchTask.java perf/TaskSource.java perf/IndexState.java perf/NRTPerfTest.java perf/RespellTask.java perf/ShowFields.java perf/TaskThreads.java perf/KeepNoCommitsDeletionPolicy.java' % ORACLE_JVM
   cmd = cmd.replace('$LUCENE_HOME', LUCENE_HOME)
 
@@ -467,10 +467,10 @@ def run():
     raise RuntimeError('compile failed')
 
   if CLIENT_HOST is not None:
-    print 'Copy sendTasks.py to client host %s' % CLIENT_HOST
+    print('Copy sendTasks.py to client host %s' % CLIENT_HOST)
     if system('scp sendTasks.py %s@%s: > /dev/null 2>&1' % (CLIENT_USER, CLIENT_HOST)):
       raise RuntimeError('copy sendTasks.py failed')
-    print 'Copy tasks file "%s" to client host %s' % (TASKS_FILE, CLIENT_HOST)
+    print('Copy tasks file "%s" to client host %s' % (TASKS_FILE, CLIENT_HOST))
     if system('scp %s %s@%s: > /dev/null 2>&1' % (TASKS_FILE, CLIENT_USER, CLIENT_HOST)):
       raise RuntimeError('copy sendTasks.py failed')
 
@@ -482,8 +482,8 @@ def run():
     maxQPS = {}
     reQPSOut = re.compile(r'; +([0-9\.]+) qps out')
     reQueueSize = re.compile(r'\[(\d+), (\d+)\]$')
-    print
-    print 'Find max QPS per job:'
+    print()
+    print('Find max QPS per job:')
     for job in JOBS:
       desc, dirImpl, postingsFormat = job
       logsDir = runOne(startTime, desc, dirImpl, postingsFormat, 'sweep')[0]
@@ -499,7 +499,7 @@ def run():
       # QPS out is avg of last 5 seconds ... make sure we only measure actual saturation
       qpsOut = qpsOut[5:]
       maxQPS[job] = sum(qpsOut)/len(qpsOut)
-      print '  QPS throughput=%.1f' % maxQPS[job]
+      print('  QPS throughput=%.1f' % maxQPS[job])
       if maxQPS[job] < 2*AUTO_QPS_START:
         raise RuntimeError('max QPS for job %s (= %s) is < 2*AUTO_QPS_START (= %s)' % \
                            (desc, maxQPS[job], AUTO_QPS_START))
@@ -554,9 +554,9 @@ def run():
 
   now = datetime.datetime.now()
 
-  print
-  print '%s: ALL DONE (elapsed time %s)' % (now, now - startTime)
-  print
+  print()
+  print('%s: ALL DONE (elapsed time %s)' % (now, now - startTime))
+  print()
 
 def printAvgCPU(topLog):
 
@@ -604,10 +604,10 @@ def printAvgCPU(topLog):
     pids.append((sum/count, minCPU, maxCPU, pid))
 
   pids.sort(reverse=True)
-  print '  CPU usage [%d CPU cores]' % cpuCoreCount
+  print('  CPU usage [%d CPU cores]' % cpuCoreCount)
   for avgCPU, minCPU, maxCPU, pid in pids:
     if maxCPU > 20:
-      print '    avg %7.2f%% CPU, min %7.2f%%, max %7.2f%% pid %s' % (avgCPU, minCPU, maxCPU, pid)
+      print('    avg %7.2f%% CPU, min %7.2f%%, max %7.2f%% pid %s' % (avgCPU, minCPU, maxCPU, pid))
 
 def emailResult(body, subject):
   fromAddress = toAddress = 'mail@mikemccandless.com'
@@ -629,9 +629,9 @@ def emailResult(body, subject):
       s.starttls()
       s.ehlo(fromAddress)
       localpass.smtplogin(s)
-    print 'sending mail...'
+    print('sending mail...')
     s.sendmail(fromAddress, (toAddress,), message)
-    print 'quitting smtp...'
+    print('quitting smtp...')
     s.quit()
   else:
     p = subprocess.Popen(["/usr/sbin/sendmail", "-t"], stdin=subprocess.PIPE)
@@ -665,7 +665,7 @@ def main():
         subject = 'Test SUCCESS'
       emailResult(open('%s/log.txt' % LOGS_DIR).read(), subject)
     logOut.close()
-    os.chmod('%s/log.txt' % LOGS_DIR, 0444)
+    os.chmod('%s/log.txt' % LOGS_DIR, o0444)
     del teeStdout
     del teeStderr
     

--- a/src/python/resultsToGraph.py
+++ b/src/python/resultsToGraph.py
@@ -1,6 +1,5 @@
 import socket
 import os
-import sys
 import re
 import time
 import constants

--- a/src/python/runAllTests.py
+++ b/src/python/runAllTests.py
@@ -88,7 +88,7 @@ reTime = re.compile(r'^Time: ([0-9\.]+)$', re.M)
 try:
   testTimes = cPickle.loads(open(TEST_TIMES_FILE, 'rb').read())
 except:
-  print 'WARNING: no test times:'
+  print('WARNING: no test times:')
   traceback.print_exc()
   testTimes = {}
 
@@ -128,12 +128,12 @@ def addJARs(path):
   
 def run(comment, cmd, logFile, printTime=False):
   t0 = time.time()
-  print comment
+  print(comment)
   if os.system('%s > %s 2>&1' % (cmd, logFile)):
-    print open(logFile).read()
+    print(open(logFile).read())
     raise RuntimeError('FAILED: %s' % cmd)
   if printTime:
-    print '  %.1f sec' % (time.time()-t0)
+    print('  %.1f sec' % (time.time()-t0))
 
 def estimateCost(testClass):
   try:
@@ -143,7 +143,7 @@ def estimateCost(testClass):
       t = 0.05
     return t
   except KeyError:
-    print 'NO COST: %s' % testClass
+    print('NO COST: %s' % testClass)
     return 1.0
 
 prLock = threading.Lock()
@@ -157,7 +157,7 @@ def aggTests(workQ, tests):
 
   pendingCost = 0
   lastWD = None
-  for cost, wd, test, classpath in tests:
+  for cost, wd, test, _ in tests:
 
     if len(tests0) > 0 and (lastWD != wd or DO_GATHER_TIMES or cost + pendingCost > COST_PER_JOB):
       #print 'JOB: %s, %s' % (pendingCost, ' '.join(tests0))
@@ -258,10 +258,10 @@ class RunThread:
               (self.tempDir, ROOT, ' '.join(job.tests))
 
         if 0:
-          print
-          print 'wd %s' % job.wd
-          print 'cp %s' % ':'.join(job.classpath)
-          print 'cmd %s' % cmd
+          print()
+          print('wd %s' % job.wd)
+          print('cp %s' % ':'.join(job.classpath))
+          print('cmd %s' % cmd)
 
         #open(logFile, 'ab').write('\nTESTS: cost=%.3f %s\n  CWD: %s\n  RUN: %s\n' % (job.cost, ' '.join(job.tests), job.wd, cmd))
         s = '\nTESTS: cost=%.3f %s\n  CWD: %s\n' % (job.cost, ' '.join(job.tests), job.wd)
@@ -302,7 +302,7 @@ class RunThread:
         if DO_GATHER_TIMES:
           m = reTime.search(output)
           if m is None:
-            print 'FAILED to parse time %s' % output
+            print('FAILED to parse time %s' % output)
             testTime = 1.0
           else:
             testTime = float(m.group(1))
@@ -380,7 +380,7 @@ for module in modules:
                          'org.apache.lucene.analysis.core.TestRandomChains',
                          'org.apache.lucene.analysis.core.TestAllAnalyzersHaveFactories',
                          'org.apache.lucene.analysis.core.TestFactories'):
-          print 'WARNING: skipping test %s' % testClass
+          print('WARNING: skipping test %s' % testClass)
           continue
 
         if doLucene:
@@ -413,7 +413,7 @@ if doSolr:
         fullFile = '%s/%s' % (dir, file)
         testClass = fullFile[strip:-5].replace('/', '.')
         if testClass in ('org.apache.solr.cloud.CloudStateUpdateTest', 'org.apache.solr.search.TestRealTimeGet', 'org.apache.solr.servlet.CacheHeaderTest', 'org.apache.solr.request.TestRemoteStreaming', 'org.apache.solr.handler.dataimport.TestSqlEntityProcessorDelta2'):
-          print 'WARNING: skipping test %s' % testClass
+          print('WARNING: skipping test %s' % testClass)
           continue
         # print '  %s' % testClass
         wd = '%s/solr/core/src/test/test-files' % ROOT
@@ -435,7 +435,7 @@ if doSolr:
                          'org.apache.solr.client.solrj.SolrExampleBinaryTest',
                          'org.apache.solr.client.solrj.embedded.SolrExampleStreamingBinaryTest',
                          'org.apache.solr.client.solrj.embedded.TestSolrProperties'):
-          print 'WARNING: skipping test %s' % testClass
+          print('WARNING: skipping test %s' % testClass)
           continue
         # print '  %s' % testClass
         wd = '%s/solr/solrj/src/test-files' % ROOT
@@ -482,7 +482,7 @@ if doSolr:
           fullFile = '%s/%s' % (dir, file)
           testClass = fullFile[strip:-5].replace('/', '.')
           if testClass in ('org.apache.solr.handler.clustering.DistributedClusteringComponentTest',):
-            print 'WARNING: skipping test %s' % testClass
+            print('WARNING: skipping test %s' % testClass)
             continue
           # print '  %s' % testClass
           #wd = '%s/solr/contrib/%s/src/test/resources' % (ROOT, contrib)
@@ -512,8 +512,8 @@ repeat = '-repeat' in sys.argv
 
 if 0:
   for cost, path, test, cp in tests:
-    print 'TEST: %s' % test
-  print 'Total %d tests' % len(tests)
+    print('TEST: %s' % test)
+  print('Total %d tests' % len(tests))
 
 pendingCost = 0
 workQ = WorkQueue()
@@ -523,11 +523,11 @@ aggTests(workQ, tests)
 for resource, threadCount in NUM_THREAD:
   if resource != 'local':
     cmd = '/usr/bin/rsync --delete -rtS %s -e "ssh -x -c arcfour -o Compression=no" --exclude=.svn/ --exclude="*.log" mike@%s:%s' % (ROOT, resource, constants.BASE_DIR)
-    print 'Copy to %s: %s' % (resource, cmd)
+    print('Copy to %s: %s' % (resource, cmd))
     t = time.time()
     if os.system(cmd):
       raise RuntimeError('rsync failed')
-    print '  %.1f sec' % (time.time()-t)
+    print('  %.1f sec' % (time.time()-t))
     os.system('ssh %s "rm -f %s/*.log"' % (resource, ROOT))
     os.system('ssh %s "killall java >& /dev/null"' % resource)
   else:
@@ -550,4 +550,4 @@ for thread in threads:
 if DO_GATHER_TIMES:
   open(TEST_TIMES_FILE, 'wb').write(cPickle.dumps(testTimes))
 
-print '\n%.1f sec [%d test suites]' % (time.time()-t0, totSuites)
+print('\n%.1f sec [%d test suites]' % (time.time()-t0, totSuites))

--- a/src/python/runAllTests.py
+++ b/src/python/runAllTests.py
@@ -2,7 +2,7 @@ import shutil
 import re
 import subprocess
 import traceback
-import cPickle
+import pickle
 import threading
 import os
 import heapq
@@ -86,7 +86,7 @@ TEST_ARGS = ' -Dtests.nightly=false -Dtests.iters=1 -Dtests.locale=random -Dtest
 reTime = re.compile(r'^Time: ([0-9\.]+)$', re.M)
 
 try:
-  testTimes = cPickle.loads(open(TEST_TIMES_FILE, 'rb').read())
+  testTimes = pickle.loads(open(TEST_TIMES_FILE, 'rb').read())
 except:
   print('WARNING: no test times:')
   traceback.print_exc()
@@ -548,6 +548,6 @@ for thread in threads:
   totSuites += thread.suiteCount
 
 if DO_GATHER_TIMES:
-  open(TEST_TIMES_FILE, 'wb').write(cPickle.dumps(testTimes))
+  open(TEST_TIMES_FILE, 'wb').write(pickle.dumps(testTimes))
 
 print('\n%.1f sec [%d test suites]' % (time.time()-t0, totSuites))

--- a/src/python/runRemoteTests.py
+++ b/src/python/runRemoteTests.py
@@ -6,7 +6,7 @@ import socket
 import constants
 import codecs
 import common
-import cPickle
+import pickle
 import os
 
 # TODO
@@ -135,7 +135,7 @@ class Remote(threading.Thread):
         msg('%s: %s' % (self.hostName, codecs.getdecoder('UTF8')(p.stdout.read(numBytes))[0]))
       elif command == 'READY':
         job = self.jobs.nextJob()
-        bytes = cPickle.dumps(job)
+        bytes = pickle.dumps(job)
         if job is not None:
           self.runningJobs[job] = time.time()
         else:
@@ -144,7 +144,7 @@ class Remote(threading.Thread):
         p.stdin.write(bytes)
       elif command == 'RESUL':
         numBytes = int(p.stdout.read(8))
-        job, msec, errors = cPickle.loads(p.stdout.read(numBytes))
+        job, msec, errors = pickle.loads(p.stdout.read(numBytes))
         del self.runningJobs[job]
         self.finishedJobs.add(job)
 
@@ -179,7 +179,7 @@ class Stats:
 
   def __init__(self):
     try:
-      self.testTimes = cPickle.loads(open(TEST_TIMES_FILE, 'rb').read())
+      self.testTimes = pickle.loads(open(TEST_TIMES_FILE, 'rb').read())
     except:
       print('WARNING: no test times:')
       self.testTimes = {}
@@ -199,7 +199,7 @@ class Stats:
 
   def save(self):
     print('Saved stats...')
-    open(TEST_TIMES_FILE, 'wb').write(cPickle.dumps(self.testTimes))
+    open(TEST_TIMES_FILE, 'wb').write(pickle.dumps(self.testTimes))
 
   def estimateCost(self, className):
     if className == 'org.apache.lucene.util.packed.TestPackedInts':

--- a/src/python/runRemoteTests.py
+++ b/src/python/runRemoteTests.py
@@ -1,4 +1,3 @@
-import random
 import sys
 import threading
 import time

--- a/src/python/runRemoteTests.py
+++ b/src/python/runRemoteTests.py
@@ -41,18 +41,18 @@ def msg(message):
   with printLock:
     lastPrint = time.time()
     if VERBOSE:
-      print '%.3fs: %s' % (time.time()-tStart, message)
+      print('%.3fs: %s' % (time.time()-tStart, message))
     else:
-      print message
+      print(message)
 
 def run(comment, cmd, logFile, printTime=False):
   t0 = time.time()
-  print comment
+  print(comment)
   if os.system('%s > %s 2>&1' % (cmd, logFile)):
-    print open(logFile).read()
+    print(open(logFile).read())
     raise RuntimeError('FAILED: %s' % cmd)
   if printTime:
-    print '  %.1f sec' % (time.time()-t0)
+    print('  %.1f sec' % (time.time()-t0))
 
 class Remote(threading.Thread):
 
@@ -182,7 +182,7 @@ class Stats:
     try:
       self.testTimes = cPickle.loads(open(TEST_TIMES_FILE, 'rb').read())
     except:
-      print 'WARNING: no test times:'
+      print('WARNING: no test times:')
       self.testTimes = {}
 
   def update(self, className, msec):
@@ -192,14 +192,14 @@ class Stats:
     l[0] += msec
     l[1] += msec*msec
     if msec - l[2] > 2.0:
-      print
-      print '%.2fs -> %.2fs: %s' % (l[2], msec, className)
-      print
+      print()
+      print('%.2fs -> %.2fs: %s' % (l[2], msec, className))
+      print()
     l[2] = max(l[2], msec)
     l[3] += 1
 
   def save(self):
-    print 'Saved stats...'
+    print('Saved stats...')
     open(TEST_TIMES_FILE, 'wb').write(cPickle.dumps(self.testTimes))
 
   def estimateCost(self, className):
@@ -292,7 +292,7 @@ def gatherTests(stats, rootDir):
 
   os.chdir(rootDir)
   
-  print 'ROOT %s' % rootDir
+  print('ROOT %s' % rootDir)
 
   if '-noc' not in sys.argv:
     os.chdir('%s/lucene' % rootDir)
@@ -357,13 +357,13 @@ def gatherTests(stats, rootDir):
           addCP('lucene/%s/%s' % (libDir, f))
 
     strip = len(rootDir) + len('/lucene/%s/src/test/' % module)
-    for dir, subDirs, files in os.walk('%s/src/test' % path):
+    for dir, _, files in os.walk('%s/src/test' % path):
       for file in files:
         if file.endswith('.java') and (file.startswith('Test') or file.endswith('Test.java')):
           fullFile = '%s/%s' % (dir, file)
           testClass = fullFile[strip:-5].replace('/', '.')
           if testClass in FLAKY_TESTS:
-            print 'WARNING: skipping test %s' % testClass
+            print('WARNING: skipping test %s' % testClass)
             continue
 
           tests.append((stats.estimateCost(testClass), testClass))
@@ -383,27 +383,27 @@ def gatherTests(stats, rootDir):
     addCP('solr/core/src/test-files')
 
     strip = len(rootDir) + len('/solr/core/src/test/')
-    for dir, subDirs, files in os.walk('%s/solr/core/src/test' % rootDir):
+    for dir, _, files in os.walk('%s/solr/core/src/test' % rootDir):
       for file in files:
         if file.endswith('.java') and (file.startswith('Test') or file.endswith('Test.java')):
 
           fullFile = '%s/%s' % (dir, file)
           testClass = fullFile[strip:-5].replace('/', '.')
           if testClass in FLAKY_TESTS:
-            print 'WARNING: skipping test %s' % testClass
+            print('WARNING: skipping test %s' % testClass)
             continue
           tests.append((stats.estimateCost(testClass), testClass))
 
     # solrj
     strip = len(rootDir) + len('/solr/solrj/src/test/')
-    for dir, subDirs, files in os.walk('%s/solr/solrj/src/test' % rootDir):
+    for dir, _, files in os.walk('%s/solr/solrj/src/test' % rootDir):
       for file in files:
         if file.endswith('.java') and (file.startswith('Test') or file.endswith('Test.java')):
 
           fullFile = '%s/%s' % (dir, file)
           testClass = fullFile[strip:-5].replace('/', '.')
           if testClass in FLAKY_TESTS:
-            print 'WARNING: skipping test %s' % testClass
+            print('WARNING: skipping test %s' % testClass)
             continue
           # print '  %s' % testClass
           tests.append((stats.estimateCost(testClass), testClass))
@@ -424,16 +424,15 @@ def gatherTests(stats, rootDir):
       addCP('solr/build/contrib/solr-%s/test-files' % contrib2)
       addCP('solr/contrib/%s/src/resources' % contrib)
 
-      s = contrib
       libDir = 'solr/contrib/%s/lib' % contrib
       addJARs(cp, libDir)
-      for dir, subDirs, files in os.walk('%s/solr/contrib/%s/src/test' % (rootDir, contrib)):
+      for dir, _, files in os.walk('%s/solr/contrib/%s/src/test' % (rootDir, contrib)):
         for file in files:
           if file.endswith('.java') and (file.startswith('Test') or file.endswith('Test.java')):
             fullFile = '%s/%s' % (dir, file)
             testClass = fullFile[strip:-5].replace('/', '.')
             if testClass in FLAKY_TESTS:
-              print 'WARNING: skipping test %s' % testClass
+              print('WARNING: skipping test %s' % testClass)
               continue
             # print '  %s' % testClass
             #wd = '%s/solr/contrib/%s/src/test/resources' % (ROOT, contrib)
@@ -441,9 +440,9 @@ def gatherTests(stats, rootDir):
 
   tests.sort(reverse=True)
   if False:
-    print 'Top slowest tests:'
+    print('Top slowest tests:')
     for idx in xrange(20):
-      print '  %5.1f sec: %s' % tests[idx]
+      print('  %5.1f sec: %s' % tests[idx])
   return cp, tests
 
 def main():
@@ -455,12 +454,12 @@ def main():
   stats = Stats()
   
   classpath, tests = gatherTests(stats, rootDir)
-  print '%d test suites' % len(tests)
+  print('%d test suites' % len(tests))
 
   if False:
-    print 'CP:'
+    print('CP:')
     for x in classpath:
-      print '  %s' % x
+      print('  %s' % x)
 
   try:
     SEED = sys.argv[1+sys.argv.index('-seed')]
@@ -536,7 +535,7 @@ def main():
       x = '../../%s' % x
     classpath2.append(x)
   classpath = ':'.join(classpath2)
-  print 'CP: %s' % classpath
+  print('CP: %s' % classpath)
   jobs = Jobs(tests)
 
   tTestsStart = time.time()
@@ -608,11 +607,11 @@ def main():
   stats.save()
   print
   if anyFails:
-    print 'FAILED'
+    print('FAILED')
   else:
-    print 'SUCCESS'
-  print
-  print '%.1f sec' % (time.time()-tTestsStart)
+    print('SUCCESS')
+  print()
+  print('%.1f sec' % (time.time()-tTestsStart))
 
   for worker in workersOrig:
     print('  %s ran %d tests' % (worker.hostName, len(worker.finishedJobs)))

--- a/src/python/searchBench.py
+++ b/src/python/searchBench.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-import subprocess
 import sys
 import os
 import re

--- a/src/python/sendTasks.py
+++ b/src/python/sendTasks.py
@@ -17,13 +17,11 @@
 
 import cStringIO
 import random
-import codecs
 import socket
 import Queue
 import sys
 import time
 import threading
-import cPickle
 import gc
 import struct
 
@@ -162,7 +160,7 @@ class SendTasks:
       try:
         taskStartTime, taskString = self.sent[taskID]
       except KeyError:
-        print 'WARNING: ignore bad return taskID=%s' % taskID
+        print('WARNING: ignore bad return taskID=%s' % taskID)
         continue
       del self.sent[taskID]
       latencyMS = (endTime-taskStartTime)*1000
@@ -210,7 +208,6 @@ class SendTasks:
 
     while True:
       task = self.queue.get()
-      startTime = time.time()
       while len(task) > 0:
         sent = self.sock.send(task)
         if sent <= 0:
@@ -235,9 +232,6 @@ def pruneTasks(taskStrings, numTasksPerCat):
   
 def run(tasksFile, serverHost, serverPort, meanQPS, numTasksPerCat, runTimeSec, savFile, out, handleCtrlC):
 
-  recentLatencyMS = 0
-  recentQueueTimeMS = 0
-  
   out.write('Mean QPS %s\n' % meanQPS)
 
   f = open(tasksFile, 'rb')
@@ -246,7 +240,6 @@ def run(tasksFile, serverHost, serverPort, meanQPS, numTasksPerCat, runTimeSec, 
     l = f.readline()
     if l == '':
       break
-    orig = l
     idx = l.find('#')
     if idx != -1:
       l = l[:idx]
@@ -275,7 +268,7 @@ def run(tasksFile, serverHost, serverPort, meanQPS, numTasksPerCat, runTimeSec, 
 
   if meanQPS == 'sweep':
     doSweep = True
-    print 'Sweep: start at %s QPS' % SWEEP_START_QPS
+    print('Sweep: start at %s QPS' % SWEEP_START_QPS)
     meanQPS = SWEEP_START_QPS
     lastSweepCheck = time.time()
   else:
@@ -317,26 +310,26 @@ def run(tasksFile, serverHost, serverPort, meanQPS, numTasksPerCat, runTimeSec, 
       if doSweep:
         if t - lastSweepCheck > SWEEP_CHECK_EVERY_SEC:
           if meanQPS == SWEEP_START_QPS and len(tasks.sent) > 4:
-            print 'Sweep: stay @ %s QPS for warmup...' % SWEEP_START_QPS
+            print('Sweep: stay @ %s QPS for warmup...' % SWEEP_START_QPS)
           elif len(tasks.sent) < 10000:
             # Still not saturated
             meanQPS *= 2
-            print 'Sweep: set target to %.1f QPS' % meanQPS
+            print('Sweep: set target to %.1f QPS' % meanQPS)
           else:
             break
           lastSweepCheck = t
       elif t - tasks.startTime > runTimeSec:
         break
 
-    print 'Sent all tasks %d times.' % iters
+    print('Sent all tasks %d times.' % iters)
 
   except KeyboardInterrupt:
     if not handleCtrlC:
       raise
     # Ctrl-c to stop the test
-    print
-    print 'Ctrl+C: stopping now...'
-    print
+    print()
+    print('Ctrl+C: stopping now...')
+    print()
   
   out.write('%8.1f sec: Done sending tasks...\n' % (time.time()-tasks.startTime))
   out.flush()
@@ -357,7 +350,7 @@ def run(tasksFile, serverHost, serverPort, meanQPS, numTasksPerCat, runTimeSec, 
 
 def printResults(results):
   for startTime, taskString, latencyMS, queueTimeMS in results:
-    print '%8.3f sec: latency %8.1f msec; queue msec %.1f; task %s' % (startTime, latencyMS, queueTimeMS, taskString)
+    print('%8.3f sec: latency %8.1f msec; queue msec %.1f; task %s' % (startTime, latencyMS, queueTimeMS, taskString))
 
 if __name__ == '__main__':
   tasksFile = sys.argv[1]

--- a/src/python/sendTasks.py
+++ b/src/python/sendTasks.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cStringIO
+import io
 import random
 import socket
 import Queue
@@ -77,7 +77,7 @@ class Results:
 
   def __init__(self, savFile):
     self.buffers = []
-    self.current = cStringIO.StringIO()
+    self.current = io.StringIO()
     self.fOut = open(savFile, 'wb')
 
   def add(self, taskString, totalHitCount, timestamp, latencyMS, queueTimeMS):

--- a/src/python/skipper.py
+++ b/src/python/skipper.py
@@ -60,7 +60,7 @@ class SkipTower:
       if VERBOSE:
         print('  nextTower skipPos=%s nextLastDocID=%d' % (nextTower.writePointer, nextTower.lastDocID))
       delta = nextTower.writePointer - self.writePointer
-      assert delta > 0;
+      assert delta > 0
       b.writeVLong(delta)
       delta = nextTower.lastDocID - self.lastDocID
       assert delta > 0

--- a/src/python/skipper.py
+++ b/src/python/skipper.py
@@ -46,8 +46,8 @@ class SkipTower:
   def write(self, b, inlined, isFixed):
 
     if VERBOSE:
-      print 'SkipTower.write skipPos=%s numNext=%d lastDocID=%s' % \
-            (b.pos, len(self.nextTowers), self.lastDocID)
+      print('SkipTower.write skipPos=%s numNext=%d lastDocID=%s' % \
+            (b.pos, len(self.nextTowers), self.lastDocID))
 
     # TODO: we can avoid writing this when codec is fixed block size!:
     #       if not... we can usually use only maybe 2-3 bits?
@@ -58,7 +58,7 @@ class SkipTower:
       nextTower = self.nextTowers[downTo]
       downTo -= 1
       if VERBOSE:
-        print '  nextTower skipPos=%s nextLastDocID=%d' % (nextTower.writePointer, nextTower.lastDocID)
+        print('  nextTower skipPos=%s nextLastDocID=%d' % (nextTower.writePointer, nextTower.lastDocID))
       delta = nextTower.writePointer - self.writePointer
       assert delta > 0;
       b.writeVLong(delta)
@@ -87,7 +87,7 @@ class SkipWriter:
 
   def finish(self, numPostingsBytes, numDocs):
     if VERBOSE:
-      print 'numPostingsBytes=%s' % numPostingsBytes
+      print('numPostingsBytes=%s' % numPostingsBytes)
 
     # Add EOF tower:
     endTower = SkipTower(numDocs, NO_MORE_DOCS, numPostingsBytes,
@@ -100,8 +100,8 @@ class SkipWriter:
   def visit(self, docCount, lastDocID, pointer):
     if docCount - self.lastSkipDocCount >= self.skipInterval:
       if VERBOSE:
-        print '    save skip: docCount=%d lastDocID=%s pointer=%s' % \
-              (docCount, lastDocID, pointer)
+        print('    save skip: docCount=%d lastDocID=%s pointer=%s' % \
+              (docCount, lastDocID, pointer))
 
       tower = SkipTower(docCount, lastDocID, pointer, self.levelLastTowers[0])
       level = 0
@@ -127,8 +127,8 @@ def writeTowers(skipWriter, fixedDocGap, postingsBytes):
   global VERBOSE
 
   if VERBOSE:
-    print 'FIXED:'
-    print '  %s' % fixedDocGap
+    print('FIXED:')
+    print('  %s' % fixedDocGap)
 
   isFixed = fixedDocGap > 0
   
@@ -148,7 +148,7 @@ def writeTowers(skipWriter, fixedDocGap, postingsBytes):
   writePointer = 0
   b = ByteBufferWriter()
   if VERBOSE:
-    print 'WRITE'
+    print('WRITE')
   while tower is not None:
 
     if inlined:
@@ -156,11 +156,11 @@ def writeTowers(skipWriter, fixedDocGap, postingsBytes):
       assert chunk > 0
       writePointer -= chunk
       if VERBOSE:
-        print '  postings chunk %s' % chunk
+        print('  postings chunk %s' % chunk)
 
     if VERBOSE:
-      print '  tower @ pointer=%s lastDocID=%s docCount=%s' % \
-            (tower.pointer, tower.lastDocID, tower.docCount)
+      print('  tower @ pointer=%s lastDocID=%s docCount=%s' % \
+            (tower.pointer, tower.lastDocID, tower.docCount))
 
     # Guess:
     guessTowerNumBytes = towerNumBytes[len(tower.nextTowers)]
@@ -174,14 +174,14 @@ def writeTowers(skipWriter, fixedDocGap, postingsBytes):
         break
       else:
         if VERBOSE:
-          print '    tower retry'
+          print('    tower retry')
         tower.writePointer = actualWritePointer
         towerNumBytes[len(tower.nextTowers)] = len(tower.bytes)
 
     writePointer -= len(tower.bytes)
     if VERBOSE:
-      print '    towerNumBytes=%s' % len(tower.bytes)
-      print '    tower.writePointer=%s' % writePointer
+      print('    towerNumBytes=%s' % len(tower.bytes))
+      print('    tower.writePointer=%s' % writePointer)
 
     nextTower = tower
     tower = tower.prevTower
@@ -190,8 +190,8 @@ def writeTowers(skipWriter, fixedDocGap, postingsBytes):
   totalBytes = -writePointer
 
   if VERBOSE:
-    print 'totalBytes=%s' % totalBytes
-    print 'FINAL WRITE'
+    print('totalBytes=%s' % totalBytes)
+    print('FINAL WRITE')
     
   tower = skipWriter.tower0
 
@@ -201,7 +201,7 @@ def writeTowers(skipWriter, fixedDocGap, postingsBytes):
       # Interleave postings bytes in:
       chunk = postingsBytes[tower.prevTower.pointer : tower.pointer]
       if VERBOSE:
-        print '  postings: chunk %d bytes @ wp=%d' % (len(chunk), b.pos)
+        print('  postings: chunk %d bytes @ wp=%d' % (len(chunk), b.pos))
       assert len(chunk) > 0
       b.writeBytes(chunk)
 
@@ -209,15 +209,15 @@ def writeTowers(skipWriter, fixedDocGap, postingsBytes):
       break
     
     if VERBOSE:
-      print '  tower @ pointer=%s lastDocID=%s docCount=%s @ wp=%s (tower.wp=%s)' % \
-            (tower.pointer, tower.lastDocID, tower.docCount, b.pos, tower.writePointer)
+      print('  tower @ pointer=%s lastDocID=%s docCount=%s @ wp=%s (tower.wp=%s)' % \
+            (tower.pointer, tower.lastDocID, tower.docCount, b.pos, tower.writePointer))
 
     assert b.pos == totalBytes + tower.writePointer, \
            'wp=%s expected=%s tower.wp=%d' % (b.pos, totalBytes +
                                                  tower.writePointer, tower.writePointer)
     b.writeBytes(tower.bytes)
     if VERBOSE:
-      print '    tower %d bytes' % len(tower.bytes)
+      print('    tower %d bytes' % len(tower.bytes))
     tower.bytes = None
     tower = tower.nextTowers[0]
 
@@ -240,8 +240,8 @@ class SkipReader:
     firstTowerPos = b.pos
     self.maxNumLevels = b.readVInt()
     if VERBOSE:
-      print 'skipInterval %d' % self.skipInterval
-      print ' %d max skip levels' % self.maxNumLevels
+      print('skipInterval %d' % self.skipInterval)
+      print('%d max skip levels' % self.maxNumLevels)
 
     self.nextTowerLastDocIDs = []
     self.nextTowerPositions = []
@@ -261,8 +261,8 @@ class SkipReader:
   def readTower(self, pos, lastDocID, targetDocID):
     
     if VERBOSE:
-      print 'READ TOWER: pos=%s lastDocID=%s' % \
-            (pos, lastDocID)
+      print('READ TOWER: pos=%s lastDocID=%s' % \
+            (pos, lastDocID))
 
     self.lastDocID = lastDocID
     self.pendingDocCount = 0
@@ -278,7 +278,7 @@ class SkipReader:
            'numLevels %s vs maxNumLevels %s' % (numLevels, self.maxNumLevels)
     
     if VERBOSE:
-      print '  %d levels' % numLevels
+      print('  %d levels' % numLevels)
 
     # Towers are written highest to lowest:
     level = numLevels - 1
@@ -293,11 +293,11 @@ class SkipReader:
         self.nextTowerDocCounts[level] += self.fixedDocGaps[level]
       if VERBOSE:
         if isFixed:
-          print '  nextPos=%s nextLastDocId=%d nextDocCount=%d' % \
-                (self.nextTowerPositions[level], nextTowerLastDocID, self.nextTowerDocCounts[level])
+          print('  nextPos=%s nextLastDocId=%d nextDocCount=%d' % \
+                (self.nextTowerPositions[level], nextTowerLastDocID, self.nextTowerDocCounts[level]))
         else:
-          print '  nextPos=%s nextLastDocId=%d' % \
-                (self.nextTowerPositions[level], nextTowerLastDocID)
+          print('  nextPos=%s nextLastDocId=%d' % \
+                (self.nextTowerPositions[level], nextTowerLastDocID))
       if nextTowerLastDocID < targetDocID:
         # Early exit: we know we will skip on this level, so don't
         # bother decoding tower entries for any levels lower:
@@ -310,9 +310,9 @@ class SkipReader:
       self.pointer = self.b.readVLong()
 
     if VERBOSE:
-      print '  docCount=%d' % self.docCount
+      print('  docCount=%d' % self.docCount)
       if not self.inlined:
-        print '  pointer=%s' % self.pointer
+        print('  pointer=%s' % self.pointer)
 
     return -1
 
@@ -322,7 +322,7 @@ class SkipReader:
       if self.pendingDocCount >= self.skipInterval:
         assert self.fixedDocGap == 0 or self.fixedDocGap == self.pendingDocCount
         if VERBOSE:
-          print '  now skip tower pos=%s pendingDocCount=%s' % (self.b.pos, self.pendingDocCount)
+          print('  now skip tower pos=%s pendingDocCount=%s' % (self.b.pos, self.pendingDocCount))
         self.readTower(self.b.pos, lastDocID, lastDocID)
 
   def skip(self, targetDocID):
@@ -331,7 +331,7 @@ class SkipReader:
     level = 0
     while level < self.maxNumLevels and self.nextTowerLastDocIDs[level] < targetDocID:
       if VERBOSE:
-        print '  up to level %d' % (1+level)
+        print('  up to level %d' % (1+level))
       level += 1
 
     if level == 0:
@@ -436,7 +436,7 @@ class WholeIntAbsCodec:
     self.lastReadCount = 1
     return b.readInt()
 
-  def flush(self, b):
+  def flush(self, _):
     pass
 
   def reset(self):
@@ -463,7 +463,7 @@ class WholeIntDeltaCodec:
     self.lastReadCount = 1
     return lastDocID + b.readInt()
 
-  def flush(self, b):
+  def flush(self, _):
     pass
 
   def reset(self):
@@ -491,7 +491,7 @@ class VIntDeltaCodec:
     self.lastReadCount = 1
     return lastDocID + b.readVInt()
 
-  def flush(self, b):
+  def flush(self, _):
     pass
 
   def reset(self):
@@ -527,7 +527,7 @@ class FixedBlockVIntDeltaCodec:
       self.upto = 0
     delta = self.pending[self.upto]
     if VERBOSE:
-      print '  readDoc lastDocID=%d delta=%d' % (lastDocID, delta)
+      print('  readDoc lastDocID=%d delta=%d' % (lastDocID, delta))
     self.upto += 1
     return lastDocID + delta
 
@@ -535,18 +535,18 @@ class FixedBlockVIntDeltaCodec:
     if self.inlinedSkipData:
       self.skipper.skipSkipData(self.lastReadCount, lastDocID)
     if VERBOSE:
-      print '  readBlock @ b.pos=%s lastDocID=%s' % (b.pos, lastDocID)
+      print('  readBlock @ b.pos=%s lastDocID=%s' % (b.pos, lastDocID))
     numBytes = b.readVInt()
     if VERBOSE:
-      print '    numBytes=%d' % numBytes
+      print('    numBytes=%d' % numBytes)
     self.pending = []
     posStart = b.pos
-    for idx in xrange(self.blockSize):
+    for _ in xrange(self.blockSize):
       delta = b.readVInt()
       assert delta > 0
       self.pending.append(delta)
       if VERBOSE:
-        print '    delta=%d' % self.pending[-1]
+        print('    delta=%d' % self.pending[-1])
     self.lastReadCount = len(self.pending)
     assert b.pos-posStart == numBytes
 
@@ -556,10 +556,10 @@ class FixedBlockVIntDeltaCodec:
   def flush(self, b):
     # print 'flush'
     if VERBOSE:
-      print '  writeBlock @ b.pos=%s' % b.pos
+      print('  writeBlock @ b.pos=%s' % b.pos)
     for i in self.pending:
       if VERBOSE:
-        print '    delta=%d' % i
+        print('    delta=%d' % i)
       self.buffer.writeVInt(i)
     for i in xrange(len(self.pending), self.blockSize):
       # not used:
@@ -567,7 +567,7 @@ class FixedBlockVIntDeltaCodec:
     self.pending = []
     b.writeVInt(self.buffer.pos)
     if VERBOSE:
-      print '    numBytes=%d' % self.buffer.pos
+      print('    numBytes=%d' % self.buffer.pos)
     b.writeBytes(''.join(self.buffer.bytes))
     self.buffer.reset()
 
@@ -634,7 +634,7 @@ def main():
   else:
     seed = random.randint(0, sys.maxint)
   
-  print 'SEED %s' % seed
+  print('SEED %s' % seed)
   r = random.Random(seed)
 
   NUM_DOCS = r.randint(30000, 100000)
@@ -656,7 +656,7 @@ def main():
   sw = SkipWriter(skipInterval)
 
   inlined = r.randint(0, 1) == 1
-  print 'INLINED %s' % inlined
+  print('INLINED %s' % inlined)
 
   i = r.randint(0, 4)
 
@@ -673,13 +673,13 @@ def main():
     if False and VERBOSE:
       blockSize = 32
     #blockSize = 64
-    print 'blockSize %d' % blockSize
+    print('blockSize %d' % blockSize)
     
     codec = FixedBlockVIntDeltaCodec(blockSize, inlined)
   else:
     codec = VariableBlockVIntDeltaCodec(r, inlined)
 
-  print 'CODEC %s' % codec
+  print('CODEC %s' % codec)
 
   if isinstance(codec, VariableBlockVIntDeltaCodec):
     fixedDocGap = 0
@@ -688,14 +688,14 @@ def main():
   else:
     fixedDocGap = skipInterval
 
-  print 'numDocs %d' % NUM_DOCS
-  print 'skipInterval %d' % skipInterval
+  print('numDocs %d' % NUM_DOCS)
+  print('skipInterval %d' % skipInterval)
 
   # Non-block coded, fixed 4 byte per docID:
   docCount = 0
   for docID in docList:
     if VERBOSE:
-      print '  write docID=%d' % docID
+      print('  write docID=%d' % docID)
     oldPos = b.pos
     codec.writeDoc(b, docID)
     docCount += 1
@@ -717,26 +717,26 @@ def main():
     skipBytesReader = reader
 
     pct = 100.0*(len(allBytes)-len(postingsBytes))/len(postingsBytes)
-    print '  %.1f%% skip (%d skip bytes; %d postings bytes)' % \
-          (pct, len(allBytes)-len(postingsBytes), len(postingsBytes))
+    print('  %.1f%% skip (%d skip bytes; %d postings bytes)' % \
+          (pct, len(allBytes)-len(postingsBytes), len(postingsBytes)))
   else:
     skipBytes = writeTowers(sw, fixedDocGap, None)
     pct = 100.0*(len(skipBytes))/len(postingsBytes)
-    print '  %.1f%% skip (%d skip bytes; %d postings bytes)' % \
-          (pct, len(skipBytes), len(postingsBytes))
+    print('  %.1f%% skip (%d skip bytes; %d postings bytes)' % \
+          (pct, len(skipBytes), len(postingsBytes)))
     reader = ByteBufferReader(postingsBytes)
     skipBytesReader = ByteBufferReader(skipBytes)
   
   for iter in xrange(100):
     if VERBOSE:
       print
-      print 'ITER %s' % iter
+      print('ITER %s' % iter)
     reader.pos = 0
     skipBytesReader.pos = 0
 
     doSkipping = r.randint(0, 3) != 2
     if VERBOSE:
-      print '  doSkipping %s' % doSkipping
+      print('  doSkipping %s' % doSkipping)
     sr = SkipReader(skipBytesReader, inlined, skipInterval, fixedDocGap)
     codec.skipper = sr
     docIDX = 0
@@ -745,7 +745,7 @@ def main():
     while docIDX < len(docList):
 
       if VERBOSE:
-        print 'cycle docIDX=%d of %d, pos=%s' % (docIDX, len(docList), reader.pos)
+        print('cycle docIDX=%d of %d, pos=%s' % (docIDX, len(docList), reader.pos))
 
       if doSkipping and r.randint(0, 1) == 1:
         # randomly jump
@@ -758,7 +758,7 @@ def main():
         # TODO: also sometimes target a non-existent docID!
         
         if VERBOSE:
-          print '  try jump targetDocID=%d' % targetDocID
+          print('  try jump targetDocID=%d' % targetDocID)
         if sr.skip(targetDocID):
           # did jump
           if inlined or sr.pointer >= reader.pos:
@@ -771,7 +771,7 @@ def main():
                                  (reader.pos, len(reader.bytes)))
             codec.afterSeek()
             if VERBOSE:
-              print '  jumped!  lastDocID=%d pointer=%s docIDX=%s' % (lastDocID, reader.pos, docIDX)
+              print('  jumped!  lastDocID=%d pointer=%s docIDX=%s' % (lastDocID, reader.pos, docIDX))
 
             if lastDocID >= targetDocID:
               raise RuntimeError('jumped docID=%d is >= targetDocID=%d' % (lastDocID, targetDocID))
@@ -792,7 +792,7 @@ def main():
       docID = codec.readDoc(reader, lastDocID)
 
       if VERBOSE:
-        print '  docID=%d' % docID
+        print('  docID=%d' % docID)
 
       if docID != docList[docIDX]:
         raise RuntimeError('FAILED: docID %d but expected %d' % (docID, docList[docIDX]))

--- a/src/python/sparsetaxis/csvToBlocks.py
+++ b/src/python/sparsetaxis/csvToBlocks.py
@@ -1,6 +1,5 @@
 import struct
 import sys
-import datetime
 import io
 
 with open(sys.argv[1], 'r', encoding='utf-8') as f, open(sys.argv[2], 'wb') as fOut:

--- a/src/python/sparsetaxis/runBenchmark.py
+++ b/src/python/sparsetaxis/runBenchmark.py
@@ -2,7 +2,6 @@ import shutil
 import pickle
 import time
 import re
-import multiprocessing
 import subprocess
 import os
 import argparse

--- a/src/python/sparsetaxis/searchLogToHistogram.py
+++ b/src/python/sparsetaxis/searchLogToHistogram.py
@@ -1,5 +1,4 @@
 import sys
-import writeGraph
 import re
 
 reHits = re.compile('T(.) (.*?) sort=(.*?): ([0-9]+) hits in ([.0-9]+) msec')

--- a/src/python/sparsetaxis/writeGraph.py
+++ b/src/python/sparsetaxis/writeGraph.py
@@ -386,7 +386,7 @@ def main():
                             msecToQPS(getFastest(sparseSortedSearchStats, 2)),
                             msecToQPS(getFastest(nonSparseSearchStats, 4)),
                             msecToQPS(getFastest(sparseSearchStats, 4)),
-                            msecToQPS(getFastest(sparseSortedSearchStats, 4))));
+                            msecToQPS(getFastest(sparseSortedSearchStats, 4))))
       searchBQQPSData.append((m.groups(),
                               msecToQPS(getFastest(nonSparseSearchStats, 6)),
                               msecToQPS(getFastest(sparseSearchStats, 6)),

--- a/src/python/test_all_fst_sizes.py
+++ b/src/python/test_all_fst_sizes.py
@@ -1,6 +1,5 @@
 # nocommit -- temporary tool
 
-import time
 import subprocess
 import re
 import pickle

--- a/src/python/tokenizeApp.py
+++ b/src/python/tokenizeApp.py
@@ -2,7 +2,6 @@ import base64
 import cgi
 import subprocess
 import wsgiref.simple_server
-import socket
 
 import sys
 sys.path.insert(0, '/home/changingbits/webapps/examples/htdocs')

--- a/src/python/vector-test.py
+++ b/src/python/vector-test.py
@@ -18,7 +18,6 @@ import os
 
 import argparse
 import competition
-import sys
 import constants
 
 GLOVE_WORD_VECTORS_FILE = '%s/data/glove.6B.300d.txt' % constants.BASE_DIR

--- a/src/python/wikiXMLToText.py
+++ b/src/python/wikiXMLToText.py
@@ -1,10 +1,8 @@
 import datetime
-import codecs
 import sys
 import time
 import xml.etree.ElementTree as ET
 import re
-import random
 
 # TODO
 #  - put header on


### PR DESCRIPTION
Migration of major syntax violations such as `print` statement.
* this makes it possible for tooling to start to help us!

Removal of unused imports:
* this makes identification of missing ones easier

Identification of SOME invalid imports and missing dependencies:
* there is more work to do here: cgi etc
* one of the dependencies is 800MB (sentence transformer) so i let that one be too

Another big one to solve, is we must rename the `setup.py` which causes total confusion to editors and tooling, because of its name. We need to followup to rename this one to something else. Otherwise it is a "root marker" that causes tooling not to respect `pyproject.toml` and `venv`, e.g. wrong data in editors.

This is just iterative progress, I think it is pretty safe. I made separate commits. It is enough to e.g. enable formatting and start working off other problems as followups.