### PR TITLE
Apply safe ruff autofixes. Create list of remaining disabled rules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PIP_INSTALL_ARGS=--disable-pip-version-check --no-input --upgrade
 VENV=${PWD}/.venv
 
 # don't behave strangely if these files exist
-.PHONY: lint format reformat ruff pyright env clean
+.PHONY: lint format reformat tidy autofix ruff ruff-fix pyright env clean
 
 # list of directories we check
 SOURCES=src/python
@@ -32,12 +32,23 @@ format: env
 	# validate formatting: if this fails, please run "make reformat" and commit changes.
 	$(VENV)/bin/ruff format --diff $(SOURCES)
 
+# alias for lucene gradle users!
+tidy: reformat
+
 # reformat code to conventions
 reformat: env
 	# organize imports
 	$(VENV)/bin/ruff check --select I --fix $(SOURCES)
 	# reformat sources
 	$(VENV)/bin/ruff format $(SOURCES)
+
+# applies all safe fixes, if successful reformats too
+autofix: ruff-fix reformat
+
+# applies safe autofixes
+ruff-fix: env
+	# fix sources with ruff
+	$(VENV)/bin/ruff check --fix $(SOURCES)
 
 # lints sources
 ruff: env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,23 +30,157 @@ line-length = 200
 indent-width = 2
 
 [tool.ruff.lint]
-# TODO: improve!
-# select = ["ALL"]
+select = ["ALL"]
 
 # disabling/enabling of rules
 ignore = [
   # These rules are disabled because they have violations, we should fix those!
+  # Remove an item, fix the issues, and send us a pull request!
+  "A001",    # Variable is shadowing a Python builtin
+  "A002",    # Function argument is shadowing a Python builtin
+  "ANN001",  # Missing type annotation for function argument
+  "ANN002",  # Missing type annotation for function *argument
+  "ANN003",  # Missing type annotation for `**kwArgs`
+  "ANN201",  # Missing return type annotation for public function
+  "ANN202",  # Missing return type annotation for private function
+  "ANN204",  # Missing return type annotation for special method `__init__`
+  "ANN205",  # Missing return type annotation for staticmethod
+  "ARG001",  # Unused function argument
+  "ARG002",  # Unused method argument
+  "B006",    # Do not use mutable data structures for argument defaults
+  "B007",    # Loop control variable not used within loop body
+  "B011",    # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
+  "B018",    # Found useless expression. Either assign it to a variable or remove it.
+  "C400",    # Unnecessary generator (rewrite as a list comprehension)
+  "C402",    # Unnecessary generator (rewrite as a dict comprehension)
+  "C403",    # Unnecessary list comprehension (rewrite as a set comprehension)
+  "C404",    # Unnecessary list comprehension (rewrite as a dict comprehension)
+  "C405",    # Unnecessary list literal (rewrite as a set literal)
+  "C408",    # Unnecessary `dict()` call (rewrite as a literal)
+  "C901",    # Function is too complex
+  "D100",    # Missing docstring in public module
+  "D101",    # Missing docstring in public class
+  "D102",    # Missing docstring in public method
+  "D103",    # Missing docstring in public function
+  "D105",    # Missing docstring in magic method
+  "D107",    # Missing docstring in `__init__`
+  "D205",    # 1 blank line required between summary line and description
+  "D400",    # First line should end with a period
+  "D401",    # First line of docstring should be in imperative mood
+  "D415",    # First line should end with a period, question mark, or exclamation point
+  "DTZ001",  # `datetime.datetime()` called without a `tzinfo` argument
+  "DTZ005",  # `datetime.datetime.now()` called without a `tz` argument
+  "DTZ004",  # `datetime.datetime.utcfromtimestamp()` used
+  "DTZ006",  # `datetime.datetime.fromtimestamp()` called without a `tz` argument
+  "DTZ007",  # Naive datetime constructed using `datetime.datetime.strptime()` without %z
   "E402",    # Module level import not at top of file
-  "E701",    # Multiple statements on one line (colon)
-  "E711",    # Comparison to None should be "is None"
-  "E722",    # Bare except
-  "E731",    # Do not assign a "lambda" use a "def"
+  "E711",    # Comparison to `None` should be `cond is None`
+  "E722",    # Do not use bare `except`
+  "E731",    # Do not assign a `lambda` expression, use a `def`
   "E741",    # Ambiguous variable name
-  "F507",    # Wrong number of arguments to format string
-  "F541",    # F-string without placeholders
-  "F633",    # Use of '>>' is invalid with print function
-  "F811",    # Redefinition of unused
-  "F841",    # Local variable assigned but never used
+  "EM101",   # Exception must not use a string literal, assign to variable first
+  "EM102",   # Exception must not use an f-string literal, assign to variable
+  "ERA001",  # Found commented-out code
+  "EXE001",  # Shebang is present but file is not executable
+  "F507",    # `%`-format string has 3 placeholder(s) but 2 substitution(s)
+  "F633",    # Use of `>>` is invalid with `print` function
+  "F811",    # Redefinition of unused variable
+  "F841",    # Local variable is assigned to but never used
+  "FBT002",  # Boolean default positional argument in function definition
+  "FBT003",  # Boolean positional value in function call
+  "FIX001",  # Line contains FIXME, consider resolving the issue
+  "FIX002",  # Line contains TODO, consider resolving the issue
+  "FIX003",  # Line contains XXX, consider resolving the issue
+  "FURB129", # Instead of calling `readlines()`, iterate over file object directly
+  "INP001",  # File is part of an implicit namespace package. Add an `__init__.py`.
+  "N802",    # Function name `camelCase` should be lowercase
+  "N803",    # Argument name `camelCase` should be lowercase
+  "N806",    # Variable `camelCase` in function should be lowercase
+  "N812",    # Lowercase `gnuplot` imported as non-lowercase `Gnuplot`
+  "N815",    # Variable `camelCase` in class scope should not be mixedCase
+  "N816",    # Variable `camelCase` in global scope should not be mixedCase
+  "PERF102", # When using only the values of a dict use the `values()` method
+  "PERF203", # `try`-`except` within a loop incurs performance overhead
+  "PERF401", # Use `list.extend` to create a transformed list
+  "PERF403", # Use a dictionary comprehension instead of a for-loop
+  "PIE810",  # Call `endswith` once with a `tuple`
+  "PLR0912", # Too many branches
+  "PLR0913", # Too many arguments in function definition
+  "PLR0915", # Too many statements
+  "PLR1714", # Consider merging multiple comparisons. Use a `set` if the elements are hashable.
+  "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
+  "PLW0128", # Redeclared variable in assignment
+  "PLW0602", # Using global for `VERBOSE` but no assignment is done
+  "PLW0603", # Using the global statement to update `camelCase` is discouraged
+  "PLW1509", # `preexec_fn` argument is unsafe when using threads
+  "PLW2901", # `for` loop variable overwritten by assignment target
+  "PT018",   # Assertion should be broken down into multiple parts
+  "PTH100",  # `os.path.abspath()` should be replaced by `Path.resolve()`
+  "PTH101",  # `os.chmod()` should be replaced by `Path.chmod()`
+  "PTH102",  # `os.mkdir()` should be replaced by `Path.mkdir()`
+  "PTH103",  # `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+  "PTH104",  # `os.rename()` should be replaced by `Path.rename()`
+  "PTH107",  # `os.remove()` should be replaced by `Path.unlink()`
+  "PTH109",  # `os.getcwd()` should be replaced by `Path.cwd()`
+  "PTH110",  # `os.path.exists()` should be replaced by `Path.exists()`
+  "PTH112",  # `os.path.isdir()` should be replaced by `Path.is_dir()`
+  "PTH113",  # `os.path.isfile()` should be replaced by `Path.is_file()`
+  "PTH116",  # `os.stat()` should be replaced by `Path.stat()`, `Path.owner()`, or `Path.group()`
+  "PTH118",  # `os.path.join()` should be replaced by `Path` with `/` operator
+  "PTH119",  # `os.path.basename()` should be replaced by `Path.name`
+  "PTH123",  # `open()` should be replaced by `Path.open()`
+  "PTH202",  # `os.path.getsize` should be replaced by `Path.stat().st_size`
+  "PTH204",  # `os.path.getmtime` should be replaced by `Path.stat().st_mtime`
+  "PTH206",  # Replace `.split(os.sep)` with `Path.parts`
+  "PTH207",  # Replace `glob` with `Path.glob` or `Path.rglob`
+  "PYI024",  # Use `typing.NamedTuple` instead of `collections.namedtuple`
+  "RET504",  # Unnecessary assignment to variable before `return` statement
+  "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
+  "RUF005",  # Consider `["Foo", *series]` instead of concatenation
+  "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
+  "S101",    # Use of `assert` detected
+  "S102",    # Use of `exec` detected
+  "S104",    #  Possible binding to all interfaces
+  "S108",    # Probable insecure usage of temporary file or directory
+  "SIM222",  # Use `True` instead of `True or ...`
+  "SIM223",  # Use `False` instead of `False and ...`
+  "S301",    # `pickle` deserialization, possible security issue
+  "S310",    # Audit URL open for permitted schemes.
+  "S311",    # Standard pseudo-random generators are not suitable for cryptographic purposes
+  "S314",    # Using `xml` to parse untrusted data, use `defusedxml` equivalents
+  "S602",    # `subprocess` call with `shell=True` seems safe, but may be changed in the future
+  "S603",    # `subprocess` call: check for execution of untrusted input
+  "S605",    # Starting a process with a shell: seems safe, but may be changed in the future
+  "S606",    # Starting a process without a shell
+  "S607",    # Starting a process with a partial executable path
+  "SIM102",  # Use a single `if` statement instead of nested `if` statements
+  "SIM105",  # Use `contextlib.suppress(KeyError)` instead of `try`-`except`-`pass`
+  "SIM108",  # Use ternary operator instead of `if`-`else`-block
+  "SIM113",  # Use `enumerate()` for index variable `count` in `for` loop
+  "SIM115",  # Use a context manager for opening files
+  "SIM117",  # Use a single `with` statement with multiple contexts instead of nested `with` statements
+  "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
+  "SLF001",  # Private member accessed: `_current_frames`
+  "T201",    # `print` found
+  "TD001",   # Invalid TODO tag: `XXX`
+  "TD002",   # Missing author in TODO
+  "TD003",   # Missing issue link for this TODO
+  "TD004",   # Missing colon in TODO
+  "TD005",   # Missing issue description after `TODO`
+  "TRY003",  # Avoid specifying long messages outside the exception class
+  "TRY201",  # Use `raise` without specifying exception name
+  "TRY203",  # Remove exception handler; error is immediately re-raised
+  "TRY300",  # Consider moving this statement to an `else` block
+  "TRY301",  # Abstract `raise` to an inner function
+  "UP031",   # Use format specifiers instead of percent format
+  "UP036",   # Version block is outdated for minimum Python version
+  "W291",    # Trailing whitespace
+  "W293",    # Blank line contains whitespace
+
+  # These rules are disabled on purpose
+  "PT015",   # Assertion always fails, replace with `pytest.fail()` [pytest is not in use]
+  "D203",    # incompatible with D211
+  "D213",    # incompatible with D212
 
   # These rules are always disabled: conflict with the formatter
   # don't enable! https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules

--- a/src/python/IndexChart.py
+++ b/src/python/IndexChart.py
@@ -19,7 +19,7 @@ except ImportError:
   Gnuplot = None
 
 
-class IndexChart(object):
+class IndexChart:
   def __init__(self, log_file, competitor, out_base=".", start_sec=50, end_sec=200):
     self.log_file = log_file
     self.start_ms = start_sec * 1000
@@ -33,7 +33,7 @@ class IndexChart(object):
   def buildRaw(self, meta=None):
     if not meta:
       meta = {}
-    lines = open(self.log_file, "r").readlines()
+    lines = open(self.log_file).readlines()
     raw_data = []
     raw_flush = []
     for line in lines:
@@ -142,7 +142,7 @@ class IndexChart(object):
 
 
 # if you want to get flushing rate for RT apply this patch
-"""
+r"""
 
 Index: lucene/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
 ===================================================================

--- a/src/python/WikipediaExtractor.py
+++ b/src/python/WikipediaExtractor.py
@@ -235,14 +235,13 @@ def unescape(text):
       if text[1] == "#":  # character reference
         if text[2] == "x":
           return chr(int(code[1:], 16))
-        else:
-          return chr(int(code))
-      else:  # named entity
-        return entitydefs[code]
+        return chr(int(code))
+      # named entity
+      return entitydefs[code]
     except:
       return text  # leave as is
 
-  return re.sub("&#?(\w+);", fixup, text)
+  return re.sub(r"&#?(\w+);", fixup, text)
 
 
 # Match HTML comments
@@ -389,8 +388,7 @@ def make_anchor_tag(match):
   anchor += trail
   if keepLinks:
     return '<a href="%s">%s</a>' % (link, anchor)
-  else:
-    return anchor
+  return anchor
 
 
 def clean(text):
@@ -474,8 +472,8 @@ def clean(text):
   text = text.replace("\t", " ")
   text = spaces.sub(" ", text)
   text = dots.sub("...", text)
-  text = re.sub(" (,:\.\)\]Â»)", r"\1", text)
-  text = re.sub("(\[\(Â«) ", r"\1", text)
+  text = re.sub(r" (,:\.\)\]Â»)", r"\1", text)
+  text = re.sub(r"(\[\(Â«) ", r"\1", text)
   text = re.sub(r"\n\W+?\n", "\n", text)  # lines with only punctuations
   text = text.replace(",,", ",").replace(",.", ".")
 
@@ -528,10 +526,7 @@ def compact(text):
       else:
         continue
     # Drop residuals of lists
-    elif line[0] in "{|" or line[-1] in "}":
-      continue
-    # Drop irrelevant lines
-    elif (line[0] == "(" and line[-1] == ")") or line.strip(".-") == "":
+    elif line[0] in "{|" or line[-1] in "}" or (line[0] == "(" and line[-1] == ")") or line.strip(".-") == "":
       continue
     elif len(headers):
       items = list(headers.items())
@@ -591,8 +586,7 @@ class OutputSplitter:
     file_name = os.path.join(dir_name, self.file_name())
     if self.compress:
       return bz2.BZ2File(file_name + ".bz2", "wb")
-    else:
-      return open(file_name, "wb")
+    return open(file_name, "wb")
 
   def dir_name(self):
     char1 = self.dir_index % 26
@@ -707,7 +701,7 @@ def main():
         else:
           file_size = int(arg)
         if file_size < minFileSize:
-          raise ValueError()
+          raise ValueError
       except ValueError:
         print >> sys.stderr, "%s: %s: Insufficient or invalid size" % (script_name, arg)
         sys.exit(2)

--- a/src/python/autoPrefixPerf.py
+++ b/src/python/autoPrefixPerf.py
@@ -4,7 +4,7 @@ import shutil
 
 # run from lucene subdir in trunk checkout
 
-reIter = re.compile(": (\d+) msec; totalHits=(\d+) hash=(\d+)")
+reIter = re.compile(r": (\d+) msec; totalHits=(\d+) hash=(\d+)")
 logsDir = "/x/tmp/prefixtermsperf2"
 
 
@@ -22,7 +22,7 @@ def parseLog(logFileName):
   indexTimeSec = None
   indexSizeBytes = None
 
-  f = open(logFileName, "r")
+  f = open(logFileName)
   while True:
     line = f.readline()
     if line == "":

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -38,7 +38,7 @@ import QPSChart
 PERF_EXE = which("perf")
 
 if PERF_EXE is None:
-  print(f"no perf executable; will not collect aggregate CPU profiling data")
+  print("no perf executable; will not collect aggregate CPU profiling data")
 else:
   print(f"perf executable is {PERF_EXE}; will collect aggregate CPU profiling data")
 
@@ -91,40 +91,35 @@ def addFiles(root):
 def htmlColor(v):
   if v < 0:
     return colorFormat(-v, "html", "red")
-  else:
-    return colorFormat(v, "html", "green")
+  return colorFormat(v, "html", "green")
 
 
 def htmlColor2(v):
   vstr = "%.1f X" % v
   if v < 1.0:
     return colorFormat(vstr, "html", "red")
-  else:
-    return colorFormat(vstr, "html", "green")
+  return colorFormat(vstr, "html", "green")
 
 
 def jiraColor(v):
   if v < 0:
     return colorFormat(-v, "jira", "red")
-  else:
-    return colorFormat(v, "jira", "green")
+  return colorFormat(v, "jira", "green")
 
 
 def pValueColor(v, form):
   vstr = "%.3f" % v
   if v <= 0.05:
     return colorFormat(vstr, form, "green")
-  else:
-    return colorFormat(vstr, form, "red")
+  return colorFormat(vstr, form, "red")
 
 
 def colorFormat(value, form, color):
   if form == "html":
-    return '<font color="{}">{}</font>'.format(color, value)
-  elif form == "jira":
-    return "{{color:{}}}{}{{color}}".format(color, value)
-  else:
-    raise RuntimeError("unknown format {}".format(form))
+    return f'<font color="{color}">{value}</font>'
+  if form == "jira":
+    return f"{{color:{color}}}{value}{{color}}"
+  raise RuntimeError(f"unknown format {form}")
 
 
 def getArg(argName, default, hasArg=True):
@@ -183,8 +178,7 @@ def nameToIndexPath(name):
 def decode(str_or_bytes):
   if PYTHON_MAJOR_VER < 3 or isinstance(str_or_bytes, str):
     return str_or_bytes
-  else:
-    return str_or_bytes.decode("utf-8")
+  return str_or_bytes.decode("utf-8")
 
 
 class SearchTask:
@@ -306,15 +300,14 @@ class SearchTask:
   def __eq__(self, other):
     if not isinstance(other, SearchTask):
       return False
-    else:
-      return (
-        self.query == other.query
-        and self.sort == other.sort
-        and self.groupField == other.groupField
-        and self.filter == other.filter
-        and self.facet_request == other.facet_request
-        and self.isCountOnly == other.isCountOnly
-      )
+    return (
+      self.query == other.query
+      and self.sort == other.sort
+      and self.groupField == other.groupField
+      and self.filter == other.filter
+      and self.facet_request == other.facet_request
+      and self.isCountOnly == other.isCountOnly
+    )
 
   def __hash__(self):
     return hash(self.query) + hash(self.sort) + hash(self.groupField) + hash(self.filter) + hash(type(self.facet_request)) + hash(self.isCountOnly)
@@ -340,8 +333,7 @@ class RespellTask:
   def __eq__(self, other):
     if not isinstance(other, RespellTask):
       return False
-    else:
-      return self.term == other.term
+    return self.term == other.term
 
   def __hash__(self):
     return hash(self.term)
@@ -361,8 +353,7 @@ class PKLookupTask:
   def __eq__(self, other):
     if not isinstance(other, PKLookupTask):
       return False
-    else:
-      return self.pkOrd == other.pkOrd
+    return self.pkOrd == other.pkOrd
 
   def __hash__(self):
     return hash(self.pkOrd)
@@ -382,8 +373,7 @@ class PKLookupWithTermStateTask:
   def __eq__(self, other):
     if not isinstance(other, PKLookupWithTermStateTask):
       return False
-    else:
-      return self.pkOrd == other.pkOrd
+    return self.pkOrd == other.pkOrd
 
   def __hash__(self):
     return hash(self.pkOrd)
@@ -403,8 +393,7 @@ class PointsPKLookupTask:
   def __eq__(self, other):
     if not isinstance(other, PointsPKLookupTask):
       return False
-    else:
-      return self.pkOrd == other.pkOrd
+    return self.pkOrd == other.pkOrd
 
   def __hash__(self):
     return hash(self.pkOrd)
@@ -857,16 +846,15 @@ def sum_hit_count(hc1, hc2):
     hc2 = int(hc2[:-1])
   else:
     hc2 = int(hc2)
-  return str(hc1 + hc2) + (lower_bound and "+" or "")
+  return str(hc1 + hc2) + ((lower_bound and "+") or "")
 
 
 def stats(l):
   # min, max, mean, stddev
   if len(l) == 0:
     return 0.0, 0.0, 0.0, 0.0
-  else:
-    mu = statistics.mean(l)
-    return min(l), max(l), mu, statistics.stdev(l) if len(l) > 1 else 0
+  mu = statistics.mean(l)
+  return min(l), max(l), mu, statistics.stdev(l) if len(l) > 1 else 0
 
 
 def run(cmd, logFile=None, indent="    ", vmstatLogFile=None, topLogFile=None):
@@ -945,7 +933,7 @@ class RunAlgs:
     if os.path.exists(fullIndexPath) and not index.doUpdate:
       print("  %s: already exists" % fullIndexPath)
       return fullIndexPath
-    elif index.doUpdate:
+    if index.doUpdate:
       if not os.path.exists(fullIndexPath):
         raise RuntimeError("index path does not exists: %s" % fullIndexPath)
       print("  %s: now update" % fullIndexPath)
@@ -1127,8 +1115,7 @@ class RunAlgs:
 
       print("  %s" % path)
       os.chdir(path)
-      if path.endswith("/"):
-        path = path[:-1]
+      path = path.removesuffix("/")
 
       cp = classPathToString(getClassPath(competitor.checkout))
       competitor.compile(cp)
@@ -1159,8 +1146,7 @@ class RunAlgs:
 
       print("  %s" % path)
       os.chdir(path)
-      if path.endswith("/"):
-        path = path[:-1]
+      path = path.removesuffix("/")
 
       cp = classPathToString(getClassPath(competitor.checkout))
       competitor.compile(cp)
@@ -1300,7 +1286,7 @@ class RunAlgs:
       if p.wait() != 0:
         print()
         print("SearchPerfTest FAILED:")
-        s = open(logFile + ".stdout", "r")
+        s = open(logFile + ".stdout")
         for line in s.readlines():
           print(line.rstrip())
         raise RuntimeError("SearchPerfTest failed; see log %s.stdout" % logFile)
@@ -1617,26 +1603,24 @@ class RunAlgs:
       pctP999 = 100 * (currentCmpMetrics["p999"] - currentBaseMetrics["p999"]) / currentBaseMetrics["p999"]
       pctP100 = 100 * (currentCmpMetrics["p100"] - currentBaseMetrics["p100"]) / currentBaseMetrics["p100"]
       print(
-        (
-          "||Task %s||P50 Base %s||P50 Cmp %s||Pct Diff %s||P90 Base %s||P90 Cmp %s||Pct Diff %s||P99 Base %s||P99 Cmp %s||Pct Diff %s||P999 Base %s||P999 Cmp %s||Pct Diff %s||P100 Base %s||P100 Cmp %s||Pct Diff %s"
-          % (
-            currentCat,
-            currentBaseMetrics["p50"],
-            currentCmpMetrics["p50"],
-            pctP50,
-            currentBaseMetrics["p90"],
-            currentCmpMetrics["p90"],
-            pctP90,
-            currentBaseMetrics["p99"],
-            currentCmpMetrics["p99"],
-            pctP99,
-            currentBaseMetrics["p999"],
-            currentCmpMetrics["p999"],
-            pctP999,
-            currentBaseMetrics["p100"],
-            currentCmpMetrics["p100"],
-            pctP100,
-          )
+        "||Task %s||P50 Base %s||P50 Cmp %s||Pct Diff %s||P90 Base %s||P90 Cmp %s||Pct Diff %s||P99 Base %s||P99 Cmp %s||Pct Diff %s||P999 Base %s||P999 Cmp %s||Pct Diff %s||P100 Base %s||P100 Cmp %s||Pct Diff %s"
+        % (
+          currentCat,
+          currentBaseMetrics["p50"],
+          currentCmpMetrics["p50"],
+          pctP50,
+          currentBaseMetrics["p90"],
+          currentCmpMetrics["p90"],
+          pctP90,
+          currentBaseMetrics["p99"],
+          currentCmpMetrics["p99"],
+          pctP99,
+          currentBaseMetrics["p999"],
+          currentCmpMetrics["p999"],
+          pctP999,
+          currentBaseMetrics["p100"],
+          currentCmpMetrics["p100"],
+          pctP100,
         )
       )
 
@@ -1827,17 +1811,16 @@ def tasksToMap(taskIters, verifyScores, verifyCounts):
       if len(d) == 0:
         d = run_d
       else:
-        for task in run_d.keys():
+        for task in run_d:
           if task not in d:
             # BUG
             raise RuntimeError(f"ERROR: tasks differ from one iteration to the next: task={task} in JVM {run_iter} is missing from JVM 0")
-          else:
-            # Make sure same task returned same results across JVMs:
-            try:
-              task.verifySame(d[task][0], verifyScores, verifyCounts)
-            except RuntimeError as re:
-              # BUG
-              raise RuntimeError(f"ERROR: hits across JVMs differ; something is acting non-deterministically across JVMs?  run 0 vs run {run_iter}") from re
+          # Make sure same task returned same results across JVMs:
+          try:
+            task.verifySame(d[task][0], verifyScores, verifyCounts)
+          except RuntimeError as re:
+            # BUG
+            raise RuntimeError(f"ERROR: hits across JVMs differ; something is acting non-deterministically across JVMs?  run 0 vs run {run_iter}") from re
         for task in d.keys():
           if task not in run_d:
             # BUG
@@ -1883,10 +1866,9 @@ def compareHits(r1, r2, verifyScores, verifyCounts):
 
   if len(warnings) == 0 and len(errors) == 0:
     return None
-  else:
-    inBoth = (len(d1) + len(d2) - onlyInD1 - onlyInD2) / 2
-    overlap = inBoth / float(max(len(d1), len(d2)))
-    return warnings, errors, overlap
+  inBoth = (len(d1) + len(d2) - onlyInD1 - onlyInD2) / 2
+  overlap = inBoth / float(max(len(d1), len(d2)))
+  return warnings, errors, overlap
 
 
 def htmlEscape(s):

--- a/src/python/blockFileHead.py
+++ b/src/python/blockFileHead.py
@@ -2,7 +2,7 @@ import sys
 
 limit = int(sys.argv[2])
 
-with open(sys.argv[1], "r") as f:
+with open(sys.argv[1]) as f:
   header = f.readline()
   print(header.rstrip())
   docCount = 0

--- a/src/python/blunders.py
+++ b/src/python/blunders.py
@@ -78,6 +78,6 @@ def init_upload(label, name, description):
 
 
 def blunders_auth_header():
-  base64string = base64.b64encode(f"lucene-nightly-bench:{constants.BLUNDER_ACCESS_KEY}".encode("utf-8")).decode("utf-8")
+  base64string = base64.b64encode(f"lucene-nightly-bench:{constants.BLUNDER_ACCESS_KEY}".encode()).decode("utf-8")
   authorization = "Basic %s" % base64string
   return authorization

--- a/src/python/buildBinaryLineDocs.py
+++ b/src/python/buildBinaryLineDocs.py
@@ -16,7 +16,7 @@ def flush(pending, pendingDocCount, fOut):
 
 print(f"build binary file from {sys.argv[1]} to {sys.argv[2]}")
 
-with open(sys.argv[1], "r", encoding="utf-8") as f, open(sys.argv[2], "wb") as fOut:
+with open(sys.argv[1], encoding="utf-8") as f, open(sys.argv[2], "wb") as fOut:
   first = True
   pending = io.BytesIO()
   pendingDocCount = 0

--- a/src/python/buildTaxisCSV.py
+++ b/src/python/buildTaxisCSV.py
@@ -62,7 +62,7 @@ def loadDocs():
     if fileName.endswith(".csv") and fileName != "alltaxis.csv":
       print("file %s" % fileName, file=sys.stderr)
       cabColor = fileName.split("_")[0]
-      with open("%s/%s" % (CSV_DIR, fileName), "r") as f:
+      with open("%s/%s" % (CSV_DIR, fileName)) as f:
         reader = csv.reader(f)
         headers = list(reader.__next__())
         # print('headers in: %s' % headers);

--- a/src/python/buildTaxisCSVConcurrent.py
+++ b/src/python/buildTaxisCSVConcurrent.py
@@ -62,7 +62,7 @@ def loadDocs(jobs, id, csvHeaders):
 
     print("%s: file %s" % (id, fileName))
     cabColor = fileName.split("_")[0]
-    with open("%s/%s" % (CSV_DIR, fileName), "r") as f:
+    with open("%s/%s" % (CSV_DIR, fileName)) as f:
       reader = csv.reader(f)
       headers = list(reader.__next__())
       # print('headers in: %s' % headers);

--- a/src/python/combineWikiFiles.py
+++ b/src/python/combineWikiFiles.py
@@ -12,11 +12,11 @@ if onlyThreeColumns:
   sys.argv.remove("-only-three-columns")
 
 # Line file docs:
-f1 = open(sys.argv[1], "r")
+f1 = open(sys.argv[1])
 line = f1.readline()
 
 # WikipediaExtractor output:
-f2 = open(sys.argv[2], "r")
+f2 = open(sys.argv[2])
 
 fOut = open(sys.argv[3], "w")
 

--- a/src/python/common.py
+++ b/src/python/common.py
@@ -18,8 +18,7 @@ else:
 def pathsep():
   if osName in ("windows", "cygwin"):
     return ";"
-  else:
-    return os.pathsep
+  return os.pathsep
 
 
 allTests = {}
@@ -44,8 +43,7 @@ def locateTest(test):
           # print '%s.%s' % (path, f[:-5])
   if test not in allTests:
     return None
-  else:
-    return allTests[test], method
+  return allTests[test], method
 
 
 def findRootDir(s):
@@ -82,8 +80,7 @@ def getLuceneMatchVersion(ROOT):
       if line.startswith("version.base="):
         return line[13:].strip()
     raise RuntimeError("could not locate lucene version")
-  else:
-    return "4.10.4"
+  return "4.10.4"
 
 
 def getLuceneTestClassPath(ROOT):
@@ -190,9 +187,7 @@ def filterCWD(l):
 
 
 def getLatestModTime(path, extension=None):
-  """
-  Returns latest modified time of all files with the specified extension under the specified path.
-  """
+  """Returns latest modified time of all files with the specified extension under the specified path."""
   modTime = 0
   for root, dirs, files in os.walk(path):
     for file in files:
@@ -205,7 +200,7 @@ def getLatestModTime(path, extension=None):
 
 def getLuceneDirFromGradleProperties():
   try:
-    with open(os.path.join(constants.BENCH_BASE_DIR, "gradle.properties"), "r") as f:
+    with open(os.path.join(constants.BENCH_BASE_DIR, "gradle.properties")) as f:
       for line in f:
         if line.find("=") == -1:
           continue

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -30,7 +30,7 @@ if hasattr(constants, "SEARCH_NUM_THREADS"):
   raise RuntimeError("please rename your localconstants.py SEARCH_NUM_THREADS to SEARCH_NUM_CONCURRENT_QUERIES")
 
 
-class Data(object):
+class Data:
   def __init__(self, name, lineFile, numDocs, tasksFile):
     self.name = name
     self.lineFile = lineFile
@@ -117,7 +117,7 @@ def sourceData(key=None):
   raise RuntimeError('unknown data source "%s" (valid keys: %s)' % (key, DATA.keys()))
 
 
-class Index(object):
+class Index:
   def __init__(
     self,
     checkout,
@@ -209,11 +209,11 @@ class Index(object):
       if vectorEncoding not in ("FLOAT32", "BYTE"):
         raise RuntimeError(f"vectorEncoding must be FLOAT32 or BYTE; got: {vectorEncoding}")
     elif vectorEncoding is not None:
-      raise RuntimeError(f"vectorEncoding must be None when there are no vectors to index (vectorFile is None)")
+      raise RuntimeError("vectorEncoding must be None when there are no vectors to index (vectorFile is None)")
 
     self.vectorEncoding = vectorEncoding
     self.mergeFactor = 10
-    if SEGS_PER_LEVEL >= self.mergeFactor:
+    if self.mergeFactor <= SEGS_PER_LEVEL:
       raise RuntimeError("SEGS_PER_LEVEL (%s) is greater than mergeFactor (%s)" % (SEGS_PER_LEVEL, self.mergeFactor))
     self.useCMS = useCMS
     self.rearrange = rearrange
@@ -272,7 +272,7 @@ class Index(object):
     return ".".join(name)
 
 
-class Competitor(object):
+class Competitor:
   doSort = False
 
   def __init__(
@@ -422,7 +422,7 @@ class Competitor(object):
       benchUtil.run("cp", "-r", os.path.join(perfSrc, "resources/*"), buildDir.replace("\\", "/"))
 
 
-class Competition(object):
+class Competition:
   def __init__(
     self,
     cold=False,

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -108,13 +108,13 @@ java_bin = JAVA_HOME + "/bin/" if JAVA_HOME else ""
 if java_bin:
   print("Using java from: %s" % java_bin)
 if "JAVA_EXE" not in globals():
-  JAVA_EXE = "{}java".format(java_bin)
+  JAVA_EXE = f"{java_bin}java"
 if "JAVAC_EXE" not in globals():
-  JAVAC_EXE = "{}javac".format(java_bin)
+  JAVAC_EXE = f"{java_bin}javac"
 if "JAVA_COMMAND" not in globals():
   JAVA_COMMAND = "%s -server -Xms2g -Xmx2g --add-modules jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC" % JAVA_EXE
 else:
-  print("use java command %s" % JAVA_COMMAND)  # pyright: ignore[reportUnboundVariable] # TODO: fix how variables are managed here
+  print("use java command %s" % JAVA_COMMAND)  # pyright: ignore[reportUndefinedVariable] # TODO: fix how variables are managed here
 
 JRE_SUPPORTS_SERVER_MODE = True
 INDEX_NUM_THREADS = 1

--- a/src/python/corrumpter.py
+++ b/src/python/corrumpter.py
@@ -153,7 +153,7 @@ def main():
         print(f"{5 - i}...")
         time.sleep(1)
     except KeyboardInterrupt:
-      print(f"\nPHEW, DISASTER AVERTED!\n")
+      print("\nPHEW, DISASTER AVERTED!\n")
       raise
     else:
       print("\n**BOOOOOOOM**\n")

--- a/src/python/createEnglishWikipediaLineDocsFile.py
+++ b/src/python/createEnglishWikipediaLineDocsFile.py
@@ -89,7 +89,7 @@ def main():
     # run wikiXMLToText first, creating first enwiki-lines.txt:
     line_file_name = os.path.join(tmp_dir_name, "enwiki-lines.txt")
     if not os.path.exists(line_file_name):
-      print(f"now bunzip & convert XML to text")
+      print("now bunzip & convert XML to text")
       t0 = time.time()
       with bz2.open(local_file_name, "rt", encoding="utf-8") as f_in, open(line_file_name, "w", encoding="utf-8") as f_out:
         wikiXMLToText.convert(f_in, f_out)

--- a/src/python/createJapaneseWikipediaLineDocsFile.py
+++ b/src/python/createJapaneseWikipediaLineDocsFile.py
@@ -61,7 +61,7 @@ def main():
     print("second file is %s bytes" % os.path.getsize(extract_file_name))
 
     # finally, run combineWikiFiles.py to merge the two into final lines file, and keep only first three columns:
-    subprocess.run([sys.executable, "src/python/combineWikiFiles.py", "-only-three-columns", line_file_name, extract_file_name, final_line_file_name])
+    subprocess.run([sys.executable, "src/python/combineWikiFiles.py", "-only-three-columns", line_file_name, extract_file_name, final_line_file_name], check=False)
 
     # ~12 GB
     print("final file is %s bytes" % os.path.getsize(final_line_file_name))

--- a/src/python/createLineFileDocsWithRandomLabel.py
+++ b/src/python/createLineFileDocsWithRandomLabel.py
@@ -30,14 +30,14 @@ def createLineFileDocsWithRandomLabels(original_file, target_file):
 
   print(f"Reading from {original_file} and writing to {target_file}")
 
-  with open(original_file, "r", encoding="utf-8") as f:
+  with open(original_file, encoding="utf-8") as f:
     line = f.readline()
     original_has_header = line.startswith("FIELDS_HEADER_INDICATOR###")
 
   print(f"input has header?={original_has_header}")
 
   # alas, we have UTF-8 bugs in some of our line docs files, so I had to use errors='replace' below:
-  with open(original_file, "r", encoding="utf-8", errors="replace") as original, open(target_file, "w", encoding="utf-8") as out:
+  with open(original_file, encoding="utf-8", errors="replace") as original, open(target_file, "w", encoding="utf-8") as out:
     i = 0
 
     # always write header even if input does not have it:
@@ -84,7 +84,7 @@ def createLineFileDocsWithRandomLabels(original_file, target_file):
 def chooseRandomLabel(body):
   body_arr = list(filter(isNotEmpty, re.split(r"\W", body)))
   if len(body_arr) == 0:
-    print(f"WARNING: empty body: {repr(body)}")
+    print(f"WARNING: empty body: {body!r}")
     return "EMPTY_LABEL"
   label = None
   i = 0
@@ -92,8 +92,7 @@ def chooseRandomLabel(body):
     label = random.choice(body_arr)
   if not isNotEmpty(label):
     return "EMPTY_LABEL"
-  else:
-    return label
+  return label
 
 
 def isNotEmpty(str):
@@ -103,11 +102,10 @@ def isNotEmpty(str):
 if __name__ == "__main__":
   if "-help" in sys.argv or "--help" in sys.argv:
     print("Usage: python createLineFileDocsWithRandomLabel.py file-name-in file-name-out [--help]")
+  elif len(sys.argv) == 3:
+    ORIGINAL_LINEFILE = sys.argv[1]
+    TARGET_LINEFILE = sys.argv[2]
+    createLineFileDocsWithRandomLabels(ORIGINAL_LINEFILE, TARGET_LINEFILE)
   else:
-    if len(sys.argv) == 3:
-      ORIGINAL_LINEFILE = sys.argv[1]
-      TARGET_LINEFILE = sys.argv[2]
-      createLineFileDocsWithRandomLabels(ORIGINAL_LINEFILE, TARGET_LINEFILE)
-    else:
-      print("Invalid arguments")
-      print("Usage: python createLineFileDocsWithRandomLabel.py file-name-in file-name-out [--help]")
+    print("Invalid arguments")
+    print("Usage: python createLineFileDocsWithRandomLabel.py file-name-in file-name-out [--help]")

--- a/src/python/docsToBlocks.py
+++ b/src/python/docsToBlocks.py
@@ -17,7 +17,7 @@ def writePending(fOut):
 
 # python3 -u /l/util/src/python/docsToBlocks.py /lucenedata/geonames/documents.json /l/data/geonames.luceneserver.blocks
 
-with open(sys.argv[1], "r") as f, open(sys.argv[2], "wb") as fOut:
+with open(sys.argv[1]) as f, open(sys.argv[2], "wb") as fOut:
   first = True
   while True:
     l = f.readline()

--- a/src/python/idPerfResultsToBarGraph.py
+++ b/src/python/idPerfResultsToBarGraph.py
@@ -33,7 +33,7 @@ html = """
 """
 
 results = []
-with open(sys.argv[1], "r") as f:
+with open(sys.argv[1]) as f:
   while True:
     line = f.readline()
     if line == "":

--- a/src/python/infer_token_vectors.py
+++ b/src/python/infer_token_vectors.py
@@ -31,8 +31,8 @@ vector_file = sys.argv[3]
 model_name = sys.argv[4]
 
 dic = dict()
-TOKENIZE_RE = re.compile("[][ \t,\-()!@#$%^&*'\"{}<>/?\\|+=_:;.]+")
-with open(input_file, "rt") as input:
+TOKENIZE_RE = re.compile("[][ \t,\\-()!@#$%^&*'\"{}<>/?\\|+=_:;.]+")
+with open(input_file) as input:
   for line in input:
     if len(dic) > 400000:
       break
@@ -48,7 +48,7 @@ BATCH_SIZE = 256
 model = SentenceTransformer(model_name)
 model.eval()
 
-with open(token_file, "wt") as tokens_out:
+with open(token_file, "w") as tokens_out:
   with open(vector_file, "wb") as vectors_out:
     tokens = []
     for token, count in dic.items():

--- a/src/python/infer_token_vectors_cohere.py
+++ b/src/python/infer_token_vectors_cohere.py
@@ -67,8 +67,8 @@ def fetch_cohere_vectors():
   print(f"embeddings dims: {embedding_dims}")
   assert embedding_dims == DIMENSIONS, f"Dataset embedding dimensions: {embedding_dims} do not match configured dimensions: {DIMENSIONS}"
 
-  with open(meta_file, "at") as meta:
-    meta.write(f"wiki_id,para_id\n")
+  with open(meta_file, "a") as meta:
+    meta.write("wiki_id,para_id\n")
 
   # do this in windows, else the RAM usage is crazy (OOME even with 256
   # GB RAM since I think this step makes 2X copy of the dataset?)
@@ -96,8 +96,8 @@ def fetch_cohere_vectors():
     with open(doc_file, "ab") as out_f:
       embs.tofile(out_f)
 
-    print(f"writing associated metadata")
-    with open(meta_file, "at") as meta:
+    print("writing associated metadata")
+    with open(meta_file, "a") as meta:
       for i in range(batch_size):
         meta.write(f"{ds_wiki_id[i]},{ds_para_id[i]}\n")
 
@@ -121,8 +121,8 @@ def fetch_cohere_vectors():
   print(f"reading queries shape: {embs_queries.shape}")
   print(f"{embs_queries[0]}")
 
-  print(f"reading metadata file")
-  with open(meta_file, "rt") as meta:
+  print("reading metadata file")
+  with open(meta_file) as meta:
     md = meta.readlines()
   print(f"metadata file row_count: {len(md)}, includes 1 header line")
   for line in md[:11]:

--- a/src/python/infostream_to_segments.py
+++ b/src/python/infostream_to_segments.py
@@ -134,9 +134,7 @@ class Segment:
     self.events.append((timestamp, event, infostream_line_number))
 
   def merge_event(self, timestamp, event, infostream_line_number):
-    """
-    Like add_event, except the timestamp might be out of order, so we do insertion sort.
-    """
+    """Like add_event, except the timestamp might be out of order, so we do insertion sort."""
     insert_at = bisect.bisect_right(self.events, timestamp, key=lambda x: x[0])
     self.events.insert(insert_at, (timestamp, event, infostream_line_number))
 
@@ -162,19 +160,18 @@ class Segment:
         # this can happen if InfoStream ends as a segment is flushing
         # raise RuntimeError(f'flushed segment {self.name} is missing ramUsedMB')
         if self.size_mb is None:
-          l.append(f"  ?? MB (?? efficiency)")
+          l.append("  ?? MB (?? efficiency)")
         else:
           l.append(f"  {self.size_mb:,.1f} MB (?? efficiency)")
       else:
         l.append(f"  {self.size_mb:,.1f} MB ({100 * self.size_mb / self.ram_used_mb:.1f}% efficiency, ram_used_mb={self.ram_used_mb:,.1f} MB)")
+    elif self.size_mb is None:
+      l.append("  ?? MB")
+    elif self.estimate_size_mb is not None:
+      pct = 100.0 * self.size_mb / self.estimate_size_mb
+      l.append(f"  {self.size_mb:,.1f} MB vs estimate {self.estimate_size_mb:,.1f} MB {pct:.1f}%")
     else:
-      if self.size_mb is None:
-        l.append(f"  ?? MB")
-      elif self.estimate_size_mb is not None:
-        pct = 100.0 * self.size_mb / self.estimate_size_mb
-        l.append(f"  {self.size_mb:,.1f} MB vs estimate {self.estimate_size_mb:,.1f} MB {pct:.1f}%")
-      else:
-        l.append(f"  {self.size_mb:,.1f} MB vs estimate ?? MB")
+      l.append(f"  {self.size_mb:,.1f} MB vs estimate ?? MB")
 
     if self.merge_during_commit is not None:
       if type(self.merge_during_commit) is tuple:
@@ -222,7 +219,7 @@ class Segment:
     l.append(f"  times {bt} / {sec_to_time_delta(ltt - btt - dtt)} / {dt}")
     if self.merged_into is not None:
       l.append(f"  merged into {self.merged_into.name}")
-    l.append(f"  events")
+    l.append("  events")
     last_ts = self.start_time
 
     # we subsample all delete flushes if there are too many...:
@@ -282,9 +279,7 @@ class Segment:
 
 
 def to_float(s):
-  """
-  Converts float number strings that might have comma, e.g. '1,464.435', to float.
-  """
+  """Converts float number strings that might have comma, e.g. '1,464.435', to float."""
   return float(s.replace(",", ""))
 
 
@@ -465,7 +460,7 @@ def main():
   merge_commit_merges = None
   do_strip_log_prefix = None
 
-  with open(infostream_log, "r") as f:
+  with open(infostream_log) as f:
     while True:
       if push_back_line is not None:
         line = push_back_line
@@ -823,7 +818,7 @@ def main():
           elif max_doc != segment.max_doc:
             raise RuntimeError(f"merging segment {segment.name} sees different max_doc={segment.max_doc} vs {max_doc}")
           segment.size_mb = size_mb
-          segment.add_event(timestamp, f"done merge", line_number)
+          segment.add_event(timestamp, "done merge", line_number)
           continue
 
         m = re_merge_commit.search(line)
@@ -929,7 +924,7 @@ def main():
         if m is not None:
           timestamp = parse_timestamp(m.group(1))
           thread_name = m.group(2)
-          print(f"clear commit thread")
+          print("clear commit thread")
           commit_thread_name = None
           assert full_flush_events[-1][1] is None
           full_flush_events[-1][1] = timestamp

--- a/src/python/initial_setup.py
+++ b/src/python/initial_setup.py
@@ -92,7 +92,7 @@ def runSetup(download):
       else:
         print("download %s to %s - might take a long time!" % (url_source, target_file))
         Downloader(url_source, target_file).download()
-        print("")
+        print()
         print("downloading %s to %s done " % (url_source, target_file))
 
       for suffix in (".bz2", ".lzma", ".zip", ".xz"):

--- a/src/python/iwLogToGraphs.py
+++ b/src/python/iwLogToGraphs.py
@@ -13,8 +13,8 @@ import time
 #   - flush sizes/frequency
 #   - commit frequency
 
-reDateTime = re.compile("(\d\d\d\d)-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(,\d\d\d)?")
-reFindMerges = re.compile("findMerges: (\d+) segments")
+reDateTime = re.compile(r"(\d\d\d\d)-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(,\d\d\d)?")
+reFindMerges = re.compile(r"findMerges: (\d+) segments")
 reMergeSize = re.compile(r"[cC](\d+) size=(.*?) MB")
 reMergeSizeWithDel = re.compile(r"[cC](\d+)/(\d+):delGen=(\d+) size=(.*?) MB")
 reMergeStart = re.compile(r"merge seg=(.*?) ")
@@ -391,7 +391,7 @@ def main():
         elif event == "end":
           mergeCount -= 1
         else:
-          raise RuntimeError()
+          raise RuntimeError
 
         w("%s,%d\\n" % (formatTime(year, month, day, hr, min, sec), mergeCount))
 

--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -160,7 +160,7 @@ def run_knn_benchmark(checkout, values):
           if value != 32:
             pv[p] = value
             print(f"  -{p}={value}")
-            print(f"  -quantize")
+            print("  -quantize")
             args += ["-quantize"]
             quantize_bits = value
         elif type(value) is bool:

--- a/src/python/lastNightlyRun.py
+++ b/src/python/lastNightlyRun.py
@@ -2,7 +2,7 @@ import datetime
 import os
 import re
 
-reDateTime = re.compile("^(\d\d\d\d).(\d\d).(\d\d).(\d\d).(\d\d).(\d\d)$")
+reDateTime = re.compile(r"^(\d\d\d\d).(\d\d).(\d\d).(\d\d).(\d\d).(\d\d)$")
 
 mostRecent = None
 

--- a/src/python/latencyOverTimeGraph.py
+++ b/src/python/latencyOverTimeGraph.py
@@ -77,10 +77,7 @@ for timestamp, taskString, latencyMS, queueTimeMS in results:
           tup = l.strip().split()
           pct = float(tup[1])
           sec = float(tup[0])
-          if best is None:
-            best = pct
-            bestSec = sec
-          elif abs(pct - PCT) < abs(best - PCT):
+          if best is None or abs(pct - PCT) < abs(best - PCT):
             best = pct
             bestSec = sec
 

--- a/src/python/loadGraphActualQPS.py
+++ b/src/python/loadGraphActualQPS.py
@@ -88,9 +88,7 @@ def graph(rowPoint, logsDir, warmupSec, names, fileName, maxQPS=None):
         else:
           print("%s: drop data point qps=%s t=%s: t is >= 30000" % (name, qps, t))
 
-        if name not in maxActualQPS:
-          maxActualQPS[name] = actualQPS
-        elif actualQPS > maxActualQPS[name]:
+        if name not in maxActualQPS or actualQPS > maxActualQPS[name]:
           maxActualQPS[name] = actualQPS
 
   graphData.sort()
@@ -122,8 +120,7 @@ def graph(rowPoint, logsDir, warmupSec, names, fileName, maxQPS=None):
   print("  saved %s" % fileName)
   if sla is None:
     return None, maxActualQPS
-  else:
-    return passesSLA, maxActualQPS
+  return passesSLA, maxActualQPS
 
 
 graphHeader = """<html>

--- a/src/python/makeNRTGraph.py
+++ b/src/python/makeNRTGraph.py
@@ -6,7 +6,7 @@ import sys
 SHOW_DIRTY_BYTES = True
 
 reReopen = re.compile(r"^Reopen:\s+([0-9.]+) msec")
-reQT = re.compile("^QT (\d+) searches=(\d+) docs=(\d+) reopens=(\d+)(?: D=(\d+))?")
+reQT = re.compile(r"^QT (\d+) searches=(\d+) docs=(\d+) reopens=(\d+)(?: D=(\d+))?")
 
 qt = 0
 reopen = None

--- a/src/python/mergeFacets.py
+++ b/src/python/mergeFacets.py
@@ -22,22 +22,21 @@ class FacetShard:
     if topN is None:
       assert specificValues is None
       return self.results, None, None
+    l = self.results[:topN]
+    if specificValues is not None:
+      l2 = []
+      seen = set()
+      for value, count in self.results:
+        if value in specificValues:
+          seen.add(value)
+          l2.append((value, count))
+      for value in specificValues:
+        if value not in seen:
+          l2.append((value, 0))
     else:
-      l = self.results[:topN]
-      if specificValues is not None:
-        l2 = []
-        seen = set()
-        for value, count in self.results:
-          if value in specificValues:
-            seen.add(value)
-            l2.append((value, count))
-        for value in specificValues:
-          if value not in seen:
-            l2.append((value, 0))
-      else:
-        l2 = None
+      l2 = None
 
-      return l, len(self.results), l2
+    return l, len(self.results), l2
 
 
 def randomString(r):
@@ -120,9 +119,8 @@ def merge(shards, topN):
             for value, count in newValues:
               print("       *%s: count=%d" % (value, count))
         shardHits[i] = (exhausted, shardValues, lowestCount)
-      else:
-        if VERBOSE:
-          print("      shard %d: skip exhausted=%s len(shardMissingValues)=%s" % (i, exhausted, len(shardMissingValues)))
+      elif VERBOSE:
+        print("      shard %d: skip exhausted=%s len(shardMissingValues)=%s" % (i, exhausted, len(shardMissingValues)))
 
     # nocommit must handle the "all shards have 0 facets" case ... we
     # will exc below
@@ -196,8 +194,7 @@ def merge(shards, topN):
       if VERBOSE:
         print("  run again with mult=%s" % mult)
       continue
-    else:
-      break
+    break
 
   # l is list of (value, ([shardSeenCount, totalCount])), sorted by totalCount descending
   return [(x[0], x[1][0]) for x in l[:topN]], iterCount
@@ -326,9 +323,7 @@ def cmpByCountThenLabel2(a, b):
 
 
 class RandomModel:
-  """
-  Each shard gets random count for each facet label.
-  """
+  """Each shard gets random count for each facet label."""
 
   def __init__(self, r, labels):
     self.r = r
@@ -349,9 +344,7 @@ class RandomModel:
 
 
 class SameDistrModel:
-  """
-  Each shard draws according to the same freq/pct for each label.
-  """
+  """Each shard draws according to the same freq/pct for each label."""
 
   def __init__(self, r, labels):
     self.r = r

--- a/src/python/nightlyCompile.py
+++ b/src/python/nightlyCompile.py
@@ -83,11 +83,10 @@ def main():
         message("  retry...")
         time.sleep(60.0)
       else:
-        s = open("hgupdate.log", "r").read()
+        s = open("hgupdate.log").read()
         if s.find("not updating") != -1:
           raise RuntimeError("hg did not update: %s" % s)
-        else:
-          break
+        break
     else:
       raise RuntimeError("failed to run hg pull -u")
 

--- a/src/python/nrtPerf.py
+++ b/src/python/nrtPerf.py
@@ -36,7 +36,7 @@ def run(command):
 
 
 reNRTReopenTime = re.compile("^Reopen: +([0-9.]+) msec$", re.MULTILINE)
-reByTime = re.compile("  (\d+) searches=(\d+) docs=(\d+) reopens=(\d+) totUpdateTime=(\d+)$")
+reByTime = re.compile(r"  (\d+) searches=(\d+) docs=(\d+) reopens=(\d+) totUpdateTime=(\d+)$")
 
 
 def runOne(
@@ -214,7 +214,4 @@ if __name__ == "__main__":
       totalPerReopen = meanReopenMS + meanUpdateMS
       avgPerDoc = 0 if reopenStats.totalReopens == 0 else totalPerReopen / (float(reopenStats.totalDocs) / reopenStats.totalReopens)
       qps = 0 if int(numSearchThreads) == 0 else (float(reopenStats.totalSearches) / reopenStats.qtCount) / int(numSearchThreads)
-      print(
-        "%6s %8s %10s %10s %10s %10s %7s %8s"
-        % (s[0], s[1], "{:,.2f}".format(meanReopenMS), "{:,.2f}".format(meanUpdateMS), "{:,.2f}".format(totalPerReopen), "{:,.2f}".format(avgPerDoc), "{:,.2f}".format(qps), s[2])
-      )
+      print("%6s %8s %10s %10s %10s %10s %7s %8s" % (s[0], s[1], f"{meanReopenMS:,.2f}", f"{meanUpdateMS:,.2f}", f"{totalPerReopen:,.2f}", f"{avgPerDoc:,.2f}", f"{qps:,.2f}", s[2]))

--- a/src/python/ps_head.py
+++ b/src/python/ps_head.py
@@ -27,8 +27,7 @@ PS_EXE_PATH = shutil.which("ps")
 
 
 class PSTopN:
-  """
-  Simple class to launch a background thread that
+  """Simple class to launch a background thread that
   periodically records top N processes (by CPU descending) to
   a destination log file.
   """

--- a/src/python/regold_nightly.py
+++ b/src/python/regold_nightly.py
@@ -27,7 +27,7 @@ def main():
 
   fixed_lucene_index_path = None
 
-  with open(fixed_index_log, "r", encoding="utf-8") as f:
+  with open(fixed_index_log, encoding="utf-8") as f:
     while True:
       line = f.readline()
       if line == "":

--- a/src/python/remoteTestServer.py
+++ b/src/python/remoteTestServer.py
@@ -20,9 +20,7 @@ them, back to the main server.
 
 
 class Child(threading.Thread):
-  """
-  Interacts with one child test runner.
-  """
+  """Interacts with one child test runner."""
 
   def __init__(self, id, parent, startedEvent):
     threading.Thread.__init__(self)
@@ -121,7 +119,7 @@ class ReadEvents:
     while True:
       try:
         self.f = open(self.fileName, "rb")
-      except IOError:
+      except OSError:
         time.sleep(0.01)
       else:
         break
@@ -147,8 +145,7 @@ class ReadEvents:
       l = self.readline()
       if l.find('"IDLE",') != -1:
         return lines
-      else:
-        lines.append(l)
+      lines.append(l)
 
 
 class Parent:
@@ -197,8 +194,7 @@ class Parent:
       len = int(sys.stdin.read(8))
       if len == -1:
         return None
-      else:
-        return cPickle.loads(sys.stdin.read(len))
+      return cPickle.loads(sys.stdin.read(len))
 
 
 def main():

--- a/src/python/repeatLuceneTest.py
+++ b/src/python/repeatLuceneTest.py
@@ -82,7 +82,7 @@ def getArg(argName, default, hasArg=True):
 
 def error(message):
   beep()
-  print(("ERROR: %s" % message))
+  print("ERROR: %s" % message)
   print()
   sys.exit(1)
 
@@ -96,7 +96,7 @@ reDefines = re.compile("-D(.*?)=(.*?)(?: |$)")
 
 
 def printReproLines(logFileName, iters):
-  with open(logFileName, "r") as f:
+  with open(logFileName) as f:
     print()
     while True:
       line = f.readline()
@@ -116,9 +116,7 @@ def parseReproLine(line, iters):
     k, v = x
     if k == "testcase":
       testCase = v
-    elif k == "testmethod":
-      testCase += ".%s" % v
-    elif k == "tests.method":
+    elif k == "testmethod" or k == "tests.method":
       testCase += ".%s" % v
     elif k == "tests.seed":
       seed = v
@@ -143,7 +141,7 @@ def parseReproLine(line, iters):
   if iters != 1:
     s = s.strip() + " -iters %s" % iters
 
-  print(("\n%s\n" % s))
+  print("\n%s\n" % s)
 
 
 tup = os.path.split(os.getcwd())
@@ -225,7 +223,7 @@ if doCompile:
     else:
       res = os.system("%s compile-test > %s/compile.log 2>&1" % (constants.ANT_EXE, logDirName))
     if res:
-      print(open("%s/compile.log" % logDirName, "r").read())
+      print(open("%s/compile.log" % logDirName).read())
       sys.exit(1)
   finally:
     os.remove("%s/compile.log" % logDirName)
@@ -243,7 +241,7 @@ def nextIter(threadID, logFileName, secLastIter):
   global iter
 
   with iterLock:
-    print("")
+    print()
     if logFileName is None:
       print("%s [%d, jvm %d, %5.1fs]:" % (datetime.datetime.now(), iter, threadID, secLastIter))
     else:
@@ -253,12 +251,9 @@ def nextIter(threadID, logFileName, secLastIter):
 
 
 def eventToLog(eventsFileIn, fileOut):
-  """
-  Appends all stdout/stderr from the events file, to human readable form.
-  """
-
+  """Appends all stdout/stderr from the events file, to human readable form."""
   r = re.compile('^    "chunk": "(.*?)"$')
-  with open(eventsFileIn, "r") as f:
+  with open(eventsFileIn) as f:
     with open(fileOut, "wb") as fOut:
       while True:
         line = f.readline()
@@ -446,9 +441,9 @@ def _run(threadID):
             ignored = True
           elif obj[0] == "TEST_IGNORED_ASSUMPTION":
             if not onlyOnce:
-              print(("\n  TEST SKIPPED: %s" % obj[1]["failure"]["message"]))
+              print("\n  TEST SKIPPED: %s" % obj[1]["failure"]["message"])
             else:
-              print(("\n  TEST SKIPPED: %s" % obj[1]["failure"]["trace"]))
+              print("\n  TEST SKIPPED: %s" % obj[1]["failure"]["trace"])
             ignored = True
           elif obj[0] == "TEST_FINISHED":
             testName = None
@@ -492,18 +487,17 @@ def _run(threadID):
         failed = True
         beep()
         break
-      elif noTestsRun:
+      if noTestsRun:
         if onlyOnce:
           failed = True
           error("no test actually ran, due to an Assume or @Ignore/@Nightly/@Slow/etc.")
+        elif USE_JUNIT:
+          print("  WARNING: no test actually ran, due to typo or an Assume or @Ignore/@Nightly/@Slow/etc.")
         else:
-          if USE_JUNIT:
-            print("  WARNING: no test actually ran, due to typo or an Assume or @Ignore/@Nightly/@Slow/etc.")
-          else:
-            print("  WARNING: no test actually ran, due to an Assume or @Ignore/@Nightly/@Slow/etc.")
+          print("  WARNING: no test actually ran, due to an Assume or @Ignore/@Nightly/@Slow/etc.")
       else:
         if onlyOnce and not USE_JUNIT and not failed:
-          print(("  OK [%d tests]\n" % testCount))
+          print("  OK [%d tests]\n" % testCount)
         if doLog and USE_JUNIT:
           if not keepLogs:
             pass

--- a/src/python/responseTimeTests.py
+++ b/src/python/responseTimeTests.py
@@ -102,7 +102,7 @@ JOBS = []
 reSVNRev = re.compile(r"revision (.*?)\.")
 
 
-class Tee(object):
+class Tee:
   def __init__(self, file, att):
     self.file = file
     self.att = att
@@ -152,12 +152,11 @@ def captureEnv(logsDir):
           print("  now setting to [never]...")
         else:
           print("  already disabled")
+      elif s.find("[always]") == -1:
+        open(fileName, "wb").write("always")
+        print("  now setting to [always]...")
       else:
-        if s.find("[always]") == -1:
-          open(fileName, "wb").write("always")
-          print("  now setting to [always]...")
-        else:
-          print("  already enabled")
+        print("  already enabled")
 
 
 def kill(name, p):
@@ -416,7 +415,7 @@ def runOne(startTime, desc, dirImpl, postingsFormat, targetQPS, pct=None):
         v = p.poll()
         if p.poll() is not None:
           raise RuntimeError("  failed to start:\n\n%s" % open(stdLog).read())
-      except IOError:
+      except OSError:
         pass
       time.sleep(1.0)
 

--- a/src/python/resultsToGraph.py
+++ b/src/python/resultsToGraph.py
@@ -19,7 +19,7 @@ def loadPoints(fileName):
   size = os.path.getsize(fileName)
   if fileName not in pointsCache or pointsCache[fileName][0] != size:
     points = []
-    with open(fileName, "r") as f:
+    with open(fileName) as f:
       for line in f.readlines():
         # print('line %s' % line)
         m = r.match(line.strip())

--- a/src/python/runFacetsBenchmark.py
+++ b/src/python/runFacetsBenchmark.py
@@ -60,7 +60,7 @@ def run_benchmark(lucene_dir, index_dir, data_dir, nightly_log_dir, doc_limit, n
   # run benchmark
   benchmark_cmd = f"{localconstants.JAVA_EXE} -cp {lucene_core_jar}:{lucene_facet_jar}:build perf.facets.BenchmarkFacets {index_dir} {num_iters}"
   print(f"RUN: {benchmark_cmd}, cwd={os.getcwd()}")
-  results = subprocess.run(benchmark_cmd, shell=True, capture_output=True)
+  results = subprocess.run(benchmark_cmd, shell=True, capture_output=True, check=False)
 
   stdout = results.stdout.decode("utf-8")
   stderr = results.stderr.decode("utf-8")

--- a/src/python/runGeoShapeBenches.py
+++ b/src/python/runGeoShapeBenches.py
@@ -8,7 +8,7 @@ import time
 
 # src/python/runGeoShapeBenches.py -compare -reindex -ant
 
-reTotHits = re.compile("totHits=(\d+)$")
+reTotHits = re.compile(r"totHits=(\d+)$")
 
 nightly = "-nightly" in sys.argv
 compareRun = "-compare" in sys.argv

--- a/src/python/runNightlyGradleTestPrecommit.py
+++ b/src/python/runNightlyGradleTestPrecommit.py
@@ -92,7 +92,7 @@ def runPrecommit(logFile):
       os.rename(logFile + ".tmp", logFile)
       print("  took: %.1f min" % ((t1 - t0) / 60.0))
       break
-    elif i < 4:
+    if i < 4:
       print(f"FAILED; see {logFile}.tmp; will try again ({5 - i - 1} attempts remain)")
     else:
       print("FAILED; see %s.tmp" % logFile)
@@ -102,8 +102,7 @@ def getTestCount(line, regexp):
   m = regexp.search(line)
   if m is not None:
     return int(m.group(1))
-  else:
-    return -1
+  return -1
 
 
 def pick_seconds(tup):
@@ -111,8 +110,7 @@ def pick_seconds(tup):
   # on Nov 30 2021 we switched to summing aggregate_tasks_seconds so the many-cored beast3 doesn't hide progress:
   if aggregate_task_seconds is not None:
     return aggregate_task_seconds
-  else:
-    return elapsed_seconds
+  return elapsed_seconds
 
 
 def writeGraph():
@@ -185,7 +183,7 @@ Aggregate task times (possibly running in parallel!):
           in_aggregate_task_times = True
           aggregate_time_sec = 0
           continue
-        elif in_aggregate_task_times:
+        if in_aggregate_task_times:
           if len(line.strip()) == 0:
             # ends with empty line
             in_aggregate_task_times = False

--- a/src/python/runOrdinalMapBenchmark.py
+++ b/src/python/runOrdinalMapBenchmark.py
@@ -43,7 +43,7 @@ def run_benchmark(lucene_dir, geonames_csv_in, index_dir, nightly_log_dir, doc_l
 
   cmd = f"{localconstants.JAVA_EXE} -cp {lucene_core_jar}:build perf.OrdinalMapBenchmark {geonames_csv_in} {localconstants.INDEX_DIR_BASE}/geonames-ordinal-map {doc_limit}"
   print(f'cmd ="{cmd}"')
-  results = subprocess.run(cmd, shell=True, capture_output=True)
+  results = subprocess.run(cmd, shell=True, capture_output=True, check=False)
   stdout = results.stdout.decode("utf-8")
   stderr = results.stderr.decode("utf-8")
 

--- a/src/python/runRemoteTests.py
+++ b/src/python/runRemoteTests.py
@@ -58,9 +58,7 @@ def run(comment, cmd, logFile, printTime=False):
 
 
 class Remote(threading.Thread):
-  """
-  Handles interactions with one remote machine.
-  """
+  """Handles interactions with one remote machine."""
 
   def __init__(self, id, stats, jobs, command, classpath, rootDir, hostName, processCount):
     threading.Thread.__init__(self)
@@ -131,7 +129,7 @@ class Remote(threading.Thread):
       msg("%s: startup read %s" % (self.hostName, s.rstrip()))
       if s == "":
         raise RuntimeError('failed to start remoteTestServer.py on host "%s"' % self.hostName)
-      elif s.strip() == "REMOTE SERVER STARTED":
+      if s.strip() == "REMOTE SERVER STARTED":
         break
 
     msg("local: %s: started" % self.hostName)

--- a/src/python/runStoredFieldsBenchmark.py
+++ b/src/python/runStoredFieldsBenchmark.py
@@ -44,7 +44,7 @@ def run_benchmark(lucene_dir, geonames_csv_in, index_dir, nightly_log_dir, doc_l
     print(f"Now run {mode} with doc_limit={doc_limit}:")
     command = f"{localconstants.JAVA_EXE} -cp {lucene_core_jar}:build perf.StoredFieldsBenchmark {geonames_csv_in} {localconstants.INDEX_DIR_BASE}/geonames-stored-fields {mode} {doc_limit}"
     print(f"RUN: {command}")
-    results = subprocess.run(command, shell=True, capture_output=True)
+    results = subprocess.run(command, shell=True, capture_output=True, check=False)
     stdout = results.stdout.decode("utf-8")
     stderr = results.stderr.decode("utf-8")
 

--- a/src/python/segments_to_html.py
+++ b/src/python/segments_to_html.py
@@ -148,13 +148,11 @@ USE_SVG = True
 
 
 def compute_time_metrics(checkpoints, commits, full_flush_events, segments, start_abs_time, end_abs_time):
-  """
-  Computes aggregate metrics by time: MB/sec writing
+  """Computes aggregate metrics by time: MB/sec writing
   (flushing/merging), number of segments, number/%tg deletes, max_doc,
   concurrent flush count, concurrent merge count, total disk usage,
   indexing rate, write amplification, delete rate, add rate
   """
-
   name_to_segment = {}
 
   # single list that mixes end and start times
@@ -296,26 +294,25 @@ def compute_time_metrics(checkpoints, commits, full_flush_events, segments, star
           tot_size_mb += segment.size_mb
           tot_flush_write_mb += segment.size_mb
           tot_weighted_write_ampl += segment.size_mb * segment.net_write_amplification
-      else:
-        if what == "segstart":
-          merge_mbs += mbs
-          merge_dps += dps
-          if segment.del_reclaims_per_sec is not None:
-            del_reclaims_per_sec += segment.del_reclaims_per_sec
-          merge_thread_count += 1
-          seg_name_to_size[segment.name] = segment.size_mb
-        elif what == "segend":
-          tot_size_mb -= segment.size_mb
-          tot_weighted_write_ampl -= segment.size_mb * segment.net_write_amplification
-        elif what == "seglight":
-          tot_size_mb += segment.size_mb
-          tot_merge_write_mb += segment.size_mb
-          merge_thread_count -= 1
-          merge_mbs -= mbs
-          merge_dps -= dps
-          if segment.del_reclaims_per_sec is not None:
-            del_reclaims_per_sec -= segment.del_reclaims_per_sec
-          tot_weighted_write_ampl += segment.size_mb * segment.net_write_amplification
+      elif what == "segstart":
+        merge_mbs += mbs
+        merge_dps += dps
+        if segment.del_reclaims_per_sec is not None:
+          del_reclaims_per_sec += segment.del_reclaims_per_sec
+        merge_thread_count += 1
+        seg_name_to_size[segment.name] = segment.size_mb
+      elif what == "segend":
+        tot_size_mb -= segment.size_mb
+        tot_weighted_write_ampl -= segment.size_mb * segment.net_write_amplification
+      elif what == "seglight":
+        tot_size_mb += segment.size_mb
+        tot_merge_write_mb += segment.size_mb
+        merge_thread_count -= 1
+        merge_mbs -= mbs
+        merge_dps -= dps
+        if segment.del_reclaims_per_sec is not None:
+          del_reclaims_per_sec -= segment.del_reclaims_per_sec
+        tot_weighted_write_ampl += segment.size_mb * segment.net_write_amplification
 
       if cur_max_doc == 0:
         # sidestep delete-by-zero ha
@@ -516,10 +513,10 @@ def main():
   w("</div>")
   w("</form>")
   w("")
-  w(f'<div id="details" style="position:absolute;left: 5;top: 5; z-index:10; background: rgba(255, 255, 255, 0.85); font-size: 18; font-weight: bold;"></div>')
+  w('<div id="details" style="position:absolute;left: 5;top: 5; z-index:10; background: rgba(255, 255, 255, 0.85); font-size: 18; font-weight: bold;"></div>')
   w('<div id="details2" style="position:absolute; right:0; display: flex; justify-content: flex-end; z-index:10; background: rgba(255, 255, 255, 0.85); font-size: 18; font-weight: bold;"></div>')
 
-  w(f'<div id="divit" align=left style="position:absolute; left:5; top:5; overflow:scroll;height:100%;width:100%">')
+  w('<div id="divit" align=left style="position:absolute; left:5; top:5; overflow:scroll;height:100%;width:100%">')
 
   w(
     f'<svg preserveAspectRatio="none" id="it" viewBox="0 0 {whole_width + 400} {whole_height + 100}" width="{whole_width}" height="{whole_height}" xmlns="http://www.w3.org/2000/svg" style="height:100%">'
@@ -559,7 +556,7 @@ def main():
         l[0] += 1
         l[1] += segment.size_mb
 
-  w(f"\n\n  <!-- full flush events -->")
+  w("\n\n  <!-- full flush events -->")
   for flush_ord, (start_time, end_time) in enumerate(full_flush_events):
     if end_time is None:
       continue
@@ -572,7 +569,7 @@ def main():
     flush_id = f"ff_{flush_ord}"
     w(f'  <rect fill="{full_flush_color}" x={x0:.2f} y={y0:.2f} width={x1 - x0:.2f} height={y1 - y0:.2f} seg_name="{flush_id}" id="{flush_id}"/>')
 
-  w(f"\n\n  <!-- merge-on-commit events -->")
+  w("\n\n  <!-- merge-on-commit events -->")
   for moc_ord, (start_time, end_time) in enumerate(merge_during_commit_events):
     if end_time is None:
       continue
@@ -812,7 +809,7 @@ def main():
       else:
         new_color = merge_dawn_color
 
-      w(f"  <!--dawn:-->")
+      w("  <!--dawn:-->")
       w(f'  <rect x={x0:.2f} y={y0:.2f} width={x_light - x0:.2f} height={height:.2f} rx=4 fill="{new_color}" seg_name="{segment.name}"/>')
 
     if segment.merged_into is not None:
@@ -826,7 +823,7 @@ def main():
       dusk_timestamp = segment.merged_into.start_time
       assert dusk_timestamp < t1
       x_dusk = padding_x + x_pixels_per_sec * (dusk_timestamp - min_start_abs_time).total_seconds()
-      w(f"  <!--dusk:-->")
+      w("  <!--dusk:-->")
       w(f'  <rect x={x_dusk:.2f} y={y0:.2f} width={x1 - x_dusk:.2f} height={height:.2f} rx=4 fill="{new_color}" seg_name="{segment.name}"/>')
 
       light_timestamp2 = None
@@ -852,12 +849,12 @@ def main():
 
         if False:
           w('var l = document.createElementNS("http://www.w3.org/2000/svg", "line");')
-          w(f'l.setAttribute("id", ");')
+          w('l.setAttribute("id", ");')
           w(f'l.setAttribute("x1", {x_dusk});')
           w(f'l.setAttribute("y1", {y0 + y_pixels_per_level / 2});')
           w(f'l.setAttribute("x2", {x_light_merge});')
           w(f'l.setAttribute("y2", {y1a - y_pixels_per_level / 2});')
-          w(f"mysvg.appendChild(l);")
+          w("mysvg.appendChild(l);")
 
   # w('canvas.on("mouse:over", show_segment_details);')
   # w('canvas.on("mouse:out", function(e) {canvas.remove(textbox);  textbox = null;});')
@@ -938,8 +935,8 @@ def main():
       details += f"\n  {100.0 * segment.born_del_count / segment.max_doc:.1f}% stillborn"
 
     # w(f'seg_details_map.set("{segment.name}", {repr(details)});')
-    w(f'seg_details2_map.set("{segment.name}", {repr(segment.to_verbose_string(min_start_abs_time, end_abs_time, False))});')
-    w(f'seg_details3_map.set("{segment.name}", {repr(segment.to_verbose_string(min_start_abs_time, end_abs_time, True))});')
+    w(f'seg_details2_map.set("{segment.name}", {segment.to_verbose_string(min_start_abs_time, end_abs_time, False)!r});')
+    w(f'seg_details3_map.set("{segment.name}", {segment.to_verbose_string(min_start_abs_time, end_abs_time, True)!r});')
 
   w("""
   const top_details = document.getElementById('details');

--- a/src/python/skipper.py
+++ b/src/python/skipper.py
@@ -165,11 +165,10 @@ def writeTowers(skipWriter, fixedDocGap, postingsBytes):
       actualWritePointer = writePointer - len(tower.bytes)
       if actualWritePointer == tower.writePointer:
         break
-      else:
-        if VERBOSE:
-          print("    tower retry")
-        tower.writePointer = actualWritePointer
-        towerNumBytes[len(tower.nextTowers)] = len(tower.bytes)
+      if VERBOSE:
+        print("    tower retry")
+      tower.writePointer = actualWritePointer
+      towerNumBytes[len(tower.nextTowers)] = len(tower.bytes)
 
     writePointer -= len(tower.bytes)
     if VERBOSE:
@@ -216,9 +215,7 @@ def writeTowers(skipWriter, fixedDocGap, postingsBytes):
 
 
 class SkipReader:
-  """
-  Reads serialized Towers.
-  """
+  """Reads serialized Towers."""
 
   def __init__(self, b, inlined, skipInterval, fixedDocGap):
     self.b = b
@@ -320,15 +317,14 @@ class SkipReader:
     if level == 0:
       # No skipping
       return False
-    else:
-      level -= 1
-      while True:
-        # Jump on this level / move down a level:
-        level = self.readTower(self.nextTowerPositions[level], self.nextTowerLastDocIDs[level], targetDocID)
-        if level == -1:
-          break
+    level -= 1
+    while True:
+      # Jump on this level / move down a level:
+      level = self.readTower(self.nextTowerPositions[level], self.nextTowerLastDocIDs[level], targetDocID)
+      if level == -1:
+        break
 
-      return True
+    return True
 
 
 def makeDocs(r, count):
@@ -410,9 +406,7 @@ class ByteBufferReader:
 
 
 class WholeIntAbsCodec:
-  """
-  Each absolute docID is written as 4 bytes.
-  """
+  """Each absolute docID is written as 4 bytes."""
 
   lastReadCount = 0
 
@@ -435,9 +429,7 @@ class WholeIntAbsCodec:
 
 
 class WholeIntDeltaCodec:
-  """
-  Each delta docID is written as 4 bytes.
-  """
+  """Each delta docID is written as 4 bytes."""
 
   lastDocID = 0
   lastReadCount = 0
@@ -462,9 +454,7 @@ class WholeIntDeltaCodec:
 
 
 class VIntDeltaCodec:
-  """
-  Each delta docID is written as 4 bytes.
-  """
+  """Each delta docID is written as 4 bytes."""
 
   lastDocID = 0
   lastReadCount = 0

--- a/src/python/sparsetaxis/backTest.py
+++ b/src/python/sparsetaxis/backTest.py
@@ -134,11 +134,9 @@ for name in os.listdir(TAXIS_LOGS_DIR):
 
 
 def getTimesToTest():
-  """
-  Carefully enumerates commit timestamps in such a way that we test large gaps first, then smaller
+  """Carefully enumerates commit timestamps in such a way that we test large gaps first, then smaller
   gaps, and eventually all commits in the range.
   """
-
   # First, make sure we test all explicitly annotated commits in the graph:
   for timestampString, desc in writeGraph.CHANGES:
     t = datetime.datetime.strptime(timestampString, "%Y-%m-%d %H:%M:%S")

--- a/src/python/sparsetaxis/csvToBlocks.py
+++ b/src/python/sparsetaxis/csvToBlocks.py
@@ -2,7 +2,7 @@ import io
 import struct
 import sys
 
-with open(sys.argv[1], "r", encoding="utf-8") as f, open(sys.argv[2], "wb") as fOut:
+with open(sys.argv[1], encoding="utf-8") as f, open(sys.argv[2], "wb") as fOut:
   # write CSV header outside of blocks:
   header = f.readline()
   fOut.write(header.encode("utf-8"))

--- a/src/python/sparsetaxis/mergeGreenAndYellow.py
+++ b/src/python/sparsetaxis/mergeGreenAndYellow.py
@@ -53,18 +53,16 @@ def compareByTime(color1, ride1, color2, ride2):
   pickup2 = pickupTime(color2, ride2)
   if pickup1 < pickup2:
     return -1
-  elif pickup1 > pickup2:
+  if pickup1 > pickup2:
     return 1
-  else:
-    # tie break by dropoff time
-    dropoff1 = dropoffTime(color1, ride1)
-    dropoff2 = dropoffTime(color2, ride2)
-    if dropoff1 < dropoff2:
-      return -1
-    elif dropoff1 > dropoff2:
-      return 1
-    else:
-      return 0
+  # tie break by dropoff time
+  dropoff1 = dropoffTime(color1, ride1)
+  dropoff2 = dropoffTime(color2, ride2)
+  if dropoff1 < dropoff2:
+    return -1
+  if dropoff1 > dropoff2:
+    return 1
+  return 0
 
 
 class TaxiReader:
@@ -86,7 +84,7 @@ class TaxiReader:
       self.year += 1
       self.month = 1
 
-    self.f = open(fileName, "r", encoding="utf-8")
+    self.f = open(fileName, encoding="utf-8")
     self.reader = csv.reader(self.f)
     headers = next(self.reader)
     self.headersToIndex = []

--- a/src/python/sparsetaxis/runBenchmark.py
+++ b/src/python/sparsetaxis/runBenchmark.py
@@ -72,7 +72,7 @@ def run(command, logFile=None):
     print("    log: %s" % logFile)
   if os.system(command) != 0:
     if logFile is not None:
-      print(open(logFile, "r", encoding="utf-8").read())
+      print(open(logFile, encoding="utf-8").read())
     raise RuntimeError('command "%s" failed' % command)
 
 
@@ -118,7 +118,7 @@ def runIndexing(args, cpuCount, sparseOrNot, sortOrNot):
           lastPrint = now
     p.wait()
     if p.returncode != 0:
-      print(open(logFile, "r", encoding="utf-8").read())
+      print(open(logFile, encoding="utf-8").read())
       raise RuntimeError("indexing failed: %s" % p.returncode)
   print("  %6.1f sec: %5.1f M docs; %5.1f K docs/sec" % (float(lastMatch.group(1)), int(lastMatch.group(2)) / 1000000.0, float(lastMatch.group(3)) / 1000.0))
 

--- a/src/python/sparsetaxis/searchLogToHistogram.py
+++ b/src/python/sparsetaxis/searchLogToHistogram.py
@@ -10,7 +10,7 @@ def extractSearchStats(searchLog, byQuerySort={}):
   heapBytesByPart = {}
   byThread = {}
 
-  with open(searchLog, "r", encoding="utf-8") as f:
+  with open(searchLog, encoding="utf-8") as f:
     while True:
       line = f.readline()
       if line == "":

--- a/src/python/sparsetaxis/sortOneFile.py
+++ b/src/python/sparsetaxis/sortOneFile.py
@@ -13,7 +13,7 @@ def sortOneFile(fileName):
   if os.path.exists(fileNameOut):
     print("  already done!")
     return
-  reader = csv.reader(open(fileName, "r", encoding="utf-8"))
+  reader = csv.reader(open(fileName, encoding="utf-8"))
   headers = next(reader)
   pickupTimeIndex = None
   dropoffTimeIndex = None

--- a/src/python/sparsetaxis/writeGraph.py
+++ b/src/python/sparsetaxis/writeGraph.py
@@ -61,7 +61,7 @@ def extractIndexStats(indexLog):
   docsPerMBDisk = 0
   flushCount = 0
   lastDPSMatch = None
-  with open(indexLog, "r", encoding="utf-8") as f:
+  with open(indexLog, encoding="utf-8") as f:
     while True:
       line = f.readline()
       if line == "":
@@ -113,7 +113,7 @@ def extractSearchStats(searchLog):
   heapBytes = None
   heapBytesByPart = {}
   byThread = {}
-  with open(searchLog, "r", encoding="utf-8") as f:
+  with open(searchLog, encoding="utf-8") as f:
     while True:
       line = f.readline()
       if line == "":
@@ -131,8 +131,7 @@ def extractSearchStats(searchLog):
             sortDesc = None
           else:
             sortDesc = "longitude"
-          if hitCount.endswith("+"):
-            hitCount = hitCount[:-1]
+          hitCount = hitCount.removesuffix("+")
           byThread[threadID].append((queryDesc, sortDesc, int(hitCount), float(msec)))
         else:
           m = reHeapUsagePart.match(line)
@@ -188,12 +187,12 @@ def extractSearchStats(searchLog):
 
 
 def extractDiskUsageStats(logFileName):
-  with open(logFileName, "r") as f:
+  with open(logFileName) as f:
     while True:
       line = f.readline()
       if line == "":
         raise RuntimeError('unexpected EOF while parsing "%s"' % logFileName)
-      elif line.startswith("num docs:"):
+      if line.startswith("num docs:"):
         break
 
     mbByPart = {}

--- a/src/python/splitWikiLineFile.py
+++ b/src/python/splitWikiLineFile.py
@@ -1,6 +1,6 @@
 import sys
 
-f = open(sys.argv[1], "r")
+f = open(sys.argv[1])
 fOut = open(sys.argv[2], "w")
 numCharLimit = int(sys.argv[3])
 

--- a/src/python/sumAnalyzerPerf.py
+++ b/src/python/sumAnalyzerPerf.py
@@ -75,7 +75,7 @@ def readResults(targetdir, lang):
 
         if len(results) == numOfAnalyzers:
           # print("keep %s" % str(results))
-          for key in results.keys():
+          for key in results:
             if key != "rev":
               if lang == "ja":
                 analyzersJa.add(key)

--- a/src/python/test_all_fst_sizes.py
+++ b/src/python/test_all_fst_sizes.py
@@ -30,13 +30,13 @@ while True:
   stdout = stdout.decode("utf-8")
   open(f"logs/{ram_mb}.stdout", "w", encoding="utf-8").write(stdout)
 
-  m = re.search('^saved FST to "fst.bin": (\d+) bytes; ([0-9.]+) sec$', stdout, re.MULTILINE)
+  m = re.search(r'^saved FST to "fst.bin": (\d+) bytes; ([0-9.]+) sec$', stdout, re.MULTILINE)
   fst_mb = int(m.group(1)) / 1024 / 1024
   fst_build_sec = float(m.group(2))
 
   actual_ram_mb = 0
 
-  for s in re.findall("RAM (\d+) bytes$", stdout, re.MULTILINE):
+  for s in re.findall(r"RAM (\d+) bytes$", stdout, re.MULTILINE):
     actual_ram_mb = max(actual_ram_mb, int(s) / 1024 / 1024)
 
   if actual_ram_mb > ram_mb:
@@ -50,7 +50,7 @@ while True:
 
   pickle.dump(results, open("results.pk", "wb"))
 
-  print(f"ram_mb,fst_mb,fst_build_sec,actual_ram_mb")
+  print("ram_mb,fst_mb,fst_build_sec,actual_ram_mb")
   for ram_mb0, fst_mb, fst_build_sec, actual_ram_mb in results:
     print(f"{ram_mb0},{fst_mb:.3f},{fst_build_sec:.3f},{actual_ram_mb:.3f}")
 

--- a/src/python/wikiXMLToText.py
+++ b/src/python/wikiXMLToText.py
@@ -34,7 +34,7 @@ class AllText:
     self.allText = []
 
   def start(self, name):
-    print("")
+    print()
     print("TEXT: %s" % name)
     self.text = []
     self.name = name
@@ -57,7 +57,7 @@ class AllText:
     mbPerPart = float(mb) / len(self.allText)
 
 
-reSpace = re.compile("\s+")
+reSpace = re.compile(r"\s+")
 
 
 def clean(s):

--- a/src/python/writeGeoGraphs.py
+++ b/src/python/writeGeoGraphs.py
@@ -177,16 +177,15 @@ def writeOneGraph(data, chartID, chartTitle, yLabel, allTimes):
 def prettyName(approach):
   if approach == "points":
     return "LatLonPoint"
-  elif approach == "points-withdvs":
+  if approach == "points-withdvs":
     return "LatLonPoint+DV"
-  elif approach == "geopoint":
+  if approach == "geopoint":
     return "GeoPoint"
-  elif approach == "geo3d":
+  if approach == "geo3d":
     return "Geo3D"
-  elif approach == "shapes":
+  if approach == "shapes":
     return "LatLonShape"
-  else:
-    raise RuntimeError("unhandled approach %s" % approach)
+  raise RuntimeError("unhandled approach %s" % approach)
 
 
 def getLabel(label):


### PR DESCRIPTION
Enable all ruff lint rules, apply all safe autofixes, then disable the remaining ones as a massive TODO list

This applies some standards/cleanup to the code in a safe way, in many cases the changes are cosmetic, but it helps to follow conventions.

If we are really against any of the changes made, I can chase down the rule and disable it and regen the PR.