### PR TITLE
Adding numSearchThread for multi-threaded search

### DIFF
--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -66,6 +66,7 @@ PARAMS = {
   #'quantizeBits': (32, 7, 4),
   "numMergeWorker": (12,),
   "numMergeThread": (4,),
+  # "numSearchThread": (8,), # fixed sized threadpool size to pass to the index searcher.
   #'numMergeWorker': (1,),
   #'numMergeThread': (1,),
   "encoding": ("float32",),


### PR DESCRIPTION
Its useful to test latency and throughput in multi-threaded scenarios. Adding new `numSearchThread` for kNN perf script.