### PR TITLE
Increase topN to 1,000.

### DIFF
--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -297,7 +297,7 @@ class Competitor:
     exitable=False,
     searchConcurrency=0,
     javacCommand=constants.JAVAC_EXE,
-    topN=100,
+    topN=1000,
     testContext="",
   ):
     self.name = name


### PR DESCRIPTION
While applications often display only 20 to 100 hits, their candidate retrieval phase may retrieve many more hits, before more reranking and selection happen. I would like to increase the topN in Lucene's nightly benchmarks to better reflect the sort of values that is effectively used nowadays.

This is a big change. With topN=100, disjunctive queries run as conjunctive queries in practice because the scorer quickly figures out that only documents that contain all terms may be competitive. This is no longer the case at topN=1,000.