### PR TITLE
Add async-profiler as an alternative option to JFR.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ work/
 node_modules/
 knnIndices/
 
+async-profiler/
+
 # emacs temporary files
 *~
 #*

--- a/build.gradle
+++ b/build.gradle
@@ -42,3 +42,65 @@ allprojects {
         }
     }
 }
+
+task setupAsyncProfiler {
+    description = 'Download and unpack async-profiler unless its native library is already present.'
+    group       = 'build setup'
+
+    // ─────────── platform detection ───────────
+    def version = '4.0'
+    def os      = org.gradle.internal.os.OperatingSystem.current()
+    def classifier, libName
+
+    if (os.isLinux()) {
+        classifier = 'linux-x64'
+        libName    = 'libasyncProfiler.so'
+    } else if (os.isMacOsX()) {
+        classifier = System.getProperty('os.arch').contains('aarch')
+                ? 'macos-arm64'
+                : 'macos-x64'
+        libName    = 'libasyncProfiler.dylib'
+    } else {
+        throw new GradleException("async-profiler: unsupported OS '${os.getName()}'")
+    }
+
+    def downloadUrl = "https://github.com/async-profiler/async-profiler/releases/" +
+            "download/v${version}/async-profiler-${version}-${classifier}.tar.gz"
+
+    // ─────────── up-to-date checks ───────────
+    def targetDir     = project.file("${project.projectDir}/async-profiler")
+    def targetLibFile = project.file("${targetDir}/lib/${libName}")
+
+    outputs.file(targetLibFile)
+    onlyIf { !targetLibFile.exists() } // skip whole task once extracted
+
+    doLast {
+        println "▶ Installing async-profiler ${version} (${classifier})"
+
+        // 1) download
+        def dlFile = project.layout.buildDirectory
+                .file("tmp/async-profiler-${version}-${classifier}.tgz")
+                .get().asFile
+        dlFile.parentFile.mkdirs()
+
+        ant.get(src: downloadUrl, dest: dlFile, verbose: true)
+
+        // 2) extract (flatten leading dir)
+        copy {
+            from tarTree(resources.gzip(dlFile))
+            into targetDir
+            includeEmptyDirs = false
+            eachFile { f ->
+                f.path = f.path.replaceFirst('^async-profiler-[^/]+/', '')
+            }
+        }
+
+        // 3) cleanup
+        dlFile.delete()
+
+        if (!targetLibFile.exists()) {
+            throw new GradleException("Extraction finished, but ${libName} not found in ${targetDir}")
+        }
+        println "✔ async-profiler ready – native lib at ${targetLibFile}"
+    }
+}

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -142,6 +142,10 @@ ANALYZER_DEFAULT = "StandardAnalyzer"
 SIMILARITY_DEFAULT = "BM25Similarity"
 MERGEPOLICY_DEFAULT = "LogDocMergePolicy"
 
+# Profiler configuration
+# Type of profiler to use: 'JFR' or 'ASYNC'
+PROFILER_TYPE = "JFR"
+
 TESTS_LINE_FILE = "/lucene/clean2.svn/lucene/test-framework/src/resources/org/apache/lucene/util/europarl.lines.txt"
 TESTS_LINE_FILE = "/lucenedata/from_hudson/hudson.enwiki.random.lines.txt"
 # TESTS_LINE_FILE = None

--- a/src/python/initial_setup.py
+++ b/src/python/initial_setup.py
@@ -39,12 +39,22 @@ USAGE = """
 Usage: python initial_setup.py [-download]
 
 Options:
-  -download downloads a 5GB linedoc file 
+  -download downloads a 5GB linedoc file
 
 """
 DEFAULT_LOCAL_CONST = """
 BASE_DIR = '%(base_dir)s'
 BENCH_BASE_DIR = '%(base_dir)s/%(cwd)s'
+
+# Type of profiler to use: 'JFR' (default) or 'ASYNC'
+PROFILER_TYPE = 'JFR'
+
+# Path to async-profiler installation directory (required if PROFILER_TYPE is 'ASYNC')
+ASYNC_PROFILER_HOME = f"{BENCH_BASE_DIR}/async-profiler"
+
+# Additional arguments to pass to async-profiler (e.g., "interval=10ms,live")
+ASYNC_PROFILER_OPTIONS = 'cstack=vm'
+
 """
 
 


### PR DESCRIPTION
I've been meaning to put this up for a while, but I had also added Perfasm as a profiling option and it requires some more thinking to determine how best to use with the amount of data generated by these benchmarks without requiring many hundreds of GB of heap space (I've played around with some options, but nothing I was ready to settle on). So I finally just pulled Perfasm out for now and will take a look at again later on in another issue.

This may warrant a bit of cleanup after the rip, but I've made a first pass at it.

I'll post some more notes on it when I make another review sweep.