### PR TITLE
Preload vector files before exact NN computation

### DIFF
--- a/src/main/knn/KnnIndexer.java
+++ b/src/main/knn/KnnIndexer.java
@@ -104,6 +104,7 @@ public class KnnIndexer {
     // aim for more compact/realistic index:
     TieredMergePolicy tmp = (TieredMergePolicy) iwc.getMergePolicy();
     tmp.setFloorSegmentMB(256);
+    tmp.setNoCFSRatio(0);
     // tmp.setSegmentsPerTier(5);
     if (useBp) {
       iwc.setMergePolicy(new BPReorderingMergePolicy(iwc.getMergePolicy(), new BpVectorReorderer(KnnGraphTester.KNN_FIELD)));


### PR DESCRIPTION
Solve issue mention in #390 

I made two changes in this pull request:
- Disable compound file  for `TieredMergePolicy` to make sure the segments created by index merges is not in the `.cfs` format. 
- Preload vector files before running queries to index to compute exact NNs 


Before & after results when computing exact NN for 100 queries, 5MM doc embeddings, 4K dimension float32
```
BEFORE
took 9205.919 sec to compute brute-force exact matches


AFTER
took 202.213 sec to compute brute-force exact matches
```
