### PR TITLE
Remove indexPath when computing hash value used for naming exact NN file

### DIFF
--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -517,7 +517,7 @@ public class KnnGraphTester {
           if (outputPath != null) {
             testSearch(indexPath, queryPath, queryStartIndex, outputPath, null);
           } else {
-            testSearch(indexPath, queryPath, queryStartIndex, null, getExactNN(docVectorsPath, indexPath, queryPath, queryStartIndex));
+            testSearch(indexPath, queryPath, queryStartIndex, null, getExactNN(docVectorsPath, queryPath, queryStartIndex));
           }
           if (operation.equals("-search-and-stats")) {
             // also print stats, after searching
@@ -1022,9 +1022,9 @@ public class KnnGraphTester {
    * The method runs "numQueryVectors" target queries and returns "topK" nearest neighbors
    * for each of them. Nearest Neighbors are computed using exact match.
    */
-  private int[][] getExactNN(Path docPath, Path indexPath, Path queryPath, int queryStartIndex) throws IOException, InterruptedException {
+  private int[][] getExactNN(Path docPath, Path queryPath, int queryStartIndex) throws IOException, InterruptedException {
     // look in working directory for cached nn file
-    String hash = Integer.toString(Objects.hash(docPath, indexPath, queryPath, numDocs, numQueryVectors, topK, similarityFunction.ordinal(), parentJoin, queryStartIndex, prefilter ? selectivity : 1f, prefilter ? randomSeed : 0f), 36);
+    String hash = Integer.toString(Objects.hash(docPath, queryPath, numDocs, numQueryVectors, topK, similarityFunction.ordinal(), parentJoin, queryStartIndex, prefilter ? selectivity : 1f, prefilter ? randomSeed : 0f), 36);
     String nnFileName = "nn-" + hash + ".bin";
     Path nnPath = Paths.get(nnFileName);
     if (Files.exists(nnPath) && isNewer(nnPath, docPath, queryPath)) {


### PR DESCRIPTION
 Exact NN should be independent of the `indexPath` as we should remove it when computing hash value used for naming exact NN File. This will help reduce some extra computation when the `indexPath` changes but the exact NNs doesn't change .e.g. when benchmarking different quantization level for the same data.



Re-running the benchmarks before & after the change:

**Before** (exact NN are computed 2 times as indexPath is part of the hash computation)
```
recall  latency(ms)    nDoc  topK  fanout  maxConn  beamWidth  quantized  index(s)  index_docs/s  num_segments  index_size(MB)  vec_disk(MB)  vec_RAM(MB)  indexType
 0.832        0.630  100000   100      50       64        250     4 bits     16.05       6231.31             1          116.66       110.245       12.589       HNSW
 0.898        0.810  100000   100      50       64        250     7 bits     22.29       4487.32             1          129.09       122.452       24.796       HNSW
```

**After** (exact NN is reused)
```
recall  latency(ms)    nDoc  topK  fanout  maxConn  beamWidth  quantized  index(s)  index_docs/s  num_segments  index_size(MB)  vec_disk(MB)  vec_RAM(MB)  indexType
 0.837        0.540  100000   100      50       64        250     4 bits     17.96       5567.62             1          116.68       110.245       12.589       HNSW
 0.897        0.800  100000   100      50       64        250     7 bits     25.18       3971.09             1          128.89       122.452       24.796       HNSW
```

