### PR TITLE
Enable intra-query concurrency and measure net cpu in knnPerfTest

### DIFF
--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -44,8 +44,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BinaryOperator;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
@@ -201,6 +199,7 @@ public class KnnGraphTester {
     quantizeBits = 7;
     quantizeCompress = false;
     numIndexThreads = 8;
+    numSearchThread = 0;
     queryStartIndex = 0;
     indexType = IndexType.HNSW;
     overSample = 1f;
@@ -439,10 +438,16 @@ public class KnnGraphTester {
           }
           break;
         case "-numSearchThread":
+          // 0: single thread mode (not passing a executorService) 
+          // -1: use number of threads equal to the number available processors
+          // Otherwise: create a fixed pool with determined number of threads.
           numSearchThread = Integer.parseInt(args[++iarg]);
-          if (numSearchThread < 0) {
-            throw new IllegalArgumentException("-numSearchThread should be >= 0");
+          if (numSearchThread == -1) {
+            numSearchThread = Runtime.getRuntime().availableProcessors();
+          } else if (numSearchThread < 0) {
+            throw new IllegalArgumentException("-numSearchThread must be >= 0");
           }
+          log("numSearchThead = %d\n", numSearchThread);
           break;
         case "-parentJoin":
           if (iarg == args.length - 1) {
@@ -869,7 +874,6 @@ public class KnnGraphTester {
             throw new IllegalStateException("index size mismatch, expected " + numDocs + " but index has " + indexNumDocs);
           }
           // warm up
-          AtomicReference<ThreadDetails> endThreadDetailsRef = new AtomicReference<>();
           for (int i = 0; i < numQueryVectors; i++) {
             if (vectorEncoding.equals(VectorEncoding.BYTE)) {
               byte[] target = targetReaderByte.nextBytes();
@@ -881,7 +885,6 @@ public class KnnGraphTester {
           }
           targetReader.reset();
           startNS = System.nanoTime();
-          cpuTimeStartNs = bean.getCurrentThreadCpuTime();
           ThreadDetails startThreadDetails = new ThreadDetails();
           for (int i = 0; i < numQueryVectors; i++) {
             if (vectorEncoding.equals(VectorEncoding.BYTE)) {
@@ -892,32 +895,19 @@ public class KnnGraphTester {
               results[i] = doKnnVectorQuery(searcher, KNN_FIELD, target, topK, fanout, prefilter, filterQuery, parentJoin);
             }
           }
-          endTimeStartNs = bean.getCurrentThreadCpuTime();
           ThreadDetails endThreadDetails = new ThreadDetails();
-          long endCPUTimeNS = 0;
           long startCPUTimeNS = 0;
-
-          if (Arrays.equals(startThreadDetails.threadIDs, endThreadDetails.threadIDs)) {
-            for(int i=0;i<startThreadDetails.threadIDs.length;i++) {
-//              if (bean.getThreadInfo(startThreadDetails.threadIDs[i]).getThreadName().startsWith("hnsw-search")) {
-                startCPUTimeNS += startThreadDetails.cpuTimesNS[i];
-//              };
-            }
-
-            for(int i=0;i<endThreadDetails.threadIDs.length;i++) {
-//              if (bean.getThreadInfo(endThreadDetails.threadIDs[i]).getThreadName().startsWith("hnsw-search")) {
-                endCPUTimeNS += endThreadDetails.cpuTimesNS[i];
-//              };
-            }
-
-            totalCpuTimeMS = TimeUnit.NANOSECONDS.toMillis(endCPUTimeNS - startCPUTimeNS);
-//          totalCpuTimeMS =  TimeUnit.NANOSECONDS.toMillis(bean.getCurrentThreadCpuTime() - cpuTimeStartNs);
-            elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNS); // ns -> ms
-          } else {
-            elapsed = 0;
-            totalCpuTimeMS = 0;
-            System.out.println("NOTE: start/end threads changed;");
+          long endCPUTimeNS = 0;
+          for(int i=0;i<startThreadDetails.threadIDs.length;i++) {
+              startCPUTimeNS += startThreadDetails.cpuTimesNS[i];
           }
+
+          for(int i=0;i<endThreadDetails.threadIDs.length;i++) {
+              endCPUTimeNS += endThreadDetails.cpuTimesNS[i];
+          }
+
+          totalCpuTimeMS = TimeUnit.NANOSECONDS.toMillis(endCPUTimeNS - startCPUTimeNS);
+          elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNS); // ns -> ms
           
           // Fetch, validate and write result document ids.
           StoredFields storedFields = reader.storedFields();
@@ -965,9 +955,11 @@ public class KnnGraphTester {
       double reindexSec = reindexTimeMsec / 1000.0;
       System.out.printf(
           Locale.ROOT,
-          "SUMMARY: %5.3f\t%5.3f\t%5.3f\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%.2f\t%.2f\t%.2f\t%d\t%.2f\t%.2f\t%s\t%5.3f\t%5.3f\t%5.3f\t%s\n",
-          recall, elapsed / (float) numQueryVectors,
+          "SUMMARY: %5.3f\t%5.3f\t%5.3f\t%5.3f\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%.2f\t%.2f\t%.2f\t%d\t%.2f\t%.2f\t%s\t%5.3f\t%5.3f\t%5.3f\t%s\n",
+          recall,
+          elapsed / (float) numQueryVectors,
           totalCpuTimeMS / (float) numQueryVectors,
+          totalCpuTimeMS / (float) elapsed,
           numDocs,
           this.topK,
           this.fanout,
@@ -1066,7 +1058,7 @@ public class KnnGraphTester {
    */
   private int[][] getExactNN(Path docPath, Path indexPath, Path queryPath, int queryStartIndex) throws IOException, InterruptedException {
     // look in working directory for cached nn file
-    String hash = Integer.toString(Objects.hash(docPath, queryPath, numDocs, numQueryVectors, topK, similarityFunction.ordinal(), parentJoin, queryStartIndex, prefilter ? selectivity : 1f, prefilter ? randomSeed : 0f), 36);
+    String hash = Integer.toString(Objects.hash(docPath, indexPath, queryPath, numDocs, numQueryVectors, topK, similarityFunction.ordinal(), parentJoin, queryStartIndex, prefilter ? selectivity : 1f, prefilter ? randomSeed : 0f), 36);
     String nnFileName = "nn-" + hash + ".bin";
     Path nnPath = Paths.get(nnFileName);
     if (Files.exists(nnPath) && isNewer(nnPath, docPath, queryPath)) {

--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BinaryOperator;
 
 import org.apache.lucene.codecs.Codec;
@@ -106,6 +107,7 @@ import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.NamedThreadFactory;
 import org.apache.lucene.util.SuppressForbidden;
 import org.apache.lucene.util.hnsw.HnswGraph;
+import perf.SearchPerfTest.ThreadDetails;
 
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 //TODO Lucene may make these unavailable, we should pull in this from hppc directly
@@ -161,6 +163,7 @@ public class KnnGraphTester {
   private boolean quantizeCompress;
   private int numMergeThread;
   private int numMergeWorker;
+  private int numSearchThread;
   private ExecutorService exec;
   private VectorSimilarityFunction similarityFunction;
   private VectorEncoding vectorEncoding;
@@ -433,6 +436,12 @@ public class KnnGraphTester {
           }
           if (numMergeThread <= 0) {
             throw new IllegalArgumentException("-numMergeThread should be >= 1");
+          }
+          break;
+        case "-numSearchThread":
+          numSearchThread = Integer.parseInt(args[++iarg]);
+          if (numSearchThread < 0) {
+            throw new IllegalArgumentException("-numSearchThread should be >= 0");
           }
           break;
         case "-parentJoin":
@@ -832,7 +841,12 @@ public class KnnGraphTester {
     long elapsed, totalCpuTimeMS, totalVisited = 0;
     int topK = (overSample > 1) ? (int) (this.topK * overSample) : this.topK;
     int fanout = (overSample > 1) ? (int) (this.fanout * overSample) : this.fanout;
-    ExecutorService executorService = Executors.newFixedThreadPool(8);
+    ExecutorService executorService;
+    if (numSearchThread > 0) {
+      executorService = Executors.newFixedThreadPool(numSearchThread, new NamedThreadFactory("hnsw-search"));
+    } else {
+      executorService = null;
+    }
     try (FileChannel input = getVectorFileChannel(queryPath, dim, vectorEncoding, !quiet)) {
       long queryPathSizeInBytes = input.size();
       log((int) (queryPathSizeInBytes / (dim * vectorEncoding.byteSize)) + " query vectors in queryPath \"" + queryPath + "\"\n");
@@ -844,16 +858,18 @@ public class KnnGraphTester {
       log("searching " + numQueryVectors + " query vectors; topK=" + topK + ", fanout=" + fanout + "\n");
       long startNS;
       ThreadMXBean bean = ManagementFactory.getThreadMXBean();
-      long cpuTimeStartNs;
+      long cpuTimeStartNs = 0;
+      long endTimeStartNs = 0;
       try (MMapDirectory dir = new MMapDirectory(indexPath)) {
         dir.setPreload((x, ctx) -> x.endsWith(".vec") || x.endsWith(".veq"));
         try (DirectoryReader reader = DirectoryReader.open(dir)) {
-          IndexSearcher searcher = new IndexSearcher(reader);
+          IndexSearcher searcher = new IndexSearcher(reader, executorService);
           int indexNumDocs = reader.maxDoc();
           if (numDocs != indexNumDocs) {
             throw new IllegalStateException("index size mismatch, expected " + numDocs + " but index has " + indexNumDocs);
           }
           // warm up
+          AtomicReference<ThreadDetails> endThreadDetailsRef = new AtomicReference<>();
           for (int i = 0; i < numQueryVectors; i++) {
             if (vectorEncoding.equals(VectorEncoding.BYTE)) {
               byte[] target = targetReaderByte.nextBytes();
@@ -866,6 +882,7 @@ public class KnnGraphTester {
           targetReader.reset();
           startNS = System.nanoTime();
           cpuTimeStartNs = bean.getCurrentThreadCpuTime();
+          ThreadDetails startThreadDetails = new ThreadDetails();
           for (int i = 0; i < numQueryVectors; i++) {
             if (vectorEncoding.equals(VectorEncoding.BYTE)) {
               byte[] target = targetReaderByte.nextBytes();
@@ -875,10 +892,33 @@ public class KnnGraphTester {
               results[i] = doKnnVectorQuery(searcher, KNN_FIELD, target, topK, fanout, prefilter, filterQuery, parentJoin);
             }
           }
-          totalCpuTimeMS =
-            TimeUnit.NANOSECONDS.toMillis(bean.getCurrentThreadCpuTime() - cpuTimeStartNs);
-          elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNS); // ns -> ms
+          endTimeStartNs = bean.getCurrentThreadCpuTime();
+          ThreadDetails endThreadDetails = new ThreadDetails();
+          long endCPUTimeNS = 0;
+          long startCPUTimeNS = 0;
 
+          if (Arrays.equals(startThreadDetails.threadIDs, endThreadDetails.threadIDs)) {
+            for(int i=0;i<startThreadDetails.threadIDs.length;i++) {
+//              if (bean.getThreadInfo(startThreadDetails.threadIDs[i]).getThreadName().startsWith("hnsw-search")) {
+                startCPUTimeNS += startThreadDetails.cpuTimesNS[i];
+//              };
+            }
+
+            for(int i=0;i<endThreadDetails.threadIDs.length;i++) {
+//              if (bean.getThreadInfo(endThreadDetails.threadIDs[i]).getThreadName().startsWith("hnsw-search")) {
+                endCPUTimeNS += endThreadDetails.cpuTimesNS[i];
+//              };
+            }
+
+            totalCpuTimeMS = TimeUnit.NANOSECONDS.toMillis(endCPUTimeNS - startCPUTimeNS);
+//          totalCpuTimeMS =  TimeUnit.NANOSECONDS.toMillis(bean.getCurrentThreadCpuTime() - cpuTimeStartNs);
+            elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNS); // ns -> ms
+          } else {
+            elapsed = 0;
+            totalCpuTimeMS = 0;
+            System.out.println("NOTE: start/end threads changed;");
+          }
+          
           // Fetch, validate and write result document ids.
           StoredFields storedFields = reader.storedFields();
           for (int i = 0; i < numQueryVectors; i++) {
@@ -899,7 +939,9 @@ public class KnnGraphTester {
         }
       }
     } finally {
-      executorService.shutdown();
+      if (executorService != null) {
+        executorService.shutdown();
+      }
     }
     if (outputPath != null) {
       ByteBuffer tmp =
@@ -923,8 +965,8 @@ public class KnnGraphTester {
       double reindexSec = reindexTimeMsec / 1000.0;
       System.out.printf(
           Locale.ROOT,
-          "SUMMARY: %5.3f\t%5.3f\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%.2f\t%.2f\t%.2f\t%d\t%.2f\t%.2f\t%s\t%5.3f\t%5.3f\t%5.3f\t%s\n",
-          recall,
+          "SUMMARY: %5.3f\t%5.3f\t%5.3f\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%.2f\t%.2f\t%.2f\t%d\t%.2f\t%.2f\t%s\t%5.3f\t%5.3f\t%5.3f\t%s\n",
+          recall, elapsed / (float) numQueryVectors,
           totalCpuTimeMS / (float) numQueryVectors,
           numDocs,
           this.topK,
@@ -1024,7 +1066,7 @@ public class KnnGraphTester {
    */
   private int[][] getExactNN(Path docPath, Path indexPath, Path queryPath, int queryStartIndex) throws IOException, InterruptedException {
     // look in working directory for cached nn file
-    String hash = Integer.toString(Objects.hash(docPath, indexPath, queryPath, numDocs, numQueryVectors, topK, similarityFunction.ordinal(), parentJoin, queryStartIndex, prefilter ? selectivity : 1f, prefilter ? randomSeed : 0f), 36);
+    String hash = Integer.toString(Objects.hash(docPath, queryPath, numDocs, numQueryVectors, topK, similarityFunction.ordinal(), parentJoin, queryStartIndex, prefilter ? selectivity : 1f, prefilter ? randomSeed : 0f), 36);
     String nnFileName = "nn-" + hash + ".bin";
     Path nnPath = Paths.get(nnFileName);
     if (Files.exists(nnPath) && isNewer(nnPath, docPath, queryPath)) {

--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -862,9 +862,6 @@ public class KnnGraphTester {
       }
       log("searching " + numQueryVectors + " query vectors; topK=" + topK + ", fanout=" + fanout + "\n");
       long startNS;
-      ThreadMXBean bean = ManagementFactory.getThreadMXBean();
-      long cpuTimeStartNs = 0;
-      long endTimeStartNs = 0;
       try (MMapDirectory dir = new MMapDirectory(indexPath)) {
         dir.setPreload((x, ctx) -> x.endsWith(".vec") || x.endsWith(".veq"));
         try (DirectoryReader reader = DirectoryReader.open(dir)) {

--- a/src/main/perf/SearchPerfTest.java
+++ b/src/main/perf/SearchPerfTest.java
@@ -157,7 +157,7 @@ public class SearchPerfTest {
   }
 
   /** Snapshots all running threads and their CPU counters */
-  static final class ThreadDetails {
+  public static final class ThreadDetails {
     public final long[] threadIDs;
     public final long[] cpuTimesNS;
     public final ThreadInfo[] threadInfos;

--- a/src/python/initial_setup.py
+++ b/src/python/initial_setup.py
@@ -29,8 +29,7 @@ BASE_URL2 = "https://home.apache.org/~sokolov"
 
 DATA_FILES = [
   # remote url, local name
-  ("https://luceneutil-corpus-files.s3.ca-central-1.amazonaws.com/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma",
-  "enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma"),
+  ("https://luceneutil-corpus-files.s3.ca-central-1.amazonaws.com/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma", "enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma"),
   # ("https://luceneutil-corpus-files.s3.ca-central-1.amazonaws.com/cohere-wikipedia-docs-768d.vec", "cohere-wikipedia-docs-768d.vec"),
   ("https://luceneutil-corpus-files.s3.ca-central-1.amazonaws.com/cohere-wikipedia-docs-5M-768d.vec", "cohere-wikipedia-docs-5M-768d.vec"),
   ("https://luceneutil-corpus-files.s3.ca-central-1.amazonaws.com/cohere-wikipedia-queries-768d.vec", "cohere-wikipedia-queries-768d.vec"),

--- a/src/python/initial_setup.py
+++ b/src/python/initial_setup.py
@@ -30,7 +30,7 @@ BASE_URL2 = "https://home.apache.org/~sokolov"
 DATA_FILES = [
   # remote url, local name
   ("https://luceneutil-corpus-files.s3.ca-central-1.amazonaws.com/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma",
-   "enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma"),
+  "enwiki-20120502-lines-1k-fixed-utf8-with-random-label.txt.lzma"),
   # ("https://luceneutil-corpus-files.s3.ca-central-1.amazonaws.com/cohere-wikipedia-docs-768d.vec", "cohere-wikipedia-docs-768d.vec"),
   ("https://luceneutil-corpus-files.s3.ca-central-1.amazonaws.com/cohere-wikipedia-docs-5M-768d.vec", "cohere-wikipedia-docs-5M-768d.vec"),
   ("https://luceneutil-corpus-files.s3.ca-central-1.amazonaws.com/cohere-wikipedia-queries-768d.vec", "cohere-wikipedia-queries-768d.vec"),

--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -52,7 +52,7 @@ PARAMS = {
   #'ndoc': (10000, 100000, 200000, 500000),
   #'ndoc': (2_000_000,),
   #'ndoc': (1_000_000,),
-  "ndoc": (1_200_000,),
+  "ndoc": (500_000,),
   #'ndoc': (50_000,),
   #'maxConn': (32, 64, 96),
   "maxConn": (64,),
@@ -65,16 +65,16 @@ PARAMS = {
   #'quantize': None,
   #'quantizeBits': (32, 7, 4),
   "numMergeWorker": (12,),
-  "numMergeThread": (2,),
-  "numSearchThread": (2, 6,),
+  "numMergeThread": (4,),
+  "numSearchThread": (0,),
   #'numMergeWorker': (1,),
   #'numMergeThread': (1,),
   "encoding": ("float32",),
   # 'metric': ('angular',),  # default is angular (dot_product)
   # 'metric': ('mip',),
-  'quantize': (True,),
-  # "quantizeBits": (32,),
-  "quantizeBits": (7, 4, 1,),
+  #'quantize': (True,),
+  "quantizeBits": (32,),
+  # "quantizeBits": (1,),
   # "overSample": (5,), # extra ratio of vectors to retrieve, for testing approximate scoring, e.g. quantized indices
   #'fanout': (0,),
   "topK": (100,),
@@ -84,7 +84,7 @@ PARAMS = {
   # "indexType": ("flat", "hnsw"), # index type, only works with singlt bit
   "queryStartIndex": (0,),  # seek to this start vector before searching, to sample different vectors
   # "forceMerge": (True, False),
-  'niter': (2000,),
+  #'niter': (10,),
 }
 
 
@@ -122,14 +122,10 @@ def run_knn_benchmark(checkout, values):
   # doc_vectors = '/d/electronics_asin_emb.bin'
   # query_vectors = '/d/electronics_query_vectors.bin'
 
-  dim = 256
-  doc_vectors = f"{constants.BASE_DIR}/data/asin_vectors.vec"
-  query_vectors = f"{constants.BASE_DIR}/data/query_vectors_new.vec"
-
   # Cohere dataset
-  # dim = 768
-  # doc_vectors = f"{constants.BASE_DIR}/data/cohere-wikipedia-docs-{dim}d.vec"
-  # query_vectors = f"{constants.BASE_DIR}/data/cohere-wikipedia-queries-{dim}d.vec"
+  dim = 768
+  doc_vectors = f"{constants.BASE_DIR}/data/cohere-wikipedia-docs-{dim}d.vec"
+  query_vectors = f"{constants.BASE_DIR}/data/cohere-wikipedia-queries-{dim}d.vec"
   # doc_vectors = f"/lucenedata/enwiki/{'cohere-wikipedia'}-docs-{dim}d.vec"
   # query_vectors = f"/lucenedata/enwiki/{'cohere-wikipedia'}-queries-{dim}d.vec"
   # parentJoin_meta_file = f"{constants.BASE_DIR}/data/{'cohere-wikipedia'}-metadata.csv"
@@ -200,8 +196,6 @@ def run_knn_benchmark(checkout, values):
         "-docs",
         doc_vectors,
         "-reindex",
-        # "-indexPath",
-        # "/Users/huynmg/lucene-bench-home/luceneutil/knnIndices/asin_vectors.vec-64-250-1000000.index",
         "-search-and-stats",
         query_vectors,
         "-numIndexThreads",
@@ -261,7 +255,7 @@ def run_knn_benchmark(checkout, values):
 
 
 def print_fixed_width(all_results, columns_to_skip):
-  header = "recall\tlatency(ms)\tnetCPU\tnDoc\ttopK\tfanout\tmaxConn\tbeamWidth\tquantized\tvisited\tindex(s)\tindex_docs/s\tforce_merge(s)\tnum_segments\tindex_size(MB)\tselectivity\tfilterType\toverSample\tvec_disk(MB)\tvec_RAM(MB)\tindexType"
+  header = "recall\tlatency(ms)\tnetCPU\tavgCpuCount\tnDoc\ttopK\tfanout\tmaxConn\tbeamWidth\tquantized\tvisited\tindex(s)\tindex_docs/s\tforce_merge(s)\tnum_segments\tindex_size(MB)\tselectivity\tfilterType\toverSample\tvec_disk(MB)\tvec_RAM(MB)\tindexType"
 
   # crazy logic to make everything fixed width so rendering in fixed width font "aligns":
   headers = header.split("\t")

--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -52,7 +52,7 @@ PARAMS = {
   #'ndoc': (10000, 100000, 200000, 500000),
   #'ndoc': (2_000_000,),
   #'ndoc': (1_000_000,),
-  "ndoc": (500_000,),
+  "ndoc": (1_200_000,),
   #'ndoc': (50_000,),
   #'maxConn': (32, 64, 96),
   "maxConn": (64,),
@@ -65,15 +65,16 @@ PARAMS = {
   #'quantize': None,
   #'quantizeBits': (32, 7, 4),
   "numMergeWorker": (12,),
-  "numMergeThread": (4,),
+  "numMergeThread": (2,),
+  "numSearchThread": (2, 6,),
   #'numMergeWorker': (1,),
   #'numMergeThread': (1,),
   "encoding": ("float32",),
   # 'metric': ('angular',),  # default is angular (dot_product)
   # 'metric': ('mip',),
-  #'quantize': (True,),
-  "quantizeBits": (32,),
-  # "quantizeBits": (1,),
+  'quantize': (True,),
+  # "quantizeBits": (32,),
+  "quantizeBits": (7, 4, 1,),
   # "overSample": (5,), # extra ratio of vectors to retrieve, for testing approximate scoring, e.g. quantized indices
   #'fanout': (0,),
   "topK": (100,),
@@ -83,7 +84,7 @@ PARAMS = {
   # "indexType": ("flat", "hnsw"), # index type, only works with singlt bit
   "queryStartIndex": (0,),  # seek to this start vector before searching, to sample different vectors
   # "forceMerge": (True, False),
-  #'niter': (10,),
+  'niter': (2000,),
 }
 
 
@@ -121,10 +122,14 @@ def run_knn_benchmark(checkout, values):
   # doc_vectors = '/d/electronics_asin_emb.bin'
   # query_vectors = '/d/electronics_query_vectors.bin'
 
+  dim = 256
+  doc_vectors = f"{constants.BASE_DIR}/data/asin_vectors.vec"
+  query_vectors = f"{constants.BASE_DIR}/data/query_vectors_new.vec"
+
   # Cohere dataset
-  dim = 768
-  doc_vectors = f"{constants.BASE_DIR}/data/cohere-wikipedia-docs-{dim}d.vec"
-  query_vectors = f"{constants.BASE_DIR}/data/cohere-wikipedia-queries-{dim}d.vec"
+  # dim = 768
+  # doc_vectors = f"{constants.BASE_DIR}/data/cohere-wikipedia-docs-{dim}d.vec"
+  # query_vectors = f"{constants.BASE_DIR}/data/cohere-wikipedia-queries-{dim}d.vec"
   # doc_vectors = f"/lucenedata/enwiki/{'cohere-wikipedia'}-docs-{dim}d.vec"
   # query_vectors = f"/lucenedata/enwiki/{'cohere-wikipedia'}-queries-{dim}d.vec"
   # parentJoin_meta_file = f"{constants.BASE_DIR}/data/{'cohere-wikipedia'}-metadata.csv"
@@ -195,6 +200,8 @@ def run_knn_benchmark(checkout, values):
         "-docs",
         doc_vectors,
         "-reindex",
+        # "-indexPath",
+        # "/Users/huynmg/lucene-bench-home/luceneutil/knnIndices/asin_vectors.vec-64-250-1000000.index",
         "-search-and-stats",
         query_vectors,
         "-numIndexThreads",
@@ -254,7 +261,7 @@ def run_knn_benchmark(checkout, values):
 
 
 def print_fixed_width(all_results, columns_to_skip):
-  header = "recall\tlatency(ms)\tnDoc\ttopK\tfanout\tmaxConn\tbeamWidth\tquantized\tvisited\tindex(s)\tindex_docs/s\tforce_merge(s)\tnum_segments\tindex_size(MB)\tselectivity\tfilterType\toverSample\tvec_disk(MB)\tvec_RAM(MB)\tindexType"
+  header = "recall\tlatency(ms)\tnetCPU\tnDoc\ttopK\tfanout\tmaxConn\tbeamWidth\tquantized\tvisited\tindex(s)\tindex_docs/s\tforce_merge(s)\tnum_segments\tindex_size(MB)\tselectivity\tfilterType\toverSample\tvec_disk(MB)\tvec_RAM(MB)\tindexType"
 
   # crazy logic to make everything fixed width so rendering in fixed width font "aligns":
   headers = header.split("\t")


### PR DESCRIPTION
https://github.com/mikemccand/luceneutil/issues/388, https://github.com/mikemccand/luceneutil/issues/332

- Add a new parameter `numSearchThread` for KnnGraphTester that allow to specify the number of threads used when executing Knn query concurrently in multiple segments. 

- Also add two new metrics to the result table: 
  - `netCPU`: total CPU summed across all threads when KNN query is executed.
  - `avgCpuCount`: average CPU  count being utilized when KNN query is executed 


Example result when executing knnPerfTest with different values of `numSearchThread` (0, 2, 5, 10)

```
recall  latency(ms)  netCPU  avgCpuCount    nDoc  topK  fanout  maxConn  beamWidth  quantized  index(s)  index_docs/s  num_segments  index_size(MB)  vec_disk(MB)  vec_RAM(MB)  indexType
 0.934        2.648   2.629        0.993  100000   100      50       64        250     7 bits      0.00      Infinity            13          127.80       122.452       24.796       HNSW
 0.934        1.250   3.204        2.563  100000   100      50       64        250     7 bits      0.00      Infinity            13          127.80       122.452       24.796       HNSW
 0.934        0.713   3.188        4.471  100000   100      50       64        250     7 bits      0.00      Infinity            13          127.80       122.452       24.796       HNSW
 0.934        0.700   3.875        5.536  100000   100      50       64        250     7 bits      0.00      Infinity            13          127.80       122.452       24.796       HNSW
```