### PR TITLE
Fix priority queue constructor issue and a typo `coutnOnlyCount`

### DIFF
--- a/src/main/perf/CreateQueries.java
+++ b/src/main/perf/CreateQueries.java
@@ -67,12 +67,7 @@ public class CreateQueries {
 
   private static class MostFrequentTerms extends PriorityQueue<TermFreq> {
     public MostFrequentTerms(int maxSize) {
-      super(maxSize);
-    }
-
-    @Override
-    protected boolean lessThan(TermFreq tf1, TermFreq tf2) {
-      return tf1.df < tf2.df;
+      super(maxSize, (tf1, tf2) -> tf1.df < tf2.df);
     }
   }
 

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -209,7 +209,7 @@ class SearchTask:
         if self.hitCount != other.hitCount:
           self.fail("wrong hitCount: %s vs %s" % (self.hitCount, other.hitCount))
         if self.countOnlyCount != other.countOnlyCount:
-          self.fail("wrong countOnlyCount: %s vs %s" % (self.countOnlyCount, other.coutnOnlyCount))
+          self.fail("wrong countOnlyCount: %s vs %s" % (self.countOnlyCount, other.countOnlyCount))
 
       if len(self.hits) != len(other.hits):
         self.fail("wrong top hit count: %s vs %s" % (len(self.hits), len(other.hits)))


### PR DESCRIPTION
Since https://github.com/apache/lucene/pull/14873 is introduced, the constructor below will fail because the constructor receives a single int is removed. This PR tries to fix that, and a typo by the way.

https://github.com/mikemccand/luceneutil/blob/522d3c377815686ea8a801d6735f68ae69d637d5/src/main/perf/CreateQueries.java#L68-L70
