### PR TITLE
Get disassembled code to verify SIMD optimizations

### DIFF
--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -11,7 +11,7 @@ import multiprocessing
 import re
 import subprocess
 import sys
-
+import shutil
 import benchUtil
 import constants
 from common import getLuceneDirFromGradleProperties
@@ -34,6 +34,12 @@ from common import getLuceneDirFromGradleProperties
 # you may want to modify the following settings:
 
 DO_PROFILING = False
+
+
+# Set this to True to generate the disassembled code to verify the intended SIMD instructions are getting used or not
+PERF_MODE = False
+
+PERF_PATH = shutil.which("perf")
 
 # e.g. to compile KnnIndexer:
 #
@@ -179,6 +185,7 @@ def run_knn_benchmark(checkout, values):
 
   cmd += ["knn.KnnGraphTester"]
 
+  index_run = 1
   all_results = []
   while advance(indexes, values):
     if NOISY:
@@ -238,6 +245,17 @@ def run_knn_benchmark(checkout, values):
         #'-quiet'
       ]
     )
+    if PERF_MODE and PERF_PATH:
+      print("Will be recording the executed instructions in perf.data file")
+      perf_cmd = [PERF_PATH, "record", "-e", "instructions:u", "-o", f"perf{index_run}.data", "-g"] + this_cmd
+      job = subprocess.run(perf_cmd)
+      if NOISY:
+        print(f"  cmd: {perf_cmd}")
+      index_run += 1
+      continue
+    elif PERF_MODE:
+      print("'perf' tool not found with perf mode enabled. Please install 'perf' tool locally")
+      sys.exit(1)
     if NOISY:
       print(f"  cmd: {this_cmd}")
     else:
@@ -264,6 +282,10 @@ def run_knn_benchmark(checkout, values):
     all_results.append((summary, args))
     if DO_PROFILING:
       benchUtil.profilerOutput(constants.JAVA_EXE, jfr_output, benchUtil.checkoutToPath(checkout), 30, (1,))
+    index_run += 1
+
+  if PERF_MODE:
+    return
 
   if NOISY:
     print("\nResults:")


### PR DESCRIPTION
This uses `perf` tool to generate the disassembled code for the run. It generates a `perf<X>.data` file (where `X=1,2,3...`) for each corresponding benchmark run/configuration. One could then simply look into the disassembled code like below :

Currently it records the executed instructions from the user space. We can add other events also if we want, but this could be a good start and keep a decent file size
 
```
sudo perf record -e instructions:u -g java <...>
```

To look into the disassembled code (disassembling is super slow) :

- Directly open the view or file
```
sudo perf annotate -i perf.data -f
```
- Print the file content
```
PAGER=cat perf annotate -i perf1.data -f --stdio 
```
