### PR TITLE
Add NDCG and full precision reranking to knn benchmarks

### DIFF
--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -917,7 +917,7 @@ public class KnnGraphTester {
           StoredFields storedFields = reader.storedFields();
           for (int i = 0; i < numQueryVectors; i++) {
             totalVisited += results[i].visitedCount();
-            resultIds[i] = KnnTesterUtils.getResultIds(results[i].topDocs(), storedFields, this.topK);
+            resultIds[i] = KnnTesterUtils.getResultIds(results[i].topDocs(), storedFields);
           }
           log(
               "completed "
@@ -1210,7 +1210,7 @@ public class KnnGraphTester {
                 .add(filterQuery, BooleanClause.Occur.FILTER)
                 .build();
         var topDocs = searcher.search(query, topK);
-        result[queryOrd] = knn.KnnTesterUtils.getResultIds(topDocs, reader.storedFields(), topK);
+        result[queryOrd] = knn.KnnTesterUtils.getResultIds(topDocs, reader.storedFields());
         if ((queryOrd + 1) % 10 == 0) {
           log(" " + (queryOrd + 1));
         }
@@ -1284,7 +1284,7 @@ public class KnnGraphTester {
                 .add(filterQuery, BooleanClause.Occur.FILTER)
                 .build();
         var topDocs = searcher.search(query, topK);
-        result[queryOrd] = knn.KnnTesterUtils.getResultIds(topDocs, reader.storedFields(), topK);
+        result[queryOrd] = knn.KnnTesterUtils.getResultIds(topDocs, reader.storedFields());
         if ((queryOrd + 1) % 10 == 0) {
           log(" " + (queryOrd + 1));
         }
@@ -1318,7 +1318,7 @@ public class KnnGraphTester {
         ParentJoinBenchmarkQuery parentJoinQuery = new ParentJoinBenchmarkQuery(query, null, topK);
         TopDocs topHits = ParentJoinBenchmarkQuery.runExactSearch(reader, parentJoinQuery);
         StoredFields storedFields = reader.storedFields();
-        result[queryOrd] = KnnTesterUtils.getResultIds(topHits, storedFields, topK);
+        result[queryOrd] = KnnTesterUtils.getResultIds(topHits, storedFields);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/src/main/knn/KnnTesterUtils.java
+++ b/src/main/knn/KnnTesterUtils.java
@@ -31,8 +31,8 @@ public class KnnTesterUtils {
 
   /** Fetches values for the "id" field from search results
    */
-  public static ResultIds[] getResultIds(TopDocs topDocs, StoredFields storedFields, int k) throws IOException {
-    ResultIds[] resultIds = new ResultIds[k];
+  public static ResultIds[] getResultIds(TopDocs topDocs, StoredFields storedFields) throws IOException {
+    ResultIds[] resultIds = new ResultIds[topDocs.scoreDocs.length];
     int i = 0;
     // TODO: switch to doc values for this id field?  more efficent than stored fields
     // TODO: or, at least load the stored documents in index (Lucene docid) order to

--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -286,8 +286,6 @@ def run_knn_benchmark(checkout, values):
     skip_headers.add("beamWidth")
   if "-rerank" not in this_cmd:
     skip_headers.add("rerank")
-    skip_headers.add("ndcg@10")
-    skip_headers.add("ndcg@K")
 
   print_fixed_width(all_results, skip_headers)
   print_chart(all_results)


### PR DESCRIPTION
Adds support to evaluate improvements in knn search ranking quality using Normalized Discounted Cumulative Gain ([NDCG](https://en.wikipedia.org/wiki/Discounted_cumulative_gain)) at 10, and at `k` for configured topK. This is useful in measuring the impact of reranking quantized search results with full precision vectors. 

Also adds support to rerank full precision vectors using a `DoubleValuesSourceRescorer` on `FullPrecisionFloatVectorSimilarityValuesSource`

Addresses #401 

+++

#### Benchmark Results
I see an `8% - 14%` improvement in NDCG@10 and a `6% - 8%` improvement in NDCG@K for 4 bit quantized knn search with full precision reranking. Improvement increases with index size. Latency impact doesn't seem significant?

```ruby
recall  ndcg@10  ndcg@K  rerank  latency(ms)  netCPU  avgCpuCount      nDoc  topK  fanout  maxConn  beamWidth  quantized  index(s)  index_docs/s  num_segments  index_size(MB)  vec_disk(MB)  vec_RAM(MB)  indexType
 0.524    0.920   0.600   false        2.235   2.216        0.991    100000   100      20       32         50     4 bits     16.96       5896.23             4          333.95       329.971       37.003       HNSW
 0.524    0.999   0.637    true        2.279   2.261        0.992    100000   100      20       32         50     4 bits      0.00      Infinity             4          333.95       329.971       37.003       HNSW
 0.490    0.901   0.568   false        3.199   3.183        0.995    500000   100      20       32         50     4 bits     70.18       7124.23             3         1670.44      1649.857      185.013       HNSW
 0.490    0.999   0.607    true        3.201   3.181        0.994    500000   100      20       32         50     4 bits      0.00      Infinity             3         1670.44      1649.857      185.013       HNSW
 0.480    0.891   0.557   false        4.774   4.756        0.996   1000000   100      20       32         50     4 bits    134.12       7456.07             6         3341.86      3299.713      370.026       HNSW
 0.480    0.999   0.598    true        4.697   4.675        0.995   1000000   100      20       32         50     4 bits      0.00      Infinity             6         3341.86      3299.713      370.026       HNSW
 0.462    0.883   0.541   false        5.081   5.035        0.991   2000000   100      20       32         50     4 bits    465.46       4296.82             7         6688.32      6599.426      740.051       HNSW
 0.462    0.998   0.583    true        4.885   4.863        0.995   2000000   100      20       32         50     4 bits      0.00      Infinity             7         6688.32      6599.426      740.051       HNSW
 0.447    0.871   0.526   false       11.633  11.495        0.988  10000000   100      20       32         50     4 bits   2110.54       4738.12            14        33489.11     32997.131     3700.256       HNSW
 0.447    0.998   0.569    true       11.037  10.984        0.995  10000000   100      20       32         50     4 bits      0.00      Infinity            14        33489.11     32997.131     3700.256       HNSW

```