### PR TITLE
Exclude merge time when reporting indexing time

### DIFF
--- a/src/main/knn/KnnIndexer.java
+++ b/src/main/knn/KnnIndexer.java
@@ -218,11 +218,12 @@ public class KnnIndexer {
           log("Indexed %d documents with %d parent docs. now flush", childDocs, parentDocs);
         }
       }
-      elapsed = System.nanoTime() - start;
 
       // give merges a chance to kick off and finish:
       log("now IndexWriter.commit()");
       iw.commit();
+
+      elapsed = System.nanoTime() - start;
 
       // wait for running merges to complete -- not sure why this is needed -- IW should wait for merges on close by default
       cms.sync();

--- a/src/main/knn/KnnIndexer.java
+++ b/src/main/knn/KnnIndexer.java
@@ -127,7 +127,7 @@ public class KnnIndexer {
       indexPath.toFile().mkdirs();
     }
 
-    long start = System.nanoTime();
+    long start = System.nanoTime(), elapsed;
     try (FSDirectory dir = FSDirectory.open(indexPath);
          IndexWriter iw = new IndexWriter(dir, iwc);
          FileChannel in = FileChannel.open(docsPath)) {
@@ -218,6 +218,7 @@ public class KnnIndexer {
           log("Indexed %d documents with %d parent docs. now flush", childDocs, parentDocs);
         }
       }
+      elapsed = System.nanoTime() - start;
 
       // give merges a chance to kick off and finish:
       log("now IndexWriter.commit()");
@@ -227,7 +228,6 @@ public class KnnIndexer {
       cms.sync();
       log("done ConcurrentMergeScheduler.sync()");
     }
-    long elapsed = System.nanoTime() - start;
     log("Indexed %d docs in %d seconds", numDocs, TimeUnit.NANOSECONDS.toSeconds(elapsed));
     return (int) TimeUnit.NANOSECONDS.toMillis(elapsed);
   }


### PR DESCRIPTION
Closes https://github.com/mikemccand/luceneutil/issues/444

Maybe we should separately have another change to also report the time spent in merging (other than force merging?)


Baseline

```
Results:
recall  latency(ms)  netCPU  avgCpuCount    nDoc  topK  fanout  maxConn  beamWidth  quantized  index(s)  index_docs/s  num_segments  index_size(MB)  vec_disk(MB)  vec_RAM(MB)  indexType
 0.515       11.837  11.556        0.976  500000   100      50       64        250     4 bits    214.82       2327.52             7         1693.03      1649.857      185.013       HNSW
 0.875       10.358  10.102        0.975  500000   100      50       64        250     7 bits    600.88        832.12             3         1872.51      1832.962      368.118       HNSW
 0.976       13.669  13.315        0.974  500000   100      50       64        250         no    232.67       2148.93             8         1504.60      1464.844     1464.844       HNSW
```

Candidate (this PR)
```
Results:
recall  latency(ms)  netCPU  avgCpuCount    nDoc  topK  fanout  maxConn  beamWidth  quantized  index(s)  index_docs/s  num_segments  index_size(MB)  vec_disk(MB)  vec_RAM(MB)  indexType
 0.515       11.515  11.236        0.976  500000   100      50       64        250     4 bits    117.83       4243.47             7         1693.23      1649.857      185.013       HNSW
 0.878       10.867  10.595        0.975  500000   100      50       64        250     7 bits    120.68       4143.29             3         1872.37      1832.962      368.118       HNSW
 0.976       13.937  13.567        0.973  500000   100      50       64        250         no    128.94       3877.65             8         1504.57      1464.844     1464.844       HNSW
```
