### PR TITLE
Fix pre-filter performance testing to truly indicate cost

### DIFF
--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -84,6 +84,7 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.FilterDocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnByteVectorQuery;
 import org.apache.lucene.search.KnnFloatVectorQuery;
@@ -1426,9 +1427,16 @@ public class KnnGraphTester {
 
   private static class BitSetQuery extends Query {
     private final BitSet[] segmentDocs;
+    private final int[] cardinalities;
+    private final int hash;
 
     BitSetQuery(BitSet[] segmentDocs) {
       this.segmentDocs = segmentDocs;
+      this.cardinalities = new int[segmentDocs.length];
+      for (int i = 0; i < segmentDocs.length; i++) {
+        cardinalities[i] = segmentDocs[i].cardinality();
+      }
+      this.hash = Arrays.hashCode(segmentDocs);
     }
 
     @Override
@@ -1436,8 +1444,12 @@ public class KnnGraphTester {
       return new ConstantScoreWeight(this, boost) {
         public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
           var bitSet = segmentDocs[context.ord];
-          var cardinality = bitSet.cardinality();
-          var scorer = new ConstantScoreScorer(score(), scoreMode, new BitSetIterator(bitSet, cardinality));
+          var cardinality = cardinalities[context.ord];
+          var scorer = new ConstantScoreScorer(
+            score(),
+            scoreMode,
+            // wrap it to simulate a more realistic query that must iterate its docs
+            new FilterDocIdSetIterator(new BitSetIterator(bitSet, cardinality)));
           return new ScorerSupplier() {
             @Override
             public Scorer get(long leadCost) throws IOException {
@@ -1474,7 +1486,7 @@ public class KnnGraphTester {
 
     @Override
     public int hashCode() {
-      return 31 * classHash() + Arrays.hashCode(segmentDocs);
+      return 31 * classHash() + hash;
     }
   }
 }


### PR DESCRIPTION
We haven't actually been measuring the true pre-filter performance for Lucene kNN search. 

Utilizing a `BitSetIterator` trips a VERY important short cut that by-passes the actual iteration of the scorer, allowing for the cost of fully realizing a filter to never trigger.

Here I am wrapping the iterator. Note the significant difference when filtering at 95%.

baseline
```
recall  latency(ms)  netCPU  avgCpuCount    nDoc  topK  fanout  maxConn  beamWidth  quantized  index(s)  index_docs/s  force_merge(s)  num_segments  index_size(MB)  vec_disk(MB)  vec_RAM(MB)  indexType
 0.761        0.266   0.254        0.955  100000    10      20       16        100         no      0.00      Infinity            0.09             1          297.50       292.969      292.969       HNSW
```

This PR (more accurate cost analysis)
```
recall  latency(ms)  netCPU  avgCpuCount    nDoc  topK  fanout  maxConn  beamWidth  quantized  index(s)  index_docs/s  force_merge(s)  num_segments  index_size(MB)  vec_disk(MB)  vec_RAM(MB)  indexType
 0.761        1.006   0.835        0.830  100000    10      20       16        100         no      0.00      Infinity            0.13             1          297.50       292.969      292.969       HNSW
```

In this particular run, the majority of the time was spent simply putting the filter into a bitset, which I suspect is more realistic as most typical user's pre-filters aren't simply bitset iterators.

For the curious, here is the jfr of the more realistic run: [baseline_and_candidate_pre_filter_test.zip](https://github.com/user-attachments/files/22013466/baseline_and_candidate_pre_filter_test.zip)