### PR TITLE
Add annotation for apache/lucene#14874

### DIFF
--- a/src/python/notation.py
+++ b/src/python/notation.py
@@ -789,6 +789,11 @@ KNOWN_CHANGES = [
     "Further improve filtering by score https://github.com/apache/lucene/pull/14970",
   ),
   (
+    "2025-07-29",
+    "Improve byte vector scoring by loading on v/s off-heap vectors more appropriately https://github.com/apache/lucene/pull/14874",
+    "Improve byte vector scoring by loading on v/s off-heap vectors more appropriately https://github.com/apache/lucene/pull/14874",
+  ),
+  (
     "2025-08-06",
     "GroupVarInt encoding for HNSW graphs https://github.com/apache/lucene/pull/14932",
     "GroupVarInt encoding for HNSW graphs https://github.com/apache/lucene/pull/14932",


### PR DESCRIPTION
### Description

@mikemccand pointed me to this bump in indexing throughput for _"~1 KB Wikipedia English docs, with KNN Scalar Quantized Vectors"_ -- see bump after `JB` from ~32 GB/hr to ~37 GB/hr (~15%):

<img width="1498" height="580" alt="Screenshot 2025-08-28 at 11 14 21 AM" src="https://github.com/user-attachments/assets/39d93f73-ac84-4d8e-bf2b-602865035695" />

Corresponding run: https://benchmarks.mikemccandless.com/2025.07.29.18.04.08.html
The only commit was https://github.com/apache/lucene/pull/14874

This speedup seems plausible, because the same scoring function is used to score quantized float vectors (we initially thought the issue to be scoped to non-quantized byte vectors)