### PR TITLE
Plumb merge parallelism via `ConcurrentMergeScheduler` instead of codec

### DIFF
--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -50,13 +50,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.lucene104.Lucene104Codec;
 import org.apache.lucene.codecs.lucene104.Lucene104HnswScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
@@ -183,10 +186,9 @@ public class KnnGraphTester implements FormatterLogger {
   private boolean quantize;
   private int quantizeBits;
   private boolean quantizeCompress;
+  private int numMaxMerge;
   private int numMergeThread;
-  private int numMergeWorker;
   private int numSearchThread;
-  private ExecutorService exec;
   private VectorSimilarityFunction similarityFunction;
   private VectorEncoding vectorEncoding;
   private Query filterQuery;
@@ -217,8 +219,8 @@ public class KnnGraphTester implements FormatterLogger {
     numQueryVectors = 1000;
     dim = 256;
     topK = 100;
-    numMergeThread = 1;
-    numMergeWorker = 1;
+    numMaxMerge = ConcurrentMergeScheduler.AUTO_DETECT_MERGES_AND_THREADS;
+    numMergeThread = ConcurrentMergeScheduler.AUTO_DETECT_MERGES_AND_THREADS;
     fanout = topK;
     similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
     vectorEncoding = VectorEncoding.FLOAT32;
@@ -247,21 +249,7 @@ public class KnnGraphTester implements FormatterLogger {
   }
 
   public static void main(String... args) throws Exception {
-    new KnnGraphTester().runWithCleanUp(args);
-  }
-
-  private void runWithCleanUp(String... args) throws Exception {
-    try {
-      run(args);
-    } finally {
-      cleanUp();
-    }
-  }
-
-  private void cleanUp() {
-    if (exec != null) {
-      exec.shutdownNow();
-    }
+    new KnnGraphTester().run(args);
   }
 
   private void run(String... args) throws Exception {
@@ -470,17 +458,14 @@ public class KnnGraphTester implements FormatterLogger {
         case "-quiet":
           quiet = true;
           break;
-        case "-numMergeWorker":
-          numMergeWorker = Integer.parseInt(args[++iarg]);
-          if (numMergeWorker <= 0) {
-            throw new IllegalArgumentException("-numMergeWorker should be >= 1");
+        case "-numMaxMerge":
+          numMaxMerge = Integer.parseInt(args[++iarg]);
+          if (numMaxMerge <= 0) {
+            throw new IllegalArgumentException("-numMaxMerge should be >= 1");
           }
           break;
         case "-numMergeThread":
           numMergeThread = Integer.parseInt(args[++iarg]);
-          if (numMergeThread > 1) {
-            exec = Executors.newFixedThreadPool(numMergeThread, new NamedThreadFactory("hnsw-merge"));
-          }
           if (numMergeThread <= 0) {
             throw new IllegalArgumentException("-numMergeThread should be >= 1");
           }
@@ -618,7 +603,6 @@ public class KnnGraphTester implements FormatterLogger {
       reindexTimeMsec = new KnnIndexer(
         docVectorsPath,
         indexPath,
-        getCodec(maxConn, beamWidth, exec, numMergeWorker, quantize, quantizeBits, indexType),
         numIndexThreads,
         vectorEncoding,
         dim,
@@ -630,7 +614,14 @@ public class KnnGraphTester implements FormatterLogger {
         parentJoinMetaFile,
         useBp,
         indexTimeFilter
-      ).createIndex();
+      ).createIndex(iwc -> {
+        ConcurrentMergeScheduler cms = (ConcurrentMergeScheduler) iwc.getMergeScheduler();
+        cms.setMaxMergesAndThreads(numMaxMerge, numMergeThread);
+        cms.setDefaultMaxMergesAndThreads(false);
+        log("Indexing with %d worker(s) and %d thread(s)\n", cms.getMaxMergeCount(), cms.getMaxThreadCount());
+
+        iwc.setCodec(getCodec(maxConn, beamWidth, cms.getMaxThreadCount(), quantize, quantizeBits, indexType));
+      });
       Files.writeString(indexKeyPath, indexKey);
       log("reindex takes %.2f sec\n", msToSec(reindexTimeMsec));
       // save indexing time so future runs that re-use this index remember:
@@ -1022,13 +1013,17 @@ public class KnnGraphTester implements FormatterLogger {
 
   @SuppressForbidden(reason = "Prints stuff")
   private double forceMerge() throws IOException, InterruptedException {
-    IndexWriterConfig iwc = new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.APPEND);
-    iwc.setCodec(getCodec(maxConn, beamWidth, exec, numMergeWorker, quantize, quantizeBits, indexType));
     KnnIndexer.TrackingConcurrentMergeScheduler tcms = new KnnIndexer.TrackingConcurrentMergeScheduler();
+    tcms.setMaxMergesAndThreads(numMaxMerge, numMergeThread);
+    tcms.setDefaultMaxMergesAndThreads(false);
+    log("Force merge using %d worker(s) and %d thread(s)\n", tcms.getMaxMergeCount(), tcms.getMaxThreadCount());
+
+    IndexWriterConfig iwc = new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.APPEND);
+    iwc.setCodec(getCodec(maxConn, beamWidth, tcms.getMaxThreadCount(), quantize, quantizeBits, indexType));
     iwc.setMergeScheduler(tcms);
     KnnIndexer.TrackingTieredMergePolicy ttmp = new KnnIndexer.TrackingTieredMergePolicy();
     iwc.setMergePolicy(ttmp);
-    log("Force merge index in " + indexPath + "\n");
+    log("Force merge index in %s\n", indexPath);
     long startNS = System.nanoTime();
     try (IndexWriter iw = new IndexWriter(FSDirectory.open(indexPath), iwc)) {
       iw.forceMerge(1, false);
@@ -1998,46 +1993,36 @@ public class KnnGraphTester implements FormatterLogger {
     }
   }
 
-  static Codec getCodec(int maxConn, int beamWidth, ExecutorService exec, int numMergeWorker, boolean quantize, int quantizeBits, IndexType indexType) {
-      KnnVectorsFormat knnVectorsFormat;
-      if (quantize) {
-          knnVectorsFormat = switch (quantizeBits) {
-              case 1 -> switch (indexType) {
-                  case FLAT -> new Lucene104ScalarQuantizedVectorsFormat(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE);
-                  case HNSW ->
-                          new Lucene104HnswScalarQuantizedVectorsFormat(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE, maxConn, beamWidth, numMergeWorker, exec);
-              };
-              case 2 -> switch (indexType) {
-                  case FLAT -> new Lucene104ScalarQuantizedVectorsFormat(ScalarEncoding.DIBIT_QUERY_NIBBLE);
-                  case HNSW ->
-                          new Lucene104HnswScalarQuantizedVectorsFormat(ScalarEncoding.DIBIT_QUERY_NIBBLE, maxConn, beamWidth, numMergeWorker, exec);
-              };
-              case 4 -> switch (indexType) {
-                  case FLAT -> new Lucene104ScalarQuantizedVectorsFormat(ScalarEncoding.PACKED_NIBBLE);
-                  case HNSW ->
-                          new Lucene104HnswScalarQuantizedVectorsFormat(ScalarEncoding.PACKED_NIBBLE, maxConn, beamWidth, numMergeWorker, exec);
-              };
-              case 7 -> switch (indexType) {
-                  case FLAT -> new Lucene104ScalarQuantizedVectorsFormat(ScalarEncoding.SEVEN_BIT);
-                  case HNSW ->
-                          new Lucene104HnswScalarQuantizedVectorsFormat(ScalarEncoding.SEVEN_BIT, maxConn, beamWidth, numMergeWorker, exec);
-              };
-              case 8 -> switch (indexType) {
-                  case FLAT -> new Lucene104ScalarQuantizedVectorsFormat(ScalarEncoding.UNSIGNED_BYTE);
-                  case HNSW ->
-                          new Lucene104HnswScalarQuantizedVectorsFormat(ScalarEncoding.UNSIGNED_BYTE, maxConn, beamWidth, numMergeWorker, exec);
-              };
-              default -> throw new IllegalArgumentException("Unsupported quantizeBits: " + quantizeBits);
-          };
-      } else {
-          knnVectorsFormat = new Lucene99HnswVectorsFormat(maxConn, beamWidth, numMergeWorker, exec);
-      }
-      return new Lucene104Codec() {
-          @Override
-          public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-              return knnVectorsFormat;
-          }
+  static Codec getCodec(int maxConn, int beamWidth, int numMergeWorker, boolean quantize, int quantizeBits, IndexType indexType) {
+    KnnVectorsFormat knnVectorsFormat;
+    if (quantize) {
+      knnVectorsFormat = switch (indexType) {
+        case FLAT -> new Lucene104ScalarQuantizedVectorsFormat(getScalarEncodingForBits(quantizeBits));
+        case HNSW -> new Lucene104HnswScalarQuantizedVectorsFormat(getScalarEncodingForBits(quantizeBits), maxConn, beamWidth, numMergeWorker, null);
       };
+    } else {
+      knnVectorsFormat = switch (indexType) {
+        case FLAT -> new Lucene99FlatVectorsFormat(FlatVectorScorerUtil.getLucene99FlatVectorsScorer());
+        case HNSW -> new Lucene99HnswVectorsFormat(maxConn, beamWidth, numMergeWorker, null);
+      };
+    }
+      return new Lucene104Codec() {
+        @Override
+        public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+          return knnVectorsFormat;
+        }
+      };
+  }
+
+  static ScalarEncoding getScalarEncodingForBits(int quantizeBits) {
+    return switch (quantizeBits) {
+      case 1 -> ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+      case 2 -> ScalarEncoding.DIBIT_QUERY_NIBBLE;
+      case 4 -> ScalarEncoding.PACKED_NIBBLE;
+      case 7 -> ScalarEncoding.SEVEN_BIT;
+      case 8 -> ScalarEncoding.UNSIGNED_BYTE;
+      default -> throw new IllegalArgumentException("Unsupported quantizeBits: " + quantizeBits);
+    };
   }
 
   private static void usage() {

--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -188,6 +188,7 @@ public class KnnGraphTester implements FormatterLogger {
   private boolean quantizeCompress;
   private int numMaxMerge;
   private int numMergeThread;
+  private ForkJoinPool graphMergeExecutor;
   private int numSearchThread;
   private VectorSimilarityFunction similarityFunction;
   private VectorEncoding vectorEncoding;
@@ -221,6 +222,7 @@ public class KnnGraphTester implements FormatterLogger {
     topK = 100;
     numMaxMerge = ConcurrentMergeScheduler.AUTO_DETECT_MERGES_AND_THREADS;
     numMergeThread = ConcurrentMergeScheduler.AUTO_DETECT_MERGES_AND_THREADS;
+    graphMergeExecutor = null;
     fanout = topK;
     similarityFunction = VectorSimilarityFunction.DOT_PRODUCT;
     vectorEncoding = VectorEncoding.FLOAT32;
@@ -470,6 +472,19 @@ public class KnnGraphTester implements FormatterLogger {
             throw new IllegalArgumentException("-numMergeThread should be >= 1");
           }
           break;
+        case "-numMergeWorker":
+          int numMergeWorker = Integer.parseInt(args[++iarg]);
+          if (numMergeWorker <= 0) {
+            throw new IllegalArgumentException("-numMergeWorker should be >= 1; use 1 for calling thread or omit the flag to use the intra-merge executor");
+          } else if (numMergeWorker > 1) {
+            final AtomicInteger id = new AtomicInteger(0);
+            graphMergeExecutor = new ForkJoinPool(numMergeWorker, pool -> {
+              var thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+              thread.setName("graph-merge-" + id.getAndIncrement());
+              return thread;
+            }, null, false);
+          }
+          break;
         case "-numSearchThread":
           // 0: single thread mode (not passing a executorService) 
           // -1: use number of threads equal to the number available processors
@@ -618,9 +633,13 @@ public class KnnGraphTester implements FormatterLogger {
         ConcurrentMergeScheduler cms = (ConcurrentMergeScheduler) iwc.getMergeScheduler();
         cms.setMaxMergesAndThreads(numMaxMerge, numMergeThread);
         cms.setDefaultMaxMergesAndThreads(false);
-        log("Indexing with %d worker(s) and %d thread(s)\n", cms.getMaxMergeCount(), cms.getMaxThreadCount());
-
-        iwc.setCodec(getCodec(maxConn, beamWidth, cms.getMaxThreadCount(), quantize, quantizeBits, indexType));
+        int numMergeWorker = cms.getMaxThreadCount();
+        if (graphMergeExecutor != null) {
+          numMergeWorker = graphMergeExecutor.getParallelism();
+        }
+        log("Indexing with %d max merge(s), %d merge thread(s), and %d merge worker(s) (using intraMergeExecutor=%s)\n",
+            cms.getMaxMergeCount(), cms.getMaxThreadCount(), numMergeWorker, graphMergeExecutor == null);
+        iwc.setCodec(getCodec(maxConn, beamWidth, numMergeWorker, graphMergeExecutor, quantize, quantizeBits, indexType));
       });
       Files.writeString(indexKeyPath, indexKey);
       log("reindex takes %.2f sec\n", msToSec(reindexTimeMsec));
@@ -684,6 +703,10 @@ public class KnnGraphTester implements FormatterLogger {
       printIndexStatistics(indexPath, KNN_FIELD_FILTERED);
     } else {
       printIndexStatistics(indexPath, KNN_FIELD);
+    }
+    if (graphMergeExecutor != null) {
+      // Close this thread pool to avoid leaking into the search ThreadDetails
+      graphMergeExecutor.close();
     }
     if (operation != null) {
       switch (operation) {
@@ -1016,10 +1039,15 @@ public class KnnGraphTester implements FormatterLogger {
     KnnIndexer.TrackingConcurrentMergeScheduler tcms = new KnnIndexer.TrackingConcurrentMergeScheduler();
     tcms.setMaxMergesAndThreads(numMaxMerge, numMergeThread);
     tcms.setDefaultMaxMergesAndThreads(false);
-    log("Force merge using %d worker(s) and %d thread(s)\n", tcms.getMaxMergeCount(), tcms.getMaxThreadCount());
+    int numMergeWorker = tcms.getMaxThreadCount();
+    if (graphMergeExecutor != null) {
+      numMergeWorker = graphMergeExecutor.getParallelism();
+    }
+    log("Force merging with %d max merge(s), %d merge thread(s), and %d merge worker(s) (using intraMergeExecutor=%s)\n",
+        tcms.getMaxMergeCount(), tcms.getMaxThreadCount(), numMergeWorker, graphMergeExecutor == null);
 
     IndexWriterConfig iwc = new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.APPEND);
-    iwc.setCodec(getCodec(maxConn, beamWidth, tcms.getMaxThreadCount(), quantize, quantizeBits, indexType));
+    iwc.setCodec(getCodec(maxConn, beamWidth, numMergeWorker, graphMergeExecutor, quantize, quantizeBits, indexType));
     iwc.setMergeScheduler(tcms);
     KnnIndexer.TrackingTieredMergePolicy ttmp = new KnnIndexer.TrackingTieredMergePolicy();
     iwc.setMergePolicy(ttmp);
@@ -1993,17 +2021,17 @@ public class KnnGraphTester implements FormatterLogger {
     }
   }
 
-  static Codec getCodec(int maxConn, int beamWidth, int numMergeWorker, boolean quantize, int quantizeBits, IndexType indexType) {
+  static Codec getCodec(int maxConn, int beamWidth, int numMergeWorker, ForkJoinPool mergeExecutor, boolean quantize, int quantizeBits, IndexType indexType) {
     KnnVectorsFormat knnVectorsFormat;
     if (quantize) {
       knnVectorsFormat = switch (indexType) {
         case FLAT -> new Lucene104ScalarQuantizedVectorsFormat(getScalarEncodingForBits(quantizeBits));
-        case HNSW -> new Lucene104HnswScalarQuantizedVectorsFormat(getScalarEncodingForBits(quantizeBits), maxConn, beamWidth, numMergeWorker, null);
+        case HNSW -> new Lucene104HnswScalarQuantizedVectorsFormat(getScalarEncodingForBits(quantizeBits), maxConn, beamWidth, numMergeWorker, mergeExecutor);
       };
     } else {
       knnVectorsFormat = switch (indexType) {
         case FLAT -> new Lucene99FlatVectorsFormat(FlatVectorScorerUtil.getLucene99FlatVectorsScorer());
-        case HNSW -> new Lucene99HnswVectorsFormat(maxConn, beamWidth, numMergeWorker, null);
+        case HNSW -> new Lucene99HnswVectorsFormat(maxConn, beamWidth, numMergeWorker, mergeExecutor);
       };
     }
       return new Lucene104Codec() {

--- a/src/main/knn/KnnIndexer.java
+++ b/src/main/knn/KnnIndexer.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.apache.lucene.codecs.Codec;
@@ -49,6 +50,9 @@ import org.apache.lucene.index.MergeTrigger;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.TieredMergePolicy;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.misc.index.BPReorderingMergePolicy;
@@ -71,7 +75,6 @@ public class KnnIndexer implements FormatterLogger {
   private final VectorEncoding vectorEncoding;
   private final int dim;
   private final VectorSimilarityFunction similarityFunction;
-  private final Codec codec;
   private final int numDocs;
   private final int docsStartIndex;
   private final int numIndexThreads;
@@ -80,16 +83,12 @@ public class KnnIndexer implements FormatterLogger {
   private final Path parentJoinMetaPath;
   private final boolean useBp;
   private final FilterScheme filterScheme;
-  private final TrackingConcurrentMergeScheduler tcms;
-  private final TrackingTieredMergePolicy ttmp;
 
-  public KnnIndexer(Path docsPath, Path indexPath, Codec codec, int numIndexThreads,
-                    VectorEncoding vectorEncoding, int dim,
+  public KnnIndexer(Path docsPath, Path indexPath, int numIndexThreads, VectorEncoding vectorEncoding, int dim,
                     VectorSimilarityFunction similarityFunction, int numDocs, int docsStartIndex, boolean quiet,
                     boolean parentJoin, Path parentJoinMetaPath, boolean useBp, FilterScheme filterScheme) {
     this.docsPath = docsPath;
     this.indexPath = indexPath;
-    this.codec = codec;
     this.numIndexThreads = numIndexThreads;
     this.vectorEncoding = vectorEncoding;
     this.dim = dim;
@@ -101,13 +100,12 @@ public class KnnIndexer implements FormatterLogger {
     this.parentJoinMetaPath = parentJoinMetaPath;
     this.useBp = useBp;
     this.filterScheme = filterScheme;
-    this.tcms = new TrackingConcurrentMergeScheduler();
-    this.ttmp = new TrackingTieredMergePolicy();
   }
 
-  public int createIndex() throws IOException, InterruptedException {
+  public int createIndex(Consumer<IndexWriterConfig> iwcMutator) throws IOException, InterruptedException {
     IndexWriterConfig iwc = new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.CREATE);
-    iwc.setCodec(codec);
+
+    TrackingConcurrentMergeScheduler tcms = new TrackingConcurrentMergeScheduler();
     iwc.setMergeScheduler(tcms);
     // iwc.setMergePolicy(NoMergePolicy.INSTANCE);
     iwc.setRAMBufferSizeMB(WRITER_BUFFER_MB);
@@ -119,7 +117,7 @@ public class KnnIndexer implements FormatterLogger {
     iwc.setMaxFullFlushMergeWaitMillis(0);
 
     // aim for more compact/realistic index:
-    
+    TrackingTieredMergePolicy ttmp = new TrackingTieredMergePolicy();
     iwc.setMergePolicy(ttmp);
     ttmp.setFloorSegmentMB(256);
     iwc.getCodec().compoundFormat().setShouldUseCompoundFile(false);
@@ -128,8 +126,8 @@ public class KnnIndexer implements FormatterLogger {
       iwc.setMergePolicy(new BPReorderingMergePolicy(iwc.getMergePolicy(), new BpVectorReorderer(KnnGraphTester.KNN_FIELD)));
     }
 
-    ConcurrentMergeScheduler cms = (ConcurrentMergeScheduler) iwc.getMergeScheduler();
-    // cms.setMaxMergesAndThreads(24, 12);
+    // Apply any other changes on top of these defaults
+    iwcMutator.accept(iwc);
 
     FieldType fieldType =
         switch (vectorEncoding) {
@@ -251,22 +249,24 @@ public class KnnIndexer implements FormatterLogger {
       }
 
       // give merges a chance to kick off and finish:
-      log("now IndexWriter.commit()\n");
+      elapsedNS = System.nanoTime() - startNS;
+      log("now IndexWriter.commit() after %d seconds\n", TimeUnit.NANOSECONDS.toSeconds(elapsedNS));
       iw.commit();
 
       elapsedNS = System.nanoTime() - startNS;
-
+      log("now wait for already running merges to finish after %d seconds\n", TimeUnit.NANOSECONDS.toSeconds(elapsedNS));
       waitForMergesWithStatus(ttmp, tcms, this);
+
+      elapsedNS = System.nanoTime() - startNS;
+      log("now IndexWriter.close() after %d seconds\n", TimeUnit.NANOSECONDS.toSeconds(elapsedNS));
     }
+    elapsedNS = System.nanoTime() - startNS;
     log("Indexed %d docs in %d seconds\n", numDocs, TimeUnit.NANOSECONDS.toSeconds(elapsedNS));
     return (int) TimeUnit.NANOSECONDS.toMillis(elapsedNS);
   }
 
   public static void waitForMergesWithStatus(TrackingTieredMergePolicy ttmp, TrackingConcurrentMergeScheduler tcms, FormatterLogger log) throws InterruptedException {
     long startNS = System.nanoTime();
-    
-    // wait for running merges to complete, and print coarse status updates
-    log.log("now wait for already running merges to finish\n");
 
     // silliness to just be able to print progress in waiting (so long...) for merges:
     long nextPrintNS = System.nanoTime();

--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -147,10 +147,9 @@ PARAMS = {
   # "fanout": (50,),
   #'quantize': None,
   #'quantizeBits': (32, 7, 4),
-  "numMergeWorker": (24,),
+  "numMaxMerge": (24,),
   "numMergeThread": (8,),
   "numSearchThread": (4,),
-  #'numMergeWorker': (1,),
   #'numMergeThread': (1,),
   "encoding": ("float32",),
   # "metric": ("cosine",),  # default is angular (dot_product)


### PR DESCRIPTION
By leaving the HNSW vector codec merge executor as `null`, the codecs will leverage the `intraMergeTaskExecutor` provided at merge-time to parallelize the merges.
To populate the field, the corresponding parameters are properly set using `ConcurrentMergeScheduler.setMaxMergesAndThreads(int, int)`.

This change results in a bit of a dependency issue with constructing the codec when using the default value `ConcurrentMergeScheduler.AUTO_DETECT_MERGES_AND_THREADS`, as the auto-detected value only becomes available after setting it on the CMS.
I modified `KnnIndexer.createIndex` to take a lambda for setting non-default options in order to get the CMS and use its values to construct the codec, but it's admittedly a bit janky.

I also modified some of the reported merge timings and print statements.

These changes were originally made as part of #502. 