### PR TITLE
fix: Add spatial3d module to compilation list

### DIFF
--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1117,7 +1117,7 @@ class RunAlgs:
         for module in ["core"]:
           print("compile lucene:core...")
           run([constants.GRADLE_EXE, "lucene:core:jar"], "%s/compile.log" % constants.LOGS_DIR)
-        for module in ("suggest", "highlighter", "misc", "analysis:common", "grouping", "codecs", "facet", "sandbox", "queryparser"):
+        for module in ("suggest", "highlighter", "misc", "analysis:common", "grouping", "codecs", "facet", "sandbox", "queryparser", "spatial3d"):
           # Try to be faster; this may miss changes, e.g. a static final constant changed in core that is used in another module:
           modulePath = "%s/lucene/%s" % (checkoutPath, module.replace(":", "/"))
           classesPath = "%s/build/classes/java" % (modulePath)


### PR DESCRIPTION
## Description

This PR adds the `spatial3d` module to the list of modules compiled during benchmark runs to fix build failure..

## Changes

**`src/python/benchUtil.py`**
- Include `spatial3d` in the modules compilation list

## Testing

Verified that benchmarks compile successfully with spatial3d included.