### PR TITLE
Enable nightly tests comparing classic facets with the new during-col…

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ in a separate phase, and a new implementation that computes facets during collec
 To compare performance for the two implementations run
 
 ```
-python src/python/localrunFacets.py -source facetsWikimediumAll
+python src/python/runFacets.py -source facetsWikimediumAll
 ```
 
 Note that only comparison of taxonomy based facets is supported at the moment. We need to add SSDV facets support

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -1612,6 +1612,9 @@ class RunAlgs:
         # When we add a whole new task (e.g. VectorSearch), just skip the comparison for the first nightly run
         # since baseline will not have this task yet:
         continue
+      if currentCat not in cmpLatencyMetrics:
+        # TODO: This could happen during the first run after separating facet tasks from search tasks - do we want to revert this after first run?
+        continue
       currentBaseMetrics = baseLatencyMetrics[currentCat]
       currentCmpMetrics = cmpLatencyMetrics[currentCat]
       pctP50 = 100 * (currentCmpMetrics["p50"] - currentBaseMetrics["p50"]) / currentBaseMetrics["p50"]

--- a/src/python/benchUtil.py
+++ b/src/python/benchUtil.py
@@ -44,6 +44,8 @@ if PERF_EXE is None:
 else:
   print(f"perf executable is {PERF_EXE}; will collect aggregate CPU profiling data")
 
+TASKSET_EXE = which("taskset")
+
 PYTHON_MAJOR_VER = sys.version_info.major
 
 VMSTAT_PATH = shutil.which("vmstat")
@@ -1193,6 +1195,16 @@ class RunAlgs:
       doSort = ""
 
     command = []
+
+    if c.cpus is not None:
+      if TASKSET_EXE is None:
+        raise RuntimeError("Number of CPUs is requested, but taskset command is not found")
+      # Limit to first N CPUs only
+      cpu_list = ",".join(str(i) for i in range(c.searchConcurrency))
+      command.append(f"{TASKSET_EXE}")
+      command.append("-c")
+      command.append(f"{cpu_list}")
+
     if PERF_EXE is not None:
       command += [PERF_EXE, "stat", "-dd"]
     command += c.javaCommand.split()

--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -300,6 +300,7 @@ class Competitor:
     topN=100,
     testContext="",
     pollute=True,
+    cpus=None,  # int, number of CPUs to use for the test
   ):
     self.name = name
     self.checkout = checkout
@@ -330,6 +331,7 @@ class Competitor:
     self.vectorDimension = vectorDimension
     self.vectorScale = vectorScale
     self.javacCommand = javacCommand
+    self.cpus = cpus
 
     # nocommit
     if False and searchConcurrency != 0 and numConcurrentQueries > 1:

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -947,8 +947,6 @@ def run():
   else:
     print("no out.png (QPSChart)!")
 
-  searchResults = results
-
   print("  search heaps: %s" % str(searchHeaps))
   print("  facets heaps: %s" % str(facetsHeaps))
 
@@ -1401,7 +1399,7 @@ def makeGraphs():
         + ","
         + ",".join(
           v.get(subcat_ord, ",")  #  allow missing values, it's a tupele qps,stddev
-          for subcat_ord in range(0, len(searchChartHeaders[cat]) - 1)
+          for subcat_ord in range(len(searchChartHeaders[cat]) - 1)
         )
         for ts, v in data.items()
       ]

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -759,7 +759,7 @@ def run():
 
   # TODO: It used to require previous results in non-DEBUG mode, but that doesn't work if you run nightlies first time ever on your machine,
   # so I think it's ok to reuse current results if previous results are missing. Another option is to add --first-time arg support?
-  #if len(resultsPrev) == 0 and DEBUG:
+  # if len(resultsPrev) == 0 and DEBUG:
   if len(resultsSearchPrev) == 0:
     # sidestep exception when we can't find any previous results because DEBUG
     resultsSearchPrev = resultsSearchNow
@@ -985,7 +985,7 @@ def run():
     medQuantizedVectorsIndexTime,
     medQuantizedVectorsBytesIndexed,
     facetResults,
-    facetsHeaps
+    facetsHeaps,
   )
 
   for fname in resultsSearchNow + resultsFacetsNow:
@@ -1208,12 +1208,10 @@ def makeGraphs():
       else:
         openGitHubPRCount, closedGitHubPRCount = None, None
 
-
       if len(tup) > 18:
         facetResults, facetHeaps = tup[18:20]
       else:
         facetResults, facetHeaps = None, None
-
 
       timeStampString = "%04d-%02d-%02d %02d:%02d:%02d" % (timeStamp.year, timeStamp.month, timeStamp.day, timeStamp.hour, timeStamp.minute, int(timeStamp.second))
       date = "%02d/%02d/%04d" % (timeStamp.month, timeStamp.day, timeStamp.year)
@@ -1271,8 +1269,8 @@ def makeGraphs():
             # TODO: why does this happen!?
             cat = str(cat, "utf-8")
           # Show all subcategory graphs together
-          if '+' in cat:
-            cat, subcat = cat.split('+')
+          if "+" in cat:
+            cat, subcat = cat.split("+")
           else:
             subcat = "QPS"
 
@@ -1395,12 +1393,21 @@ def makeGraphs():
   sort(bigIndexChartData)
   sort(gcIndexTimesChartData)
   sort(fixedIndexSizeChartData)
-  searchChartDataFinal = {cat:
-                            [",".join(searchChartHeaders[cat])]
-                            + sorted([ts + "," + ",".join(v.get(subcat_ord, ",")  #  allow missing values, it's a tupele qps,stddev
-                                                          for subcat_ord in range(0, len(searchChartHeaders[cat]) - 1)) for ts,v in data.items()])
-                          for cat, data in searchChartData.items()}
-
+  searchChartDataFinal = {
+    cat: [",".join(searchChartHeaders[cat])]
+    + sorted(
+      [
+        ts
+        + ","
+        + ",".join(
+          v.get(subcat_ord, ",")  #  allow missing values, it's a tupele qps,stddev
+          for subcat_ord in range(0, len(searchChartHeaders[cat]) - 1)
+        )
+        for ts, v in data.items()
+      ]
+    )
+    for cat, data in searchChartData.items()
+  }
 
   # Index time, including GC/JIT times
   writeIndexingHTML(fixedIndexSizeChartData, medIndexChartData, medIndexVectorsChartData, medIndexQuantizedVectorsChartData, bigIndexChartData, gcIndexTimesChartData)

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -81,6 +81,9 @@ DIR_IMPL = "MMapDirectory"
 # Make sure we exercise Lucene's intra-query concurrency code paths:
 SEARCH_CONCURRENCY = 8
 
+# Applies to both inter and intra query concurrency for facet tests
+FACETS_CONCURRENCY = 8
+
 INDEXING_RAM_BUFFER_MB = 2048
 
 # "randomly" pick 5 queries for each category, but see validate_nightly_task_count where we
@@ -603,8 +606,9 @@ def run():
     vectorDimension=constants.VECTORS_DIMENSIONS,
     directory=DIR_IMPL,
     commitPoint="multi",
-    numConcurrentQueries=SEARCH_CONCURRENCY,
-    searchConcurrency=SEARCH_CONCURRENCY,
+    numConcurrentQueries=FACETS_CONCURRENCY,
+    searchConcurrency=FACETS_CONCURRENCY,
+    cpus=FACETS_CONCURRENCY,
   )
 
   # c = benchUtil.Competitor(id, 'trunk.nightly', index, DIR_IMPL, 'StandardAnalyzerNoStopWords', 'multi', constants.WIKI_MEDIUM_TASKS_FILE)

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -603,7 +603,7 @@ def run():
     vectorDimension=constants.VECTORS_DIMENSIONS,
     directory=DIR_IMPL,
     commitPoint="multi",
-    numConcurrentQueries=1,
+    numConcurrentQueries=SEARCH_CONCURRENCY,
     searchConcurrency=SEARCH_CONCURRENCY,
   )
 
@@ -1146,6 +1146,7 @@ def makeGraphs():
   # For Search/Facets tasks headers/number of columns can be dynamic as it depends on number of subcategories.
   # If there are no subcategories, use "QPS" by default
   # The format for task with subcategories is "CATEGORY+SUBCATEGORY: ..."
+  # Use subcategories to show multiple graphs on the same page
   searchChartHeaders = {}
   searchChartData = {}
   storedFieldsResults = {

--- a/src/python/runFacets.py
+++ b/src/python/runFacets.py
@@ -24,16 +24,15 @@ import competition
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(prog="Local Benchmark Run", description="Run a local benchmark on provided source dataset.")
   parser.add_argument("-s", "-source", "--source", help="Data source to run the benchmark on.")
-  parser.add_argument("-searchConcurrency", "--searchConcurrency", default="-1", type=int, help="Search concurrency, 0 for disabled, -1 for using all cores")
+  parser.add_argument("-cpuNum", "--cpuNum", default="8", type=int, help="Number of CPUs to use, also used as number of searcher threads and concurrent queries, -1 for using all cores")
   parser.add_argument("-l", "--lucene-dir", default=os.environ.get("BASELINE") or "lucene_baseline", help="Path to lucene repo to be used for comparison")
   args = parser.parse_args()
   print("Running benchmarks with the following args: %s" % args)
 
   sourceData = competition.sourceData(args.source)
-  countsAreCorrect = args.searchConcurrency != 0
   # enable groupByCat and increase taskRepeatCount to limit time when tasks from different categories
   # are running at the same time and compete for searcher thread pool
-  comp = competition.Competition(verifyCounts=not countsAreCorrect, groupByCat=True, taskRepeatCount=200)
+  comp = competition.Competition(verifyCounts=True, groupByCat=True, taskRepeatCount=200)
 
   index = comp.newIndex(
     args.lucene_dir,
@@ -52,9 +51,16 @@ if __name__ == "__main__":
       ("sortedset:RandomLabel", "RandomLabel"),
     ),
   )
-  # create a competitor named baseline with sources in the ../trunk folder
-  comp.competitor("post_collection_facets", args.lucene_dir, index=index, searchConcurrency=args.searchConcurrency, testContext="facetMode:POST_COLLECTION", pk=False)
-  comp.competitor("during_collection_facets", args.lucene_dir, index=index, searchConcurrency=args.searchConcurrency, testContext="facetMode:DURING_COLLECTION", pk=False)
+  # Set searchConcurrency, numConcurrentQueries, and cpus to the same
+  # number to make inter-only (post collection) and inter+intra (during
+  # collection) facets comparison fair, given that tasks are also grouped
+  # by category (Competition.groupByCat).
+  comp.competitor(
+    "post_collection_facets", args.lucene_dir, index=index, searchConcurrency=args.cpuNum, numConcurrentQueries=args.cpuNum, cpus=args.cpuNum, testContext="facetMode:POST_COLLECTION", pk=False
+  )
+  comp.competitor(
+    "during_collection_facets", args.lucene_dir, index=index, searchConcurrency=args.cpuNum, numConcurrentQueries=args.cpuNum, cpus=args.cpuNum, testContext="facetMode:DURING_COLLECTION", pk=False
+  )
 
   # start the benchmark - this can take long depending on your index and machines
   comp.benchmark("facet_implementations")

--- a/tasks/wikinightly.facets.tasks
+++ b/tasks/wikinightly.facets.tasks
@@ -1,0 +1,77 @@
+# Moving all nightly facet tasks to separate file to run them using
+# both post collection and during collection facets and compare performance
+BrowseDateTaxoFacets+postCollection: *:* +post_collection_facets:Date.taxonomy
+BrowseDateTaxoFacets+duringCollection: *:* +during_collection_facets:Date.taxonomy
+
+BrowseMonthTaxoFacets+postCollection: *:* +post_collection_facets:Month.taxonomy
+BrowseDayOfYearTaxoFacets+postCollection: *:* +post_collection_facets:DayOfYear.taxonomy
+BrowseRandomLabelTaxoFacets+postCollection: *:* +post_collection_facets:RandomLabel.taxonomy
+BrowseRandomLabelTaxoFacets+duringCollection: *:* +during_collection_facets:RandomLabel.taxonomy
+BrowseMonthTaxoFacets+duringCollection: *:* +during_collection_facets:Month.taxonomy
+BrowseDayOfYearTaxoFacets+duringCollection: *:* +during_collection_facets:DayOfYear.taxonomy
+
+
+BrowseDateSSDVFacets: *:* +facets:Date.sortedset
+BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
+BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
+BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
+
+TermDateFacets+postCollection: 0 +post_collection_facets:Date.taxonomy # freq=708472
+TermDateFacets+postCollection: names +post_collection_facets:Date.taxonomy # freq=402762
+TermDateFacets+postCollection: nbsp +post_collection_facets:Date.taxonomy # freq=492778
+TermDateFacets+postCollection: part +post_collection_facets:Date.taxonomy # freq=588644
+TermDateFacets+postCollection: st +post_collection_facets:Date.taxonomy # freq=306811
+
+TermDateFacets+duringCollection: 0 +during_collection_facets:Date.taxonomy # freq=708472
+TermDateFacets+duringCollection: names +during_collection_facets:Date.taxonomy # freq=402762
+TermDateFacets+duringCollection: nbsp +during_collection_facets:Date.taxonomy # freq=492778
+TermDateFacets+duringCollection: part +during_collection_facets:Date.taxonomy # freq=588644
+TermDateFacets+duringCollection: st +during_collection_facets:Date.taxonomy # freq=306811
+
+OrHighMedDayTaxoFacets+postCollection: 4 steve +post_collection_facets:DayOfYear.taxonomy # freq=986452 freq=84364
+OrHighMedDayTaxoFacets+postCollection: some groups +post_collection_facets:DayOfYear.taxonomy # freq=839919 freq=146670
+OrHighMedDayTaxoFacets+postCollection: a named +post_collection_facets:DayOfYear.taxonomy # freq=6560531 freq=310150
+OrHighMedDayTaxoFacets+postCollection: not opening +post_collection_facets:DayOfYear.taxonomy # freq=1713264 freq=84576
+OrHighMedDayTaxoFacets+postCollection: which pre +post_collection_facets:DayOfYear.taxonomy # freq=1963428 freq=90549
+
+OrHighMedDayTaxoFacets+duringCollection: 4 steve +during_collection_facets:DayOfYear.taxonomy # freq=986452 freq=84364
+OrHighMedDayTaxoFacets+duringCollection: some groups +during_collection_facets:DayOfYear.taxonomy # freq=839919 freq=146670
+OrHighMedDayTaxoFacets+duringCollection: a named +during_collection_facets:DayOfYear.taxonomy # freq=6560531 freq=310150
+OrHighMedDayTaxoFacets+duringCollection: not opening +during_collection_facets:DayOfYear.taxonomy # freq=1713264 freq=84576
+OrHighMedDayTaxoFacets+duringCollection: which pre +during_collection_facets:DayOfYear.taxonomy # freq=1963428 freq=90549
+
+AndHighMedDayTaxoFacets+postCollection: +web +available +post_collection_facets:DayOfYear.taxonomy # freq=1118334 freq=175514
+AndHighMedDayTaxoFacets+postCollection: +other +christian +post_collection_facets:DayOfYear.taxonomy # freq=1269961 freq=140312
+AndHighMedDayTaxoFacets+postCollection: +into +70 +post_collection_facets:DayOfYear.taxonomy # freq=888684 freq=90305
+AndHighMedDayTaxoFacets+postCollection: +at +space +post_collection_facets:DayOfYear.taxonomy # freq=2857534 freq=163436
+AndHighMedDayTaxoFacets+postCollection: +for +few +post_collection_facets:DayOfYear.taxonomy # freq=4380011 freq=226422
+
+AndHighMedDayTaxoFacets+duringCollection: +web +available +during_collection_facets:DayOfYear.taxonomy # freq=1118334 freq=175514
+AndHighMedDayTaxoFacets+duringCollection: +other +christian +during_collection_facets:DayOfYear.taxonomy # freq=1269961 freq=140312
+AndHighMedDayTaxoFacets+duringCollection: +into +70 +during_collection_facets:DayOfYear.taxonomy # freq=888684 freq=90305
+AndHighMedDayTaxoFacets+duringCollection: +at +space +during_collection_facets:DayOfYear.taxonomy # freq=2857534 freq=163436
+AndHighMedDayTaxoFacets+duringCollection: +for +few +during_collection_facets:DayOfYear.taxonomy # freq=4380011 freq=226422
+
+AndHighHighDayTaxoFacets+postCollection: +a +work +post_collection_facets:DayOfYear.taxonomy # freq=6560531 freq=853422
+AndHighHighDayTaxoFacets+postCollection: +and +2 +post_collection_facets:DayOfYear.taxonomy # freq=7318061 freq=1549245
+AndHighHighDayTaxoFacets+postCollection: +in +2011 +post_collection_facets:DayOfYear.taxonomy # freq=7320987 freq=871410
+AndHighHighDayTaxoFacets+postCollection: +was +also +post_collection_facets:DayOfYear.taxonomy # freq=3763623 freq=1959419
+AndHighHighDayTaxoFacets+postCollection: +to +an +post_collection_facets:DayOfYear.taxonomy # freq=6155577 freq=2628056
+
+AndHighHighDayTaxoFacets+duringCollection: +a +work +during_collection_facets:DayOfYear.taxonomy # freq=6560531 freq=853422
+AndHighHighDayTaxoFacets+duringCollection: +and +2 +during_collection_facets:DayOfYear.taxonomy # freq=7318061 freq=1549245
+AndHighHighDayTaxoFacets+duringCollection: +in +2011 +during_collection_facets:DayOfYear.taxonomy # freq=7320987 freq=871410
+AndHighHighDayTaxoFacets+duringCollection: +was +also +during_collection_facets:DayOfYear.taxonomy # freq=3763623 freq=1959419
+AndHighHighDayTaxoFacets+duringCollection: +to +an +during_collection_facets:DayOfYear.taxonomy # freq=6155577 freq=2628056
+
+MedTermDayTaxoFacets+postCollection: result +post_collection_facets:DayOfYear.taxonomy # freq=276803
+MedTermDayTaxoFacets+postCollection: college +post_collection_facets:DayOfYear.taxonomy # freq=278094
+MedTermDayTaxoFacets+postCollection: site +post_collection_facets:DayOfYear.taxonomy # freq=277788
+MedTermDayTaxoFacets+postCollection: man +post_collection_facets:DayOfYear.taxonomy # freq=278112
+MedTermDayTaxoFacets+postCollection: football +post_collection_facets:DayOfYear.taxonomy # freq=277738
+
+MedTermDayTaxoFacets+duringCollection: result +during_collection_facets:DayOfYear.taxonomy # freq=276803
+MedTermDayTaxoFacets+duringCollection: college +during_collection_facets:DayOfYear.taxonomy # freq=278094
+MedTermDayTaxoFacets+duringCollection: site +during_collection_facets:DayOfYear.taxonomy # freq=277788
+MedTermDayTaxoFacets+duringCollection: man +during_collection_facets:DayOfYear.taxonomy # freq=278112
+MedTermDayTaxoFacets+duringCollection: football +during_collection_facets:DayOfYear.taxonomy # freq=277738

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -86,28 +86,6 @@ Term: nbsp # freq=492778
 Term: part # freq=588644
 Term: st # freq=306811
 
-BrowseDateTaxoFacets: *:* +facets:Date.taxonomy
-
-BrowseMonthTaxoFacets: *:* +facets:Month.taxonomy
-
-BrowseDayOfYearTaxoFacets: *:* +facets:DayOfYear.taxonomy
-
-BrowseDateSSDVFacets: *:* +facets:Date.sortedset
-
-BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
-
-BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
-
-BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
-
-BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
-
-TermDateFacets: 0 +facets:Date.taxonomy # freq=708472
-TermDateFacets: names +facets:Date.taxonomy # freq=402762
-TermDateFacets: nbsp +facets:Date.taxonomy # freq=492778
-TermDateFacets: part +facets:Date.taxonomy # freq=588644
-TermDateFacets: st +facets:Date.taxonomy # freq=306811
-
 TermDateTimeSort: lastmodndvsort//0 # freq=708472
 TermDateTimeSort: lastmodndvsort//names # freq=402762
 TermDateTimeSort: lastmodndvsort//nbsp # freq=492778
@@ -197,30 +175,6 @@ PostFilteredVectorSearch: vector//many geografia +filter=5%
 PostFilteredVectorSearch: vector//many foundation +filter=5%
 PostFilteredVectorSearch: vector//this school +filter=5%
 PostFilteredVectorSearch: vector//such 2007 +filter=5%
-
-OrHighMedDayTaxoFacets: 4 steve +facets:DayOfYear.taxonomy # freq=986452 freq=84364
-OrHighMedDayTaxoFacets: some groups +facets:DayOfYear.taxonomy # freq=839919 freq=146670
-OrHighMedDayTaxoFacets: a named +facets:DayOfYear.taxonomy # freq=6560531 freq=310150
-OrHighMedDayTaxoFacets: not opening +facets:DayOfYear.taxonomy # freq=1713264 freq=84576
-OrHighMedDayTaxoFacets: which pre +facets:DayOfYear.taxonomy # freq=1963428 freq=90549
-
-AndHighMedDayTaxoFacets: +web +available +facets:DayOfYear.taxonomy # freq=1118334 freq=175514
-AndHighMedDayTaxoFacets: +other +christian +facets:DayOfYear.taxonomy # freq=1269961 freq=140312
-AndHighMedDayTaxoFacets: +into +70 +facets:DayOfYear.taxonomy # freq=888684 freq=90305
-AndHighMedDayTaxoFacets: +at +space +facets:DayOfYear.taxonomy # freq=2857534 freq=163436
-AndHighMedDayTaxoFacets: +for +few +facets:DayOfYear.taxonomy # freq=4380011 freq=226422
-
-AndHighHighDayTaxoFacets: +a +work +facets:DayOfYear.taxonomy # freq=6560531 freq=853422
-AndHighHighDayTaxoFacets: +and +2 +facets:DayOfYear.taxonomy # freq=7318061 freq=1549245
-AndHighHighDayTaxoFacets: +in +2011 +facets:DayOfYear.taxonomy # freq=7320987 freq=871410
-AndHighHighDayTaxoFacets: +was +also +facets:DayOfYear.taxonomy # freq=3763623 freq=1959419
-AndHighHighDayTaxoFacets: +to +an +facets:DayOfYear.taxonomy # freq=6155577 freq=2628056
-
-MedTermDayTaxoFacets: result +facets:DayOfYear.taxonomy # freq=276803
-MedTermDayTaxoFacets: college +facets:DayOfYear.taxonomy # freq=278094
-MedTermDayTaxoFacets: site +facets:DayOfYear.taxonomy # freq=277788
-MedTermDayTaxoFacets: man +facets:DayOfYear.taxonomy # freq=278112
-MedTermDayTaxoFacets: football +facets:DayOfYear.taxonomy # freq=277738
 
 # CombinedFieldQuery: does BM25F across the title and body fields, with a boost
 # of 8 on the title field


### PR DESCRIPTION
…lection facets

Changelist:
1. Add support for `CATEGORY+SUBCATEGORY` format, for nightly tests all subcategories are added to the same graph
2. Separate nightly search and facet tasks files and execution - it is required as facets require slightly different configuration to be able to compare old/new API, see details in https://github.com/mikemccand/luceneutil/pull/325#issuecomment-2680008803
3. Allow missing task in candidate if benchUtil#simpleReport - required to remove facet tasks from search tasks in [2]
4. Allow missing previous results
5. Fix script name typo in README.md (not related to nightlies)

Tested locally on top of changes from this branch to enable nightly benches https://github.com/mikemccand/luceneutil/compare/main...epotyom:luceneutil:fix_nightly_start_from_scratch