### PR TITLE
Enhanced PKLookupTask

### DIFF
--- a/src/main/perf/IndexState.java
+++ b/src/main/perf/IndexState.java
@@ -20,6 +20,7 @@ package perf;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -66,8 +67,7 @@ class IndexState {
   public final Map<Object, ThreadLocal<PointsPKLookupState>> pointsPKLookupStates = new HashMap<>();
   public final Map<Object, ThreadLocal<PKLookupWithTermStateState>> pkLookupWithTermStateStates = new HashMap<>();
 
-  // Leaf ordinals sorted by descending maxDoc, so PK lookups check the largest segments first.
-  // Computed once at IndexState construction time to avoid re-sorting on every task run.
+  // Leaf ordinals sorted by descending maxDoc,
   public final int[] leafOrder;
 
   public IndexState(ExecutorService executor, ReferenceManager<IndexSearcher> mgr, TaxonomyReader taxoReader, String textFieldName,
@@ -98,7 +98,7 @@ class IndexState {
     try {
       hasDeletions = searcher.getIndexReader().hasDeletions();
 
-      java.util.List<LeafReaderContext> leaves = searcher.getIndexReader().leaves();
+      List<LeafReaderContext> leaves = searcher.getIndexReader().leaves();
       for(LeafReaderContext ctx : leaves) {
         pkLookupStates.put(ctx.reader().getCoreCacheHelper().getKey(), new ThreadLocal<PKLookupState>());
         pointsPKLookupStates.put(ctx.reader().getCoreCacheHelper().getKey(), new ThreadLocal<PointsPKLookupState>());

--- a/src/main/perf/IndexState.java
+++ b/src/main/perf/IndexState.java
@@ -66,6 +66,10 @@ class IndexState {
   public final Map<Object, ThreadLocal<PointsPKLookupState>> pointsPKLookupStates = new HashMap<>();
   public final Map<Object, ThreadLocal<PKLookupWithTermStateState>> pkLookupWithTermStateStates = new HashMap<>();
 
+  // Leaf ordinals sorted by descending maxDoc, so PK lookups check the largest segments first.
+  // Computed once at IndexState construction time to avoid re-sorting on every task run.
+  public final int[] leafOrder;
+
   public IndexState(ExecutorService executor, ReferenceManager<IndexSearcher> mgr, TaxonomyReader taxoReader, String textFieldName,
                     DirectSpellChecker spellChecker, String hiliteImpl, FacetsConfig facetsConfig, Map<String,Integer> facetFields) throws IOException {
     this.executor = executor;
@@ -94,10 +98,22 @@ class IndexState {
     try {
       hasDeletions = searcher.getIndexReader().hasDeletions();
 
-      for(LeafReaderContext ctx : searcher.getIndexReader().leaves()) {
+      java.util.List<LeafReaderContext> leaves = searcher.getIndexReader().leaves();
+      for(LeafReaderContext ctx : leaves) {
         pkLookupStates.put(ctx.reader().getCoreCacheHelper().getKey(), new ThreadLocal<PKLookupState>());
         pointsPKLookupStates.put(ctx.reader().getCoreCacheHelper().getKey(), new ThreadLocal<PointsPKLookupState>());
         pkLookupWithTermStateStates.put(ctx.reader().getCoreCacheHelper().getKey(), new ThreadLocal<PKLookupWithTermStateState>());
+      }
+
+      // Pre-compute leaf ordering by descending maxDoc
+      Integer[] order = new Integer[leaves.size()];
+      for (int i = 0; i < order.length; i++) {
+        order[i] = i;
+      }
+      Arrays.sort(order, (a, b) -> Integer.compare(leaves.get(b).reader().maxDoc(), leaves.get(a).reader().maxDoc()));
+      leafOrder = new int[order.length];
+      for (int i = 0; i < order.length; i++) {
+        leafOrder[i] = order[i];
       }
 
       groupBlocksExist = searcher.count(groupEndQuery) > 0;

--- a/src/main/perf/PKLookupTask.java
+++ b/src/main/perf/PKLookupTask.java
@@ -124,8 +124,7 @@ final class PKLookupTask extends Task {
                 //System.out.println("TEST: lookup " + ids[idx].utf8ToString());
                 if (pkState.termsEnum.seekExact(id)) {
                     //System.out.println("  found!");
-                    pkState.postingsEnum = pkState.termsEnum.postings(pkState.postingsEnum, 0);
-                    PostingsEnum docs = pkState.postingsEnum;
+                    PostingsEnum docs = pkState.termsEnum.postings(pkState.postingsEnum, 0);
                     assert docs != null;
                     for (int d = docs.nextDoc(); d != DocIdSetIterator.NO_MORE_DOCS; d = docs.nextDoc()) {
                         if (pkState.liveDocs == null || pkState.liveDocs.get(d)) {

--- a/src/main/perf/PKLookupTask.java
+++ b/src/main/perf/PKLookupTask.java
@@ -20,6 +20,7 @@ package perf;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -34,6 +35,8 @@ final class PKLookupTask extends Task {
   private final BytesRef[] ids;
   private final int[] answers;
   private final int ord;
+  private static final int NON_EXISTENT_IDS_RATIO = 10;
+  private final Set<BytesRef> syntheticMissIds;
 
   @Override
   public String getCategory() {
@@ -44,6 +47,7 @@ final class PKLookupTask extends Task {
     ids = other.ids;
     ord = other.ord;
     answers = new int[ids.length];
+    syntheticMissIds = other.syntheticMissIds;
     Arrays.fill(answers, -1);
   }
 
@@ -52,14 +56,30 @@ final class PKLookupTask extends Task {
     ids = new BytesRef[count];
     answers = new int[count];
     Arrays.fill(answers, -1);
+    syntheticMissIds = new HashSet<>();
+
+    int missCount = count * NON_EXISTENT_IDS_RATIO / 100;
+    int hitCount = count - missCount;
+
     int idx = 0;
-    while(idx < count) {
-      final BytesRef id = new BytesRef(LineFileDocs.intToID(random.nextInt(maxDoc)));
-      if (seen.contains(id) == false) {
-        seen.add(id);
-        ids[idx++] = id;
-      }
+    while (idx < count) {
+        BytesRef id = null;
+        if (idx < hitCount) {
+            id = new BytesRef(LineFileDocs.intToID(random.nextInt(maxDoc)));
+        }
+        else{
+            id = new BytesRef(LineFileDocs.intToID(maxDoc + random.nextInt(maxDoc)));
+        }
+        if (seen.contains(id) == false) {
+            seen.add(id);
+            if (idx >= hitCount) {
+                syntheticMissIds.add(id);
+            }
+            ids[idx++] = id;
+        }
     }
+
+    Arrays.sort(ids);
   }
 
   @Override
@@ -69,53 +89,59 @@ final class PKLookupTask extends Task {
 
   @Override
   public void go(IndexState state, TaskParser taskParser) throws IOException {
-
     final IndexSearcher searcher = state.mgr.acquire();
     try {
-      final List<LeafReaderContext> subReaders = searcher.getIndexReader().leaves();
-      IndexState.PKLookupState[] pkStates = new IndexState.PKLookupState[subReaders.size()];
-      for(int subIDX=0;subIDX<subReaders.size();subIDX++) {
-        LeafReaderContext ctx = subReaders.get(subIDX);
-        ThreadLocal<IndexState.PKLookupState> states = state.pkLookupStates.get(ctx.reader().getCoreCacheHelper().getKey());
-        // NPE here means you are trying to use this task on a newly refreshed NRT reader!
-        IndexState.PKLookupState pkState = states.get();
-        if (pkState == null) {
-          pkState = new IndexState.PKLookupState(ctx.reader(), "id");
-          states.set(pkState);
-        }
-        pkStates[subIDX] = pkState;
-      }
+        final List<LeafReaderContext> subReaders = searcher.getIndexReader().leaves();
 
-      for(int idx=0;idx<ids.length;idx++) {
-        int base = 0;
-        final BytesRef id = ids[idx];
-        for(int subIDX=0;subIDX<subReaders.size();subIDX++) {
-          IndexState.PKLookupState pkState = pkStates[subIDX];
-          //System.out.println("\nTASK: sub=" + sub);
-          //System.out.println("TEST: lookup " + ids[idx].utf8ToString());
-          if (pkState.termsEnum.seekExact(id)) { 
-            //System.out.println("  found!");
-            PostingsEnum docs = pkState.termsEnum.postings(pkState.postingsEnum, 0);
-            assert docs != null;
-            int docID = DocIdSetIterator.NO_MORE_DOCS;
-            for (int d = docs.nextDoc(); d != DocIdSetIterator.NO_MORE_DOCS; d = docs.nextDoc()) {
-              if (pkState.liveDocs == null || pkState.liveDocs.get(d)) {
-                docID = d;
-                // stop iterating for additional docs since we know this is a unique id
-                break;
-              }
-            }
-            if (docID != DocIdSetIterator.NO_MORE_DOCS) {
-              answers[idx] = base + docID;
-              // stop checking further segments since we know this is a unique id
-              break;
-            }
-          }
-          base += subReaders.get(subIDX).reader().maxDoc();
+        Integer[] segOrder = new Integer[subReaders.size()];
+        for (int i = 0; i < segOrder.length; i++){
+            segOrder[i] = i;
         }
-      }
+
+        // Sorting by maxDoc
+        Arrays.sort(segOrder, (a, b) ->
+                subReaders.get(b).reader().maxDoc() - subReaders.get(a).reader().maxDoc());
+
+        IndexState.PKLookupState[] pkStates = new IndexState.PKLookupState[subReaders.size()];
+        for (int subIDX = 0; subIDX < subReaders.size(); subIDX++) {
+            LeafReaderContext ctx = subReaders.get(subIDX);
+            ThreadLocal<IndexState.PKLookupState> states = state.pkLookupStates.get(ctx.reader().getCoreCacheHelper().getKey());
+            // NPE here means you are trying to use this task on a newly refreshed NRT reader!
+            IndexState.PKLookupState pkState = states.get();
+            if (pkState == null) {
+                pkState = new IndexState.PKLookupState(ctx.reader(), "id");
+                states.set(pkState);
+            }
+            pkStates[subIDX] = pkState;
+        }
+
+        for (int idx = 0; idx < ids.length; idx++) {
+            final BytesRef id = ids[idx];
+            boolean found = false;
+            for (int subIDX : segOrder) {
+                IndexState.PKLookupState pkState = pkStates[subIDX];
+                //System.out.println("\nTASK: sub=" + sub);
+                //System.out.println("TEST: lookup " + ids[idx].utf8ToString());
+                if (pkState.termsEnum.seekExact(id)) {
+                    //System.out.println("  found!");
+                    pkState.postingsEnum = pkState.termsEnum.postings(pkState.postingsEnum, 0);
+                    PostingsEnum docs = pkState.postingsEnum;
+                    assert docs != null;
+                    for (int d = docs.nextDoc(); d != DocIdSetIterator.NO_MORE_DOCS; d = docs.nextDoc()) {
+                        if (pkState.liveDocs == null || pkState.liveDocs.get(d)) {
+                            answers[idx] = subReaders.get(subIDX).docBase + d;
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (found) {
+                        break;
+                    }
+                }
+            }
+        }
     } finally {
-      state.mgr.release(searcher);
+        state.mgr.release(searcher);
     }
   }
 
@@ -135,7 +161,7 @@ final class PKLookupTask extends Task {
   public void printResults(PrintStream out, IndexState state) throws IOException {
     for(int idx=0;idx<ids.length;idx++) {
       if (answers[idx] == -1) {
-        if (!state.hasDeletions) {
+        if (!state.hasDeletions && syntheticMissIds.contains(ids[idx]) == false) {
           throw new RuntimeException("PKLookup: id=" + ids[idx].utf8ToString() + " failed to find a matching document");
         } else {
           // TODO: we should verify that these are in fact

--- a/src/main/perf/PKLookupTask.java
+++ b/src/main/perf/PKLookupTask.java
@@ -72,8 +72,6 @@ final class PKLookupTask extends Task {
         id = new BytesRef(LineFileDocs.intToID(random.nextInt(maxDoc)));
       } else {
         // Corrupt a real-looking ID by replacing a random digit with an uppercase letter.
-        // Since intToID produces base-36 [0-9a-z], an uppercase char guarantees a non-existent ID
-        // while keeping it naturally distributed among real IDs in sorted order.
         char[] chars = LineFileDocs.intToID(random.nextInt(maxDoc)).toCharArray();
         int pos = random.nextInt(chars.length);
         chars[pos] = (char) ('A' + random.nextInt(26));

--- a/src/main/perf/PKLookupTask.java
+++ b/src/main/perf/PKLookupTask.java
@@ -35,7 +35,7 @@ final class PKLookupTask extends Task {
   private final BytesRef[] ids;
   private final int[] answers;
   private final int ord;
-  private static final int NON_EXISTENT_IDS_RATIO = 10;
+  private static final int NON_EXISTENT_IDS_PERCENT = 10;
   private final Set<BytesRef> syntheticMissIds;
 
   @Override
@@ -58,27 +58,37 @@ final class PKLookupTask extends Task {
     Arrays.fill(answers, -1);
     syntheticMissIds = new HashSet<>();
 
-    int missCount = count * NON_EXISTENT_IDS_RATIO / 100;
+    int missCount = (count * NON_EXISTENT_IDS_PERCENT) / 100;
+    if (missCount == 0 && NON_EXISTENT_IDS_PERCENT > 0) {
+      throw new IllegalArgumentException("count=" + count + " is too small to " +
+              "produce any non-existent IDs with NON_EXISTENT_IDS_PERCENT=" + NON_EXISTENT_IDS_PERCENT);
+    }
     int hitCount = count - missCount;
 
     int idx = 0;
     while (idx < count) {
-        BytesRef id = null;
-        if (idx < hitCount) {
-            id = new BytesRef(LineFileDocs.intToID(random.nextInt(maxDoc)));
+      BytesRef id;
+      if (idx < hitCount) {
+        id = new BytesRef(LineFileDocs.intToID(random.nextInt(maxDoc)));
+      } else {
+        // Corrupt a real-looking ID by replacing a random digit with an uppercase letter.
+        // Since intToID produces base-36 [0-9a-z], an uppercase char guarantees a non-existent ID
+        // while keeping it naturally distributed among real IDs in sorted order.
+        char[] chars = LineFileDocs.intToID(random.nextInt(maxDoc)).toCharArray();
+        int pos = random.nextInt(chars.length);
+        chars[pos] = (char) ('A' + random.nextInt(26));
+        id = new BytesRef(new String(chars));
+      }
+      if (seen.contains(id) == false) {
+        seen.add(id);
+        if (idx >= hitCount) {
+          syntheticMissIds.add(id);
         }
-        else{
-            id = new BytesRef(LineFileDocs.intToID(maxDoc + random.nextInt(maxDoc)));
-        }
-        if (seen.contains(id) == false) {
-            seen.add(id);
-            if (idx >= hitCount) {
-                syntheticMissIds.add(id);
-            }
-            ids[idx++] = id;
-        }
+        ids[idx++] = id;
+      }
     }
 
+    // Sort so lookups are in term-order, optimizing for Lucene's fastest batch PK lookup use case
     Arrays.sort(ids);
   }
 
@@ -93,51 +103,42 @@ final class PKLookupTask extends Task {
     try {
         final List<LeafReaderContext> subReaders = searcher.getIndexReader().leaves();
 
-        Integer[] segOrder = new Integer[subReaders.size()];
-        for (int i = 0; i < segOrder.length; i++){
-            segOrder[i] = i;
-        }
-
-        // Sorting by maxDoc
-        Arrays.sort(segOrder, (a, b) ->
-                subReaders.get(b).reader().maxDoc() - subReaders.get(a).reader().maxDoc());
-
         IndexState.PKLookupState[] pkStates = new IndexState.PKLookupState[subReaders.size()];
         for (int subIDX = 0; subIDX < subReaders.size(); subIDX++) {
             LeafReaderContext ctx = subReaders.get(subIDX);
             ThreadLocal<IndexState.PKLookupState> states = state.pkLookupStates.get(ctx.reader().getCoreCacheHelper().getKey());
             // NPE here means you are trying to use this task on a newly refreshed NRT reader!
             IndexState.PKLookupState pkState = states.get();
-            if (pkState == null) {
-                pkState = new IndexState.PKLookupState(ctx.reader(), "id");
-                states.set(pkState);
+          if (pkState == null) {
+              pkState = new IndexState.PKLookupState(ctx.reader(), "id");
+              states.set(pkState);
             }
             pkStates[subIDX] = pkState;
         }
 
         for (int idx = 0; idx < ids.length; idx++) {
-            final BytesRef id = ids[idx];
-            boolean found = false;
-            for (int subIDX : segOrder) {
-                IndexState.PKLookupState pkState = pkStates[subIDX];
-                //System.out.println("\nTASK: sub=" + sub);
-                //System.out.println("TEST: lookup " + ids[idx].utf8ToString());
-                if (pkState.termsEnum.seekExact(id)) {
-                    //System.out.println("  found!");
-                    PostingsEnum docs = pkState.termsEnum.postings(pkState.postingsEnum, 0);
-                    assert docs != null;
-                    for (int d = docs.nextDoc(); d != DocIdSetIterator.NO_MORE_DOCS; d = docs.nextDoc()) {
-                        if (pkState.liveDocs == null || pkState.liveDocs.get(d)) {
-                            answers[idx] = subReaders.get(subIDX).docBase + d;
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (found) {
-                        break;
-                    }
+          final BytesRef id = ids[idx];
+          boolean found = false;
+          for (int subIDX : state.leafOrder) {
+            IndexState.PKLookupState pkState = pkStates[subIDX];
+            //System.out.println("\nTASK: sub=" + sub);
+            //System.out.println("TEST: lookup " + ids[idx].utf8ToString());
+            if (pkState.termsEnum.seekExact(id)) {
+              //System.out.println("  found!");
+              PostingsEnum docs = pkState.termsEnum.postings(pkState.postingsEnum, 0);
+              assert docs != null;
+              for (int d = docs.nextDoc(); d != DocIdSetIterator.NO_MORE_DOCS; d = docs.nextDoc()) {
+                if (pkState.liveDocs == null || pkState.liveDocs.get(d)) {
+                  answers[idx] = subReaders.get(subIDX).docBase + d;
+                  found = true;
+                  break;
                 }
+              }
+              if (found) {
+                break;
+              }
             }
+          }
         }
     } finally {
         state.mgr.release(searcher);
@@ -160,12 +161,15 @@ final class PKLookupTask extends Task {
   public void printResults(PrintStream out, IndexState state) throws IOException {
     for(int idx=0;idx<ids.length;idx++) {
       if (answers[idx] == -1) {
-        if (!state.hasDeletions && syntheticMissIds.contains(ids[idx]) == false) {
-          throw new RuntimeException("PKLookup: id=" + ids[idx].utf8ToString() + " failed to find a matching document");
-        } else {
-          // TODO: we should verify that these are in fact
-          // the deleted docs...
+        if (syntheticMissIds.contains(ids[idx])) {
+          // Expected miss -- this is a synthetic non-existent ID
           continue;
+        } else if (state.hasDeletions) {
+          // Could be a deleted doc
+          // TODO: we should verify that these are in fact the deleted docs...
+          continue;
+        } else {
+          throw new RuntimeException("PKLookup: id=" + ids[idx].utf8ToString() + " failed to find a matching document");
         }
       }
 


### PR DESCRIPTION
Trying to enhance PKLookupTask, Did the following:

- IDs are now sorted.
- Segments are now visited in descending order of maxdoc
- Added 10% non-existent IDs.

Suggestions take from this Lucene issue: https://github.com/apache/lucene/issues/15520

Testing:

I ran `python src/python/localrun.py -source wikimediumall` on lucene util with/without this change, lucene candidate and baseline were exactly the same. I see a QPS increase for `PKLookup` (I am not sure if this is the right way to test this):

- Baseline

```
PKLookup      202.69      (2.3%)      202.90      (2.3%)    0.1% (  -4% -    4%) 0.886
```

- Candidate

```
PKLookup      251.45      (3.4%)      254.45      (3.4%)    1.2% (  -5% -    8%) 0.266
```

`REV-2`:

```
PKLookup      249.58      (2.6%)      248.75      (3.0%)   -0.3% (  -5% -    5%) 0.705
```
