### PR TITLE
Optimize date parsing in LineFileDocs

### DIFF
--- a/src/main/perf/LineFileDocs.java
+++ b/src/main/perf/LineFileDocs.java
@@ -34,12 +34,12 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.text.DateFormatSymbols;
-import java.text.ParsePosition;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -372,16 +372,17 @@ public class LineFileDocs implements Closeable {
     //final LongField rand;
     final Field timeSec;
     // Necessary for "old style" wiki line files:
-    final SimpleDateFormat dateParser = new SimpleDateFormat("dd-MMM-yyyy HH:mm:ss", Locale.US);
+    static final DateTimeFormatter dateParser = new DateTimeFormatterBuilder()
+        .parseCaseInsensitive()
+        .appendPattern("dd-MMM-yyyy HH:mm:ss")
+        .optionalStart()
+        .appendPattern(".SSS")
+        .optionalEnd()
+        .toFormatter(Locale.US);
     final KnnFloatVectorField floatVectorField;
     final KnnByteVectorField byteVectorField;
 
-    // For just y/m/day:
-    //final SimpleDateFormat dateParser = new SimpleDateFormat("y/M/d", Locale.US);
-
-    //final SimpleDateFormat dateParser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
     final Calendar dateCal = Calendar.getInstance();
-    final ParsePosition datePos = new ParsePosition(0);
 
     DocState(boolean storeBody, boolean tvsBody, boolean bodyPostingsOffsets, boolean addDVFields, boolean addDVSkippers, int vectorDimension, VectorEncoding vectorEncoding) {
       doc = new Document();
@@ -703,18 +704,16 @@ public class LineFileDocs implements Closeable {
 
       final String dateString = line.substring(1+spot, spot2);
       doc.date.setStringValue(dateString);
-      doc.datePos.setIndex(0);
-      final Date date = doc.dateParser.parse(dateString, doc.datePos);
-      if (date == null) {
+      final LocalDateTime ldt = LocalDateTime.parse(dateString, DocState.dateParser);
+      if (ldt == null) {
         System.out.println("FAILED: " + dateString);
       }
-      //doc.dateMSec.setLongValue(date.getTime());
 
-      //doc.rand.setLongValue(rand.nextInt(10000));
-      //System.out.println("DATE: " + date);
-      doc.dateCal.setTime(date);
+      doc.dateCal.set(ldt.getYear(), ldt.getMonthValue() - 1, ldt.getDayOfMonth(),
+                      ldt.getHour(), ldt.getMinute(), ldt.getSecond());
+      doc.dateCal.set(Calendar.MILLISECOND, 0);
       msecSinceEpoch = doc.dateCal.getTimeInMillis();
-      timeSec = doc.dateCal.get(Calendar.HOUR_OF_DAY)*3600 + doc.dateCal.get(Calendar.MINUTE)*60 + doc.dateCal.get(Calendar.SECOND);
+      timeSec = ldt.getHour()*3600 + ldt.getMinute()*60 + ldt.getSecond();
       if (doc.floatVectorField != null) {
         doc.floatVectorField.setVectorValue((float[]) lfd.vector.array());
       } else if (doc.byteVectorField != null) {


### PR DESCRIPTION
## What this changes

This replaces `SimpleDateFormat` with `java.time.DateTimeFormatter` for date parsing in `LineFileDocs.nextDoc()`.

I found `SimpleDateFormat.parse()` showing a clear flat top in flamegraph during doc construction within indexing. 
<img width="1346" height="437" alt="indexing-flamegraph" src="https://github.com/user-attachments/assets/094fe372-679e-465d-aa22-b17604abc41b" />
But, what to callout here, reading and constructing documents from wiki line docs is not the hot path if we look at overall time spending during indexing benchmark since indexing is both an IO and CPU intensive operation. If I comment out `w.addDocuments()` and just measure the doc-reading + construction loop, the numbers look like this:

**Mac (Apple M3 Pro, 12 cores, 36 GB)**

| | docs/sec |
|---|---|
| Normal indexing (baseline) | 17,391 |
| Document construction only, no indexing — original | 548,335 |
| Document construction only, no indexing — optimized | 658,604 |

**Linux (m5.4xlarge, Intel Xeon Platinum 8175M, 16 vCPU, 64 GB)**

| | docs/sec |
|---|---|
| Normal indexing (baseline) | 10,183 |
| Document construction only, no indexing — original | 274,827 |
| Document construction only, no indexing — optimized | 391,128 |

The doc construction overhead is a small fraction of the total indexing time, roughly ~3.2% on Mac and ~3.7% on Linux. That said, according to Amdahl's Law, this is trivial, but since document construction runs sequentially with `w.addDocuments()`, the overhead is still additive, just the smaller the better. And the improvement in the construction-only path is meaningful: ~20% on Mac, ~42% on Linux.

Note that this is unlike the doc *reading* thread, which runs separately and feeds documents into the index threads, that thread takes additional CPU but doesn't affect indexing TPS.

## JMH benchmark

I wrote a standalone JMH benchmark just for data parsing, run with OpenJDK 25.0.2+10-69.

**x86_64 (m5.4xlarge)**

```
Benchmark                              Mode  Cnt    Score   Error   Units
DateParseBenchmark.dateTimeFormatter  thrpt    8    1.027 ± 0.002  ops/us
DateParseBenchmark.simpleDateFormat   thrpt    8    0.514 ± 0.009  ops/us
```

~2x throughput improvement.

**Mac (Apple M3 Pro)**

```
Benchmark                              Mode  Cnt    Score    Error   Units
DateParseBenchmark.dateTimeFormatter  thrpt    8    2.555 ±  0.143  ops/us
DateParseBenchmark.simpleDateFormat   thrpt    8    1.633 ±  0.016  ops/us
```

~1.56x throughput improvement.

## Correctness

There's no Java unit test framework in luceneutil, but I verified with a local test that asserts both parsers produce the same `msecSinceEpoch` and `timeSec` for all date string variants (uppercase, mixed-case, with/without millis). The test code is included below for reference.

<details>
<summary>JMH benchmark code</summary>

```java
import java.text.ParsePosition;
import java.text.SimpleDateFormat;
import java.time.LocalDateTime;
import java.time.format.DateTimeFormatter;
import java.time.format.DateTimeFormatterBuilder;
import java.util.Calendar;
import java.util.Date;
import java.util.Locale;
import java.util.concurrent.TimeUnit;

import org.openjdk.jmh.annotations.*;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.RunnerException;
import org.openjdk.jmh.runner.options.Options;
import org.openjdk.jmh.runner.options.OptionsBuilder;

@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MICROSECONDS)
@Warmup(iterations = 3, time = 3)
@Measurement(iterations = 4, time = 5)
@Fork(2)
@State(Scope.Thread)
public class DateParseBenchmark {

    private static final String[] DATE_STRINGS = {
            "30-APR-2012 03:25:17.000",
            "15-Jan-2008 14:02:33",
            "01-DEC-2015 23:59:59.123",
            "07-mar-2010 00:00:00",
            "22-SEP-2019 11:45:08.456",
            "03-Jul-2005 08:30:00",
            "28-FEB-2020 17:12:44.789",
            "11-nov-2017 06:55:21",
            "25-APR-2012 13:28:20.000",
            "15-JAN-2012 04:36:50.000",
            "23-APR-2012 16:29:05.000"
    };

    private int index;

    private SimpleDateFormat sdf;
    private ParsePosition sdfPos;
    private Calendar sdfCal;

    private static final DateTimeFormatter DTF = new DateTimeFormatterBuilder()
            .parseCaseInsensitive()
            .appendPattern("dd-MMM-yyyy HH:mm:ss")
            .optionalStart()
            .appendPattern(".SSS")
            .optionalEnd()
            .toFormatter(Locale.US);
    private Calendar dtfCal;

    @Setup(Level.Trial)
    public void setup() {
        sdf = new SimpleDateFormat("dd-MMM-yyyy HH:mm:ss", Locale.US);
        sdfPos = new ParsePosition(0);
        sdfCal = Calendar.getInstance();
        dtfCal = Calendar.getInstance();
        index = 0;
    }

    private String nextDateString() {
        String s = DATE_STRINGS[index];
        index = (index + 1) % DATE_STRINGS.length;
        return s;
    }

    @Benchmark
    public long simpleDateFormat() {
        String dateString = nextDateString();
        sdfPos.setIndex(0);
        Date date = sdf.parse(dateString, sdfPos);
        sdfCal.setTime(date);
        return sdfCal.getTimeInMillis();
    }

    @Benchmark
    public long dateTimeFormatter() {
        String dateString = nextDateString();
        LocalDateTime ldt = LocalDateTime.parse(dateString, DTF);
        dtfCal.set(ldt.getYear(), ldt.getMonthValue() - 1, ldt.getDayOfMonth(),
                ldt.getHour(), ldt.getMinute(), ldt.getSecond());
        dtfCal.set(Calendar.MILLISECOND, 0);
        return dtfCal.getTimeInMillis();
    }

    public static void main(String[] args) throws RunnerException {
        Options opt = new OptionsBuilder()
                .include(DateParseBenchmark.class.getSimpleName())
                .build();
        new Runner(opt).run();
    }
}
```

</details>

<details>
<summary>Unit test code</summary>

```java
import java.text.ParsePosition;
import java.text.SimpleDateFormat;
import java.time.LocalDateTime;
import java.time.format.DateTimeFormatter;
import java.time.format.DateTimeFormatterBuilder;
import java.util.Calendar;
import java.util.Date;
import java.util.Locale;

import org.junit.jupiter.api.Test;
import org.junit.jupiter.params.ParameterizedTest;
import org.junit.jupiter.params.provider.CsvSource;

import static org.junit.jupiter.api.Assertions.*;

class DateParseCorrectnessTest {

    private final SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy HH:mm:ss", Locale.US);
    private final ParsePosition sdfPos = new ParsePosition(0);

    private static final DateTimeFormatter DTF = new DateTimeFormatterBuilder()
            .parseCaseInsensitive()
            .appendPattern("dd-MMM-yyyy HH:mm:ss")
            .optionalStart()
            .appendPattern(".SSS")
            .optionalEnd()
            .toFormatter(Locale.US);

    @ParameterizedTest(name = "\"{0}\" -> timeSec={1}")
    @CsvSource({
            "30-APR-2012 03:25:17.000,      12317",
            "15-Jan-2008 14:02:33,          50553",
            "01-DEC-2015 23:59:59.123,      86399",
            "07-mar-2010 00:00:00,          0",
            "22-SEP-2019 11:45:08.456,      42308",
            "03-Jul-2005 08:30:00,          30600",
            "28-FEB-2020 17:12:44.789,      61964",
            "11-nov-2017 06:55:21,          24921",
            "25-APR-2012 13:28:20.000,      48500",
            "15-JAN-2012 04:36:50.000,      16610",
            "23-APR-2012 16:29:05.000,      59345",
    })
    void dtfMatchesSdf(String dateString, int expectedTimeSec) {
        sdfPos.setIndex(0);
        Date date = sdf.parse(dateString, sdfPos);
        assertNotNull(date, "SimpleDateFormat failed to parse: " + dateString);

        Calendar sdfCal = Calendar.getInstance();
        sdfCal.setTime(date);
        long sdfMsec = sdfCal.getTimeInMillis();
        int sdfTimeSec = sdfCal.get(Calendar.HOUR_OF_DAY) * 3600
                + sdfCal.get(Calendar.MINUTE) * 60
                + sdfCal.get(Calendar.SECOND);

        LocalDateTime ldt = LocalDateTime.parse(dateString, DTF);
        assertNotNull(ldt, "DateTimeFormatter failed to parse: " + dateString);

        Calendar dtfCal = Calendar.getInstance();
        dtfCal.set(ldt.getYear(), ldt.getMonthValue() - 1, ldt.getDayOfMonth(),
                ldt.getHour(), ldt.getMinute(), ldt.getSecond());
        dtfCal.set(Calendar.MILLISECOND, 0);
        long dtfMsec = dtfCal.getTimeInMillis();
        int dtfTimeSec = ldt.getHour() * 3600 + ldt.getMinute() * 60 + ldt.getSecond();

        assertEquals(sdfMsec, dtfMsec,
                "msecSinceEpoch mismatch for: " + dateString);
        assertEquals(sdfTimeSec, dtfTimeSec,
                "timeSec mismatch for: " + dateString);
        assertEquals(expectedTimeSec, dtfTimeSec,
                "timeSec does not match expected for: " + dateString);
    }

    @Test
    void dtfHandlesAllMonthsUppercase() {
        String[] months = {"JAN","FEB","MAR","APR","MAY","JUN","JUL","AUG","SEP","OCT","NOV","DEC"};
        for (int i = 0; i < months.length; i++) {
            String dateString = "15-" + months[i] + "-2020 12:00:00";
            LocalDateTime ldt = LocalDateTime.parse(dateString, DTF);
            assertEquals(i + 1, ldt.getMonthValue(), "Month mismatch for " + months[i]);
        }
    }

    @Test
    void dtfHandlesAllMonthsLowercase() {
        String[] months = {"jan","feb","mar","apr","may","jun","jul","aug","sep","oct","nov","dec"};
        for (int i = 0; i < months.length; i++) {
            String dateString = "15-" + months[i] + "-2020 12:00:00";
            LocalDateTime ldt = LocalDateTime.parse(dateString, DTF);
            assertEquals(i + 1, ldt.getMonthValue(), "Month mismatch for " + months[i]);
        }
    }

    @Test
    void dtfHandlesMixedCaseMonths() {
        String[] months = {"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"};
        for (int i = 0; i < months.length; i++) {
            String dateString = "15-" + months[i] + "-2020 12:00:00";
            LocalDateTime ldt = LocalDateTime.parse(dateString, DTF);
            assertEquals(i + 1, ldt.getMonthValue(), "Month mismatch for " + months[i]);
        }
    }

    @Test
    void dtfWithoutMillis() {
        String dateString = "01-Jan-2000 00:00:00";
        LocalDateTime ldt = LocalDateTime.parse(dateString, DTF);
        assertEquals(2000, ldt.getYear());
        assertEquals(1, ldt.getMonthValue());
        assertEquals(1, ldt.getDayOfMonth());
        assertEquals(0, ldt.getHour());
        assertEquals(0, ldt.getMinute());
        assertEquals(0, ldt.getSecond());
    }

    @Test
    void dtfWithMillis() {
        String dateString = "31-Dec-2099 23:59:59.999";
        LocalDateTime ldt = LocalDateTime.parse(dateString, DTF);
        assertEquals(2099, ldt.getYear());
        assertEquals(12, ldt.getMonthValue());
        assertEquals(31, ldt.getDayOfMonth());
        assertEquals(23, ldt.getHour());
        assertEquals(59, ldt.getMinute());
        assertEquals(59, ldt.getSecond());
    }
}
```

</details>