### PR TITLE
Update README about binary line docs format and mention `localconstants.py` overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ python src/python/localrun.py -source wikimediumall -iterations 20 -warmups 20
 
 For details on all the available options, use the `-h` or `--help` parameter.
 
-## Useful `localconstants.py` overrides
+### Useful `localconstants.py` overrides
 
 Any variable in `constants.py` can be overridden in `localconstants.py`. Some common ones:
 
@@ -131,9 +131,20 @@ Any variable in `constants.py` can be overridden in `localconstants.py`. Some co
 # Use multiple indexing threads (default: 1)
 INDEX_NUM_THREADS = 8
 
-# Use the binary line docs format for faster document parsing from input files.
+# Use the binary line docs format for faster document parsing.
 # Generate it with: python3 -u src/python/buildBinaryLineDocs.py <input.txt> <output.bin>
 WIKI_MEDIUM_DOCS_LINE_FILE = '%s/data/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.bin' % BASE_DIR
+
+# Override the Java version and commandline
+import os
+os.environ["JAVA_HOME"] = "/path/to/jdk"
+# add jfr and other JDK tools to PATH
+os.environ["PATH"] = os.environ["JAVA_HOME"] + "/bin:" + os.environ.get("PATH", "")
+java_home = os.environ["JAVA_HOME"]
+_java_bin = java_home + "/bin/"
+JAVA_EXE = f"{_java_bin}java"
+JAVAC_EXE = f"{_java_bin}javac"
+JAVA_COMMAND = "%s -server -Xms8g -Xmx8g --add-modules jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC" % JAVA_EXE
 ```
 
 # Running the geo benchmark

--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ python src/python/localrun.py -source wikimediumall -iterations 20 -warmups 20
 
 For details on all the available options, use the `-h` or `--help` parameter.
 
+## Useful `localconstants.py` overrides
+
+Any variable in `constants.py` can be overridden in `localconstants.py`. Some common ones:
+
+```python
+# Use multiple indexing threads (default: 1)
+INDEX_NUM_THREADS = 8
+
+# Use the binary line docs format for faster document parsing from input files.
+# Generate it with: python3 -u src/python/buildBinaryLineDocs.py <input.txt> <output.bin>
+WIKI_MEDIUM_DOCS_LINE_FILE = '%s/data/enwiki-20120502-lines-1k-fixed-utf8-with-random-label.bin' % BASE_DIR
+```
+
 # Running the geo benchmark
 
 This one is different and self-contained. Read the command-line examples at the top of src/main/perf/IndexAndSearchOpenStreetMaps.java


### PR DESCRIPTION
Follow up of #566 where I was trying to optimize document parsing in `LineFileDocs.java` during indexing, but when I checked the nightly benchmark [flame graph on blunders.io](https://blunders.io/jfr-demo/indexing-1kb-2026.04.30.00.15.31/cpu-samples-drill-down), I saw `UnicodeUtil.UTF8toUTF16` in the hot path, this method is only invoked in the binary parsing branch, not the text file parsing branch. And as it turns out, the nightly benchmarks actually use a binary of the wikipedia data, not the .txt file I download and decompress locally following the README's instruction.

<img width="1413" height="779" alt="Screenshot 2026-05-02 at 11 46 41 PM" src="https://github.com/user-attachments/assets/f36670dd-80be-40d0-bc97-a78b4b15619b" />

This PR addresses the documentation gap. I've added a section in README to let users understand they can override in `localconstants.py` as well. Besides, one important override of indexing threads is introduced, defaulting to 1 only applies to "Fixed (deterministic, 1-thread) search index" in [nightly bench indexing](https://benchmarks.mikemccandless.com/indexing.html), while "~1 KB Wikipedia English docs" and others definitely run with multi-threaded indexing.
