### PR TITLE
Fix macOS compatibility for ps_head.py and competition.py

### DIFF
--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -16,7 +16,9 @@
 #
 
 import glob
+import hashlib
 import os
+import platform
 import random
 import subprocess
 import time
@@ -238,8 +240,6 @@ class Index:
     if self.useCFS:
       name.append("cfs")
 
-    # TODO: adding facets to filename makes it too long and runs into limits on some machines
-    # Can we remove this from file name and record it in a different logfile.
     if self.facets is not None:
       name.append("facets")
       for arg in self.facets:
@@ -271,7 +271,17 @@ class Index:
         name.append("int8-quantized")
 
     name.append("nd%gM" % (self.numDocs / 1000000.0))
-    return ".".join(name)
+    full_name = ".".join(name)
+
+    # On macOS, truncate if the name is too long for the 255-byte filename limit.
+    # Keep a prefix and append a short hash of the full name so it remains unique.
+    if platform.system() == "Darwin":
+      max_len = 200
+      if len(full_name) > max_len:
+        name_hash = hashlib.sha256(full_name.encode()).hexdigest()[:12]
+        full_name = full_name[:max_len] + "." + name_hash
+
+    return full_name
 
 
 class Competitor:

--- a/src/python/ps_head.py
+++ b/src/python/ps_head.py
@@ -15,6 +15,7 @@
 
 import datetime
 import os
+import platform
 import shutil
 import subprocess
 import threading
@@ -37,7 +38,10 @@ class PSTopN:
       raise RuntimeError("could not find ps executable in this environment")
     if os.path.exists(log_file_name):
       raise RuntimeError(f"please remove log file {log_file_name} first")
-    self.cmd = f"{PS_EXE_PATH} -eo pid,%cpu,%mem,bsdtime,etime,start,args --cols=120 --sort=-%cpu | head -{top_n} >> {log_file_name} 2>&1"
+    if platform.system() == "Darwin":
+      self.cmd = f"{PS_EXE_PATH} -eo pid,%cpu,%mem,cputime,etime,lstart,args -r | head -{top_n} >> {log_file_name} 2>&1"
+    else:
+      self.cmd = f"{PS_EXE_PATH} -eo pid,%cpu,%mem,bsdtime,etime,start,args --cols=120 --sort=-%cpu | head -{top_n} >> {log_file_name} 2>&1"
     self.stop_now = False
     self.poll_interval_sec = poll_interval_sec
     self.wakey_wakey = threading.Condition()


### PR DESCRIPTION
Two small fixes to get luceneutil running on macOS without error.

`ps_head.py`: macOS ps doesn't support `--cols` or `--sort`. The fix detects Darwin and uses `-r` for CPU sort with `cputime,lstart` as column names instead. 

`competition.py`: File names can exceed the macOS 255-byte filename limit, especially with facets + vectors + custom formats. On Darwin only, names too long get truncated with a short sha256 hash appended for uniqueness.

Tested locally on macOS, both issues resolve. Linux behavior is unchanged.