### PR TITLE
Optimize intToID in LineFileDocs

### DIFF
--- a/src/main/perf/LineFileDocs.java
+++ b/src/main/perf/LineFileDocs.java
@@ -292,11 +292,16 @@ public class LineFileDocs implements Closeable {
     }
   }
 
+  private static final char[] BASE36_DIGITS = "0123456789abcdefghijklmnopqrstuvwxyz".toCharArray();
+
   public static String intToID(int id) {
     // Base 36, prefixed with 0s to be length 6 (= 2.2 B)
-    final String s = String.format("%6s", Integer.toString(id, Character.MAX_RADIX)).replace(' ', '0');
-    //System.out.println("fromint: " + id + " -> " + s);
-    return s;
+    char[] buf = new char[6];
+    for (int i = 5; i >= 0; i--) {
+      buf[i] = BASE36_DIGITS[id % 36];
+      id /= 36;
+    }
+    return new String(buf);
   }
 
   public static int idToInt(BytesRef id) {

--- a/src/main/perf/LineFileDocs.java
+++ b/src/main/perf/LineFileDocs.java
@@ -301,6 +301,7 @@ public class LineFileDocs implements Closeable {
       buf[i] = BASE36_DIGITS[id % 36];
       id /= 36;
     }
+    assert id == 0;
     return new String(buf);
   }
 


### PR DESCRIPTION
Identified in flame graph, sample [link](https://blunders.io/jfr-demo/indexing-1kb-2026.04.26.08.15.09/cpu-samples-drill-down) on blunders.io. Replace the expensive `String.format` with a simple loop that computes base-36 digits directly into a char array. This should remove Formatter/String.format overhead from the hot indexing path in LineFileDocs.nextDoc and shorten the small flat top.

<img width="1436" height="449" alt="Screenshot 2026-05-06 at 1 14 50 AM" src="https://github.com/user-attachments/assets/d6013163-a08f-40cd-bcc5-55482618f483" />
