### PR TITLE
Add binary format for GeoNames indexing benchmark

### DIFF
--- a/src/extra/perf/IndexGeoNamesBinary.java
+++ b/src/extra/perf/IndexGeoNamesBinary.java
@@ -1,0 +1,272 @@
+package perf;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoubleField;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.KeywordField;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexWriterConfig.OpenMode;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.PrintStreamInfoStream;
+
+/**
+ * Indexes GeoNames data from a pre-built binary file (created by buildBinaryGeoNames.py).
+ * This avoids the overhead of tab-splitting and string parsing at indexing time.
+ *
+ * <p>Usage:
+ * <pre>
+ *   java perf.IndexGeoNamesBinary &lt;geonames.bin&gt; &lt;indexPath&gt; &lt;numThreads&gt;
+ * </pre>
+ *
+ * <p>Binary format per chunk (little-endian):
+ * <pre>
+ *   [int32: docCount] [int32: chunkByteLength] [chunk bytes...]
+ * </pre>
+ *
+ * <p>Each doc within a chunk:
+ * <pre>
+ *   int32  geoNameID
+ *   double latitude     (NaN if missing)
+ *   double longitude    (NaN if missing)
+ *   int64  population   (-1 if missing)
+ *   int64  elevation    (Long.MIN_VALUE if missing)
+ *   int32  dem          (Integer.MIN_VALUE if missing)
+ *   int64  modifiedMsec (-1 if missing)
+ *   [int16 + bytes] x 12 string fields: name, asciiName, alternateNames,
+ *       featureClass, featureCode, countryCode, cc2, admin1..4, timezone
+ * </pre>
+ */
+public class IndexGeoNamesBinary {
+
+  private static final Field.Store STORE = Field.Store.NO;
+
+  public static void main(String[] args) throws Exception {
+    if (args.length < 3) {
+      System.err.println("Usage: IndexGeoNamesBinary <geonames.bin> <indexPath> <numThreads>");
+      System.exit(1);
+    }
+
+    String binaryFile = args[0];
+    Path indexPath = Paths.get(args[1]);
+    int numThreads = Integer.parseInt(args[2]);
+
+    Directory dir = FSDirectory.open(indexPath);
+    IndexWriterConfig iwc = new IndexWriterConfig(new StandardAnalyzer());
+    iwc.setOpenMode(OpenMode.CREATE);
+    iwc.setRAMBufferSizeMB(128);
+    iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+    iwc.setInfoStream(new PrintStreamInfoStream(System.out));
+    final IndexWriter w = new IndexWriter(dir, iwc);
+
+    final ArrayBlockingQueue<ByteBuffer> workQueue = new ArrayBlockingQueue<>(1000);
+    final AtomicBoolean done = new AtomicBoolean();
+    final AtomicInteger docsIndexed = new AtomicInteger();
+    final long startMS = System.currentTimeMillis();
+
+    // Worker threads: read chunks from queue and index documents
+    Thread[] threads = new Thread[numThreads];
+    for (int i = 0; i < numThreads; i++) {
+      threads[i] = new Thread(() -> {
+        try {
+          while (true) {
+            ByteBuffer buffer = workQueue.poll(100, TimeUnit.MILLISECONDS);
+            if (buffer == null) {
+              if (done.get()) {
+                break;
+              }
+              continue;
+            }
+
+            while (buffer.hasRemaining()) {
+              Document doc = readOneDoc(buffer);
+              w.addDocument(doc);
+
+              int count = docsIndexed.incrementAndGet();
+              if (count % 200000 == 0) {
+                long ms = System.currentTimeMillis();
+                System.out.println(count + ": " + ((ms - startMS) / 1000.0) + " sec");
+              }
+            }
+          }
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      });
+    }
+
+    for (Thread thread : threads) {
+      thread.start();
+    }
+
+    // Reader thread: read binary file and enqueue chunks
+    byte[] headerBytes = new byte[8];
+    ByteBuffer header = ByteBuffer.wrap(headerBytes).order(ByteOrder.LITTLE_ENDIAN);
+
+    try (SeekableByteChannel channel = Files.newByteChannel(Paths.get(binaryFile), StandardOpenOption.READ)) {
+      while (true) {
+        header.clear();
+        int bytesRead = channel.read(header);
+        if (bytesRead == -1) {
+          break;
+        }
+        if (bytesRead != 8) {
+          throw new RuntimeException("Expected 8 header bytes but read " + bytesRead);
+        }
+        header.flip();
+        int docCount = header.getInt();
+        int chunkLength = header.getInt();
+
+        ByteBuffer chunk = ByteBuffer.allocate(chunkLength).order(ByteOrder.LITTLE_ENDIAN);
+        bytesRead = channel.read(chunk);
+        if (bytesRead != chunkLength) {
+          throw new RuntimeException("Expected " + chunkLength + " chunk bytes but read " + bytesRead);
+        }
+        chunk.flip();
+        workQueue.put(chunk);
+      }
+    }
+
+    done.set(true);
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    w.close();
+    dir.close();
+
+    long ms = System.currentTimeMillis();
+    System.out.println("Total: " + docsIndexed.get() + " docs in " + ((ms - startMS) / 1000.0) + " sec");
+  }
+
+  /** Read one document from the chunk buffer and return a Lucene Document. */
+  private static Document readOneDoc(ByteBuffer buffer) {
+    Document doc = new Document();
+
+    // Fixed numeric fields
+    int geoNameID = buffer.getInt();
+    double latitude = buffer.getDouble();
+    double longitude = buffer.getDouble();
+    long population = buffer.getLong();
+    long elevation = buffer.getLong();
+    int dem = buffer.getInt();
+    long modifiedMsec = buffer.getLong();
+
+    // TextField fields need String (analyzer requires char sequences)
+    String name = readString(buffer);
+    String asciiName = readString(buffer);
+    String alternateNames = readString(buffer);
+
+    // StringField/KeywordField can take BytesRef directly — avoids UTF-8 -> UTF-16 -> UTF-8 round-trip
+    BytesRef featureClass = readBytesRef(buffer);
+    BytesRef featureCode = readBytesRef(buffer);
+    BytesRef countryCode = readBytesRef(buffer);
+    BytesRef cc2 = readBytesRef(buffer);
+    BytesRef admin1 = readBytesRef(buffer);
+    BytesRef admin2 = readBytesRef(buffer);
+    BytesRef admin3 = readBytesRef(buffer);
+    BytesRef admin4 = readBytesRef(buffer);
+    BytesRef timezone = readBytesRef(buffer);
+
+    // Build document
+    doc.add(new IntPoint("geoNameID", geoNameID));
+    doc.add(new TextField("name", name, STORE));
+    doc.add(new TextField("asciiName", asciiName, STORE));
+    doc.add(new TextField("alternateNames", alternateNames, STORE));
+
+    if (!Double.isNaN(latitude)) {
+      doc.add(new DoubleField("latitude", latitude, STORE));
+    }
+    if (!Double.isNaN(longitude)) {
+      doc.add(new DoubleField("longitude", longitude, STORE));
+    }
+
+    doc.add(new StringField("featureClass", featureClass, STORE));
+    doc.add(new StringField("featureCode", featureCode, STORE));
+    doc.add(new KeywordField("countryCode", countryCode, STORE));
+    doc.add(new StringField("cc2", cc2, STORE));
+    doc.add(new StringField("admin1Code", admin1, STORE));
+    doc.add(new StringField("admin2Code", admin2, STORE));
+    doc.add(new StringField("admin3Code", admin3, STORE));
+    doc.add(new StringField("admin4Code", admin4, STORE));
+
+    if (population >= 0) {
+      doc.add(new LongField("population", population, STORE));
+    }
+    if (elevation != Long.MIN_VALUE) {
+      doc.add(new LongField("elevation", elevation, STORE));
+    }
+    if (dem != Integer.MIN_VALUE) {
+      doc.add(new IntField("dem", dem, STORE));
+    }
+
+    doc.add(new KeywordField("timezone", timezone, STORE));
+
+    if (modifiedMsec >= 0) {
+      doc.add(new LongField("modified", modifiedMsec, STORE));
+    }
+
+    return doc;
+  }
+
+  /** Read a length-prefixed UTF-8 string as String (needed for TextField which requires tokenization). */
+  private static String readString(ByteBuffer buffer) {
+    int len = Short.toUnsignedInt(buffer.getShort());
+    if (len == 0) {
+      return "";
+    }
+    byte[] bytes = new byte[len];
+    buffer.get(bytes);
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  /** Read a length-prefixed UTF-8 field as BytesRef — no charset conversion needed for StringField/KeywordField. */
+  private static BytesRef readBytesRef(ByteBuffer buffer) {
+    int len = Short.toUnsignedInt(buffer.getShort());
+    if (len == 0) {
+      return new BytesRef();
+    }
+    byte[] bytes = new byte[len];
+    buffer.get(bytes);
+    return new BytesRef(bytes, 0, len);
+  }
+}

--- a/src/python/buildBinaryGeoNames.py
+++ b/src/python/buildBinaryGeoNames.py
@@ -1,0 +1,145 @@
+"""Converts GeoNames allCountries.txt (tab-separated) into a binary format
+that can be read directly by Java without string splitting.
+
+Usage::
+
+  python3 -u src/python/buildBinaryGeoNames.py <input.txt> <output.bin>
+  python3 -u src/python/buildBinaryGeoNames.py /lucenedata/geonames/allCountries.txt /lucenedata/geonames/allCountries.bin
+
+Binary format (little-endian):
+  Repeated chunks:
+    [int32: docCount] [int32: chunkByteLength] [chunk bytes...]
+
+  Each doc within a chunk:
+    [int32: geoNameID]
+    [double: latitude]    (NaN if missing)
+    [double: longitude]   (NaN if missing)
+    [int64: population]   (-1 if missing)
+    [int64: elevation]    (Long.MIN_VALUE if missing)
+    [int32: dem]          (Integer.MIN_VALUE if missing)
+    [int64: modifiedMsec] (-1 if missing)
+    [int16: nameLen] [nameBytes...]
+    [int16: asciiNameLen] [asciiNameBytes...]
+    [int16: alternateNamesLen] [alternateNamesBytes...]
+    [int16: featureClassLen] [featureClassBytes...]
+    [int16: featureCodeLen] [featureCodeBytes...]
+    [int16: countryCodeLen] [countryCodeBytes...]
+    [int16: cc2Len] [cc2Bytes...]
+    [int16: admin1Len] [admin1Bytes...]
+    [int16: admin2Len] [admin2Bytes...]
+    [int16: admin3Len] [admin3Bytes...]
+    [int16: admin4Len] [admin4Bytes...]
+    [int16: timezoneLen] [timezoneBytes...]
+"""
+
+import datetime
+import io
+import math
+import struct
+import sys
+
+CHUNK_SIZE_THRESHOLD = 64 * 1024  # flush chunk when pending bytes exceed 64KB
+
+epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+
+
+def parse_date(s):
+  """Parse yyyy-MM-dd to milliseconds since epoch (UTC), or -1 if empty/invalid."""
+  if not s.strip():
+    return -1
+  try:
+    dt = datetime.datetime.strptime(s.strip(), "%Y-%m-%d").replace(tzinfo=datetime.timezone.utc)
+    return int((dt - epoch).total_seconds() * 1000)
+  except ValueError:
+    return -1
+
+
+def encode_str(s):
+  """Encode a string field as [int16 length][utf-8 bytes]."""
+  b = s.encode("utf-8")
+  return struct.pack("<H", len(b)) + b
+
+
+def flush(pending, pending_doc_count, f_out):
+  data = pending.getvalue()
+  f_out.write(struct.pack("<ii", pending_doc_count, len(data)))
+  f_out.write(data)
+
+
+def main():
+  if len(sys.argv) != 3:
+    print(f"Usage: python3 {sys.argv[0]} <input.txt> <output.bin>")
+    sys.exit(1)
+
+  input_path = sys.argv[1]
+  output_path = sys.argv[2]
+
+  print(f"Converting GeoNames text file: {input_path}")
+  print(f"Output binary file: {output_path}")
+
+  doc_count = 0
+  pending = io.BytesIO()
+  pending_doc_count = 0
+
+  with open(input_path, encoding="utf-8") as f_in, open(output_path, "wb") as f_out:
+    for line in f_in:
+      line = line.rstrip("\n")
+      if not line:
+        continue
+
+      fields = line.split("\t")
+      if len(fields) != 19:
+        raise ValueError(f"Expected 19 tab-separated fields but got {len(fields)} at line {doc_count + 1}")
+
+      # Parse numeric fields
+      geo_name_id = int(fields[0]) if fields[0] else 0
+      latitude = float(fields[4]) if fields[4] else math.nan
+      longitude = float(fields[5]) if fields[5] else math.nan
+      population = int(fields[14]) if fields[14] else -1
+      elevation = int(fields[15]) if fields[15] else -9223372036854775808  # Long.MIN_VALUE
+      dem = int(fields[16]) if fields[16] else -2147483648  # Integer.MIN_VALUE
+      modified_msec = parse_date(fields[18])
+
+      # Write fixed-size numeric fields
+      pending.write(struct.pack("<i", geo_name_id))
+      pending.write(struct.pack("<d", latitude))
+      pending.write(struct.pack("<d", longitude))
+      pending.write(struct.pack("<q", population))
+      pending.write(struct.pack("<q", elevation))
+      pending.write(struct.pack("<i", dem))
+      pending.write(struct.pack("<q", modified_msec))
+
+      # Write variable-length string fields
+      pending.write(encode_str(fields[1]))  # name
+      pending.write(encode_str(fields[2]))  # asciiName
+      pending.write(encode_str(fields[3]))  # alternateNames
+      pending.write(encode_str(fields[6]))  # featureClass
+      pending.write(encode_str(fields[7]))  # featureCode
+      pending.write(encode_str(fields[8]))  # countryCode
+      pending.write(encode_str(fields[9]))  # cc2
+      pending.write(encode_str(fields[10]))  # admin1
+      pending.write(encode_str(fields[11]))  # admin2
+      pending.write(encode_str(fields[12]))  # admin3
+      pending.write(encode_str(fields[13]))  # admin4
+      pending.write(encode_str(fields[17]))  # timezone
+
+      pending_doc_count += 1
+      doc_count += 1
+
+      if pending.tell() > CHUNK_SIZE_THRESHOLD:
+        flush(pending, pending_doc_count, f_out)
+        pending = io.BytesIO()
+        pending_doc_count = 0
+
+      if doc_count % 1_000_000 == 0:
+        print(f"  {doc_count} docs converted...")
+
+    # Flush remaining
+    if pending_doc_count > 0:
+      flush(pending, pending_doc_count, f_out)
+
+  print(f"Done. {doc_count} docs written to {output_path}")
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
The existing `src/extra/perf/IndexGeoNames.java` reads the raw text geo names `allCountries.txt` file, every document construction has to pay the cost of string split, date format, int/long/double parsing and utf8->utf16-utf8 for string/keyword field. As a benchmarking tool that is supposed to measure indexing performance, it is a lot noise, for example, in https://github.com/apache/lucene/pull/15990, Tim wants to validate the performance gains, but as Amdahl’s law plays here, the overall end-to-end improvement gets diminished. 

This PR adds a pre-conversion step (similar to how we already do `buildBinaryLineDocs.py` for the wikipedia dataset) so that the indexing benchmark can read binary file instead of text file focusing more on what matters of indexing.

Here I introduce:

- `buildBinaryGeoNames.py`: converts geo names `allCountries.txt` into a chunked binary format. No String split, date format, int/long/double parsing are needed during runtime anymore.

- `IndexGeoNamesBinary.java`: reads the binary file into ByteBuffer chunks. Note that for non-tokenized fields (StringField/KeywordField), we pass BytesRef directly to avoid utf8->utf16-utf8 round-trip overhead.

### Benchmark
Ran `java perf.IndexGeoNamesBinary allCountries.bin /path/to/index 1` with OpenJDK 25.0.2, 1 indexing threads, no merge policy, 128MB RAM buffer. I validated that the output segments file numbers and sizes for correctness.

**Mac (Apple M3 Pro, 12 cores, 36 GB)**

| Mode | Time | End-to-end indexing speedup | Flamegraph |
|------|------|---------|------------|
| Text | 71.161 sec | | [link](https://neoremind.com/report/lucene-geo-binary/mac/geo-text-flamegraph-20260507-122545.html) |
| Binary | 55.648 sec | **~22% faster** | [link](https://neoremind.com/report/lucene-geo-binary/mac/geo-binary-flamegraph-20260507-122247.html) |

**Linux (m5.4xlarge, Intel Xeon 8175M, 16 vCPU, 64 GB)**

| Mode | Time | End-to-end indexing speedup | Flamegraph |
|------|------|---------|------------|
| Text | 182.128 sec | | [link](https://neoremind.com/report/lucene-geo-binary/linux/geo-text-flamegraph-20260507-044916.html) |
| Binary | 158.333 sec | **~13% faster** | [link](https://neoremind.com/report/lucene-geo-binary/linux/geo-binary-flamegraph-20260507-051921.html) |
