### PR TITLE
Add range facet task support; unify +facets: syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 venvPath = "."
 venv = ".venv"
 include = [ "src/python" ]
+pythonVersion = "3.12"
 # TODO: improve!
 # typeCheckingMode = "strict"
 reportUnnecessaryTypeIgnoreComment = "error"

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,5 @@ rtree==1.4.0
 ruff==0.11.6
 # type checker
 basedpyright==1.29.0
+
+nodejs-wheel-binaries==22.13.1  # pin to manylinux_2_17 wheel; update in sync with basedpyright

--- a/src/main/perf/SearchTask.java
+++ b/src/main/perf/SearchTask.java
@@ -23,8 +23,11 @@ import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.facet.FacetsCollectorManager;
+import org.apache.lucene.facet.range.DoubleRange;
+import org.apache.lucene.facet.range.DoubleRangeFacetCounts;
 import org.apache.lucene.facet.range.LongRange;
 import org.apache.lucene.facet.range.LongRangeFacetCounts;
+import org.apache.lucene.sandbox.facet.utils.RangeFacetBuilderFactory;
 import org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetCounts;
 import org.apache.lucene.facet.sortedset.SortedSetDocValuesReaderState;
 import org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts;
@@ -214,8 +217,11 @@ final class SearchTask extends Task {
           }
         }
       } else if (facetRequests.isEmpty() == false) {
-        if (state.facetsConfig == null) {
-          throw new IllegalStateException("Missing facet config, cannot run facet requests");
+        // only taxonomy/sortedset facets need facetsConfig
+        boolean needsFacetsConfig = facetRequests.stream()
+            .anyMatch(r -> r.type().equals("taxonomy") || r.type().equals("sortedset"));
+        if (needsFacetsConfig && state.facetsConfig == null) {
+          throw new IllegalStateException("Missing facet config, cannot run taxonomy/sortedset facet requests");
         }
         if (doDrillSideways) {
           // nocommit todo
@@ -224,7 +230,6 @@ final class SearchTask extends Task {
         } else {
           facetResults = new ArrayList<FacetResult>();
           // TODO: support sort, filter too!!
-          // TODO: support other facet methods
           List<TaskParser.TaskBuilder.FacetTask> postCollectionFacetTasks = new ArrayList<>();
           List<TaskParser.TaskBuilder.FacetTask> duringCollectionFacetTasks = new ArrayList<>();
           for (TaskParser.TaskBuilder.FacetTask request : facetRequests) {
@@ -245,14 +250,14 @@ final class SearchTask extends Task {
             FacetOrchestrator facetOrchestrator = new FacetOrchestrator();
             List<FacetBuilder> facetBuilders = new ArrayList<>();
             for (TaskParser.TaskBuilder.FacetTask request : duringCollectionFacetTasks) {
-              // TODO: handle other types, not just taxonomy
-              FacetBuilder facetBuilder;
-              if (request.dimension().endsWith(".taxonomy")) {
-                facetBuilder = new TaxonomyFacetBuilder(state.facetsConfig, state.taxoReader, request.dimension()).withSortByCount().withTopN(10);
-              } else {
-                // should have been prevented higher up:
-                throw new AssertionError("unknown facet method \"" + state.facetFields.get(request.dimension()) + "\"");
-              }
+              FacetBuilder facetBuilder = switch (request.type()) {
+                case "taxonomy" -> new TaxonomyFacetBuilder(
+                    state.facetsConfig, state.taxoReader, request.spec() + ".taxonomy")
+                    .withSortByCount().withTopN(10);
+                case "range" -> buildRangeFacetBuilder(request.spec());
+                default -> throw new AssertionError(
+                    "unsupported facet type for DURING_COLLECTION: " + request.type());
+              };
               facetBuilders.add(facetBuilder);
               facetOrchestrator.addBuilder(facetBuilder);
             }
@@ -275,62 +280,54 @@ final class SearchTask extends Task {
           if (postCollectionFacetTasks.isEmpty() == false) {
             if (q instanceof MatchAllDocsQuery) {
               for (TaskParser.TaskBuilder.FacetTask request : postCollectionFacetTasks) {
-                if (request.dimension().startsWith("range:")) {
-                  throw new AssertionError("fix me!");
-                } else if (request.dimension().endsWith(".taxonomy")) {
-                  // TODO: fixme to handle N facets in one indexed field!  Need to make the facet counts once per indexed field...
-                  Facets facets = new FastTaxonomyFacetCounts(state.facetsConfig.getDimConfig(request.dimension()).indexFieldName, searcher.getIndexReader(), state.taxoReader, state.facetsConfig);
-                  FacetResult res = facets.getTopChildren(10, request.dimension());
-                  facetResults.add(res);
-                } else if (request.dimension().endsWith(".sortedset")) {
-                  // TODO: fixme to handle N facets in one SSDV field!  Need to make the facet counts once per indexed field...
-                  SortedSetDocValuesReaderState ssdvFacetsState = state.getSortedSetReaderState(state.facetsConfig.getDimConfig(request.dimension()).indexFieldName);
-                  SortedSetDocValuesFacetCounts facets = new SortedSetDocValuesFacetCounts(ssdvFacetsState);
-                  facetResults.add(facets.getTopChildren(10, request.dimension()));
-                } else {
-                  // should have been prevented higher up:
-                  throw new AssertionError("unknown facet method \"" + state.facetFields.get(request.dimension()) + "\"");
+                switch (request.type()) {
+                  case "taxonomy" -> {
+                    // TODO: fixme to handle N facets in one indexed field!
+                    String dim = request.spec() + ".taxonomy";
+                    Facets facets = new FastTaxonomyFacetCounts(
+                        state.facetsConfig.getDimConfig(dim).indexFieldName,
+                        searcher.getIndexReader(), state.taxoReader, state.facetsConfig);
+                    facetResults.add(facets.getTopChildren(10, dim));
+                  }
+                  case "sortedset" -> {
+                    // TODO: fixme to handle N facets in one SSDV field!
+                    String dim = request.spec() + ".sortedset";
+                    SortedSetDocValuesReaderState ssdvState = state.getSortedSetReaderState(
+                        state.facetsConfig.getDimConfig(dim).indexFieldName);
+                    SortedSetDocValuesFacetCounts facets = new SortedSetDocValuesFacetCounts(ssdvState);
+                    facetResults.add(facets.getTopChildren(10, dim));
+                  }
+                  case "range" -> throw new AssertionError(
+                      "range facets with MatchAllDocsQuery in POST_COLLECTION not yet supported");
+                  default -> throw new AssertionError("unknown facet type: " + request.type());
                 }
               }
               getFacetResultsMsec = (System.nanoTime() - t0) / 1000000.0;
             } else {
-              FacetsCollectorManager.FacetsResult fr = FacetsCollectorManager.search(searcher, q, 10, new FacetsCollectorManager());
+              FacetsCollectorManager.FacetsResult fr = FacetsCollectorManager.search(
+                  searcher, q, 10, new FacetsCollectorManager());
               hits = fr.topDocs();
               FacetsCollector fc = fr.facetsCollector();
-              for (TaskParser.TaskBuilder.FacetTask facetRequest : postCollectionFacetTasks) {
-                String request = facetRequest.dimension();
-                if (request.startsWith("range:")) {
-                  int i = request.indexOf(':', 6);
-                  if (i == -1) {
-                    throw new IllegalArgumentException("range facets request \"" + request + "\" is missing field; should be range:field:0-10,10-20");
+              for (TaskParser.TaskBuilder.FacetTask request : postCollectionFacetTasks) {
+                switch (request.type()) {
+                  case "taxonomy" -> {
+                    // TODO: fixme to handle N facets in one indexed field!
+                    String dim = request.spec() + ".taxonomy";
+                    Facets facets = new FastTaxonomyFacetCounts(
+                        state.facetsConfig.getDimConfig(dim).indexFieldName,
+                        state.taxoReader, state.facetsConfig, fc);
+                    facetResults.add(facets.getTopChildren(10, dim));
                   }
-                  String field = request.substring(6, i);
-                  String[] rangeStrings = request.substring(i + 1, request.length()).split(",");
-                  LongRange[] ranges = new LongRange[rangeStrings.length];
-                  for (int rangeIDX = 0; rangeIDX < ranges.length; rangeIDX++) {
-                    String rangeString = rangeStrings[rangeIDX];
-                    int j = rangeString.indexOf('-');
-                    if (j == -1) {
-                      throw new IllegalArgumentException("range facets request should be X-Y; got: " + rangeString);
-                    }
-                    long start = Long.parseLong(rangeString.substring(0, j));
-                    long end = Long.parseLong(rangeString.substring(j + 1));
-                    ranges[rangeIDX] = new LongRange(rangeString, start, true, end, true);
+                  case "sortedset" -> {
+                    // TODO: fixme to handle N facets in one SSDV field!
+                    String dim = request.spec() + ".sortedset";
+                    SortedSetDocValuesReaderState ssdvState = state.getSortedSetReaderState(
+                        state.facetsConfig.getDimConfig(dim).indexFieldName);
+                    SortedSetDocValuesFacetCounts facets = new SortedSetDocValuesFacetCounts(ssdvState, fc);
+                    facetResults.add(facets.getTopChildren(10, dim));
                   }
-                  LongRangeFacetCounts facets = new LongRangeFacetCounts(field, fc, ranges);
-                  facetResults.add(facets.getTopChildren(ranges.length, field));
-                } else if (request.endsWith(".taxonomy")) {
-                  // TODO: fixme to handle N facets in one indexed field!  Need to make the facet counts once per indexed field...
-                  Facets facets = new FastTaxonomyFacetCounts(state.facetsConfig.getDimConfig(request).indexFieldName, state.taxoReader, state.facetsConfig, fc);
-                  facetResults.add(facets.getTopChildren(10, request));
-                } else if (request.endsWith(".sortedset")) {
-                  // TODO: fixme to handle N facets in one SSDV field!  Need to make the facet counts once per indexed field...
-                  SortedSetDocValuesReaderState ssdvFacetsState = state.getSortedSetReaderState(state.facetsConfig.getDimConfig(request).indexFieldName);
-                  SortedSetDocValuesFacetCounts facets = new SortedSetDocValuesFacetCounts(ssdvFacetsState, fc);
-                  facetResults.add(facets.getTopChildren(10, request));
-                } else {
-                  // should have been prevented higher up:
-                  throw new AssertionError("unknown facet method \"" + state.facetFields.get(request) + "\"");
+                  case "range" -> facetResults.add(buildRangeFacetResult(request.spec(), fc));
+                  default -> throw new AssertionError("unknown facet type: " + request.type());
                 }
               }
             }
@@ -447,6 +444,84 @@ final class SearchTask extends Task {
   }
 
   public int totHiliteHash;
+
+  /** Parse range spec "long|field|r1min-r1max,..." or "double|field|..." and build DURING_COLLECTION FacetBuilder. */
+  private FacetBuilder buildRangeFacetBuilder(String spec) throws IOException {
+    String[] parts = spec.split("\\|", 3);
+    if (parts.length != 3) {
+      throw new IllegalArgumentException("range facet spec must be numericType|field|ranges, got: " + spec);
+    }
+    String numType  = parts[0]; // "long" or "double"
+    String field    = parts[1];
+    String rangeStr = parts[2];
+    if (numType.equals("long")) {
+      LongRange[] ranges = parseLongRanges(rangeStr);
+      return RangeFacetBuilderFactory.forLongRanges(field, ranges);
+    } else if (numType.equals("double")) {
+      DoubleRange[] ranges = parseDoubleRanges(rangeStr);
+      return RangeFacetBuilderFactory.forDoubleRanges(field, ranges);
+    } else {
+      throw new IllegalArgumentException("unknown numeric type \"" + numType + "\"; expected \"long\" or \"double\"");
+    }
+  }
+
+  /** Build POST_COLLECTION FacetResult for a range spec using a pre-collected FacetsCollector. */
+  private FacetResult buildRangeFacetResult(String spec, FacetsCollector fc) throws IOException {
+    String[] parts = spec.split("\\|", 3);
+    if (parts.length != 3) {
+      throw new IllegalArgumentException("range facet spec must be numericType|field|ranges, got: " + spec);
+    }
+    String numType  = parts[0];
+    String field    = parts[1];
+    String rangeStr = parts[2];
+    if (numType.equals("long")) {
+      LongRange[] ranges = parseLongRanges(rangeStr);
+      LongRangeFacetCounts facets = new LongRangeFacetCounts(field, fc, ranges);
+      return facets.getTopChildren(ranges.length, field);
+    } else if (numType.equals("double")) {
+      DoubleRange[] ranges = parseDoubleRanges(rangeStr);
+      DoubleRangeFacetCounts facets = new DoubleRangeFacetCounts(field, fc, ranges);
+      return facets.getTopChildren(ranges.length, field);
+    } else {
+      throw new IllegalArgumentException("unknown numeric type \"" + numType + "\"; expected \"long\" or \"double\"");
+    }
+  }
+
+  /** Parse "r1min-r1max,r2min-r2max,..." into LongRange[]. */
+  private static LongRange[] parseLongRanges(String rangeStr) {
+    String[] tokens = rangeStr.split(",");
+    LongRange[] ranges = new LongRange[tokens.length];
+    for (int idx = 0; idx < tokens.length; idx++) {
+      String tok = tokens[idx];
+      int dash = tok.indexOf('-', tok.charAt(0) == '-' ? 1 : 0); // handle negative start
+      if (dash == -1) {
+        throw new IllegalArgumentException("range must be min-max, got: " + tok);
+      }
+      long min = Long.parseLong(tok.substring(0, dash));
+      long max = Long.parseLong(tok.substring(dash + 1));
+      ranges[idx] = new LongRange(tok, min, true, max, false); // half-open [min, max)
+    }
+    return ranges;
+  }
+
+  /** Parse "r1min-r1max,r2min-r2max,..." into DoubleRange[]. */
+  private static DoubleRange[] parseDoubleRanges(String rangeStr) {
+    String[] tokens = rangeStr.split(",");
+    DoubleRange[] ranges = new DoubleRange[tokens.length];
+    for (int idx = 0; idx < tokens.length; idx++) {
+      String tok = tokens[idx];
+      // find the '-' that separates min from max (skip a leading minus sign if present)
+      int dash = tok.indexOf('-', tok.charAt(0) == '-' ? 1 : 0);
+      if (dash == -1) {
+        throw new IllegalArgumentException("range must be min-max, got: " + tok);
+      }
+      double min = Double.parseDouble(tok.substring(0, dash));
+      double max = Double.parseDouble(tok.substring(dash + 1));
+      ranges[idx] = new DoubleRange(tok, min, true, max, false); // half-open [min, max)
+    }
+    return ranges;
+  }
+
 
   private void hilite(int docID, IndexState indexState, IndexSearcher searcher) throws IOException {
     //System.out.println("  title=" + searcher.doc(docID).get("titleTokenized"));

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -417,73 +417,86 @@ class TaskParser implements Closeable {
 
     List<FacetTask> parseFacets() {
       List<FacetTask> facets = new ArrayList<>();
-      Map<String, TestContext.FacetMode> prefixTypes = Map.of(" +facets:", TestContext.FacetMode.UNDEFINED,
-              " +post_collection_facets:", TestContext.FacetMode.POST_COLLECTION,
-              " +during_collection_facets:", TestContext.FacetMode.DURING_COLLECTION
-      );
+      // Unified syntax: +facets:TYPE:SPEC[:mode]
+      // TYPE: taxonomy | sortedset | range
+      // SPEC: dim name (taxonomy/sortedset) or "long|field|r1min-r1max,..." / "double|field|..." (range)
+      // mode (optional): during | post  (absent = UNDEFINED, inherits testContext)
+      final String PREFIX = " +facets:";
       while (true) {
-        boolean found = false;
-        for (Map.Entry<String, TestContext.FacetMode> ent : prefixTypes.entrySet()) {
-          String prefix = ent.getKey();
-          TestContext.FacetMode facetMode = ent.getValue();
-          int prefixLength = prefix.length();
-          int i = text.indexOf(prefix);
-          if (i == -1) {
-            continue;
-          }
-          found = true;
-          if (testContext.facetMode != TestContext.FacetMode.UNDEFINED) {
-                  if (facetMode != TestContext.FacetMode.UNDEFINED &&
-                  facetMode != testContext.facetMode) {
-                    throw new IllegalArgumentException("Task and test context define different facet modes. Task: "
-                            + facetMode + ", test context: " + testContext.facetMode);
-                  }
-                  facetMode = testContext.facetMode;
-          }
-          int j = text.indexOf(" ", i + 1);
-          if (j == -1) {
-            j = text.length();
-          }
-          String facetDim = text.substring(i + prefixLength, j);
-          int k = facetDim.indexOf(".");
-          if (k == -1) {
-            throw new IllegalArgumentException("+facet:x should have format Dim.(taxonomy|sortedset); got: " + facetDim);
-          }
-          String s = facetDim.substring(0, k);
-          if (state.facetFields.containsKey(s) == false) {
-            throw new IllegalArgumentException("facetDim " + s + " was not indexed");
-          }
-          facets.add(new FacetTask(facetDim, facetMode));
-          text = text.substring(0, i) + text.substring(j);
-        }
-        if (!found) {
+        int i = text.indexOf(PREFIX);
+        if (i == -1) {
           break;
         }
+        int j = text.indexOf(" ", i + 1);
+        if (j == -1) {
+          j = text.length();
+        }
+        // split on ":" into at most 3 parts: [type, spec, optional_mode]
+        String token = text.substring(i + PREFIX.length(), j);
+        String[] parts = token.split(":", 3);
+        if (parts.length < 2) {
+          throw new IllegalArgumentException("+facets: requires at least TYPE:SPEC, got: " + token);
+        }
+        String type = parts[0];
+        String spec = parts[1];
+        TestContext.FacetMode facetMode;
+        if (parts.length == 3) {
+          facetMode = switch (parts[2]) {
+            case "during" -> TestContext.FacetMode.DURING_COLLECTION;
+            case "post"   -> TestContext.FacetMode.POST_COLLECTION;
+            default -> throw new IllegalArgumentException(
+                "unknown facet mode \"" + parts[2] + "\"; expected \"during\" or \"post\"");
+          };
+        } else {
+          facetMode = TestContext.FacetMode.UNDEFINED;
+        }
+        // testContext override (task-level mode must match testContext when both are explicit)
+        if (testContext.facetMode != TestContext.FacetMode.UNDEFINED) {
+          if (facetMode != TestContext.FacetMode.UNDEFINED && facetMode != testContext.facetMode) {
+            throw new IllegalArgumentException("Task and test context define different facet modes. Task: "
+                + facetMode + ", test context: " + testContext.facetMode);
+          }
+          facetMode = testContext.facetMode;
+        }
+        // validate known type and that dim is indexed (range fields validated at search time)
+        switch (type) {
+          case "taxonomy", "sortedset" -> {
+            if (state.facetFields.containsKey(spec) == false) {
+              throw new IllegalArgumentException("facetDim " + spec + " was not indexed");
+            }
+          }
+          case "range" -> {
+            // spec format: "long|field|ranges" or "double|field|ranges" -- validated at search time
+          }
+          default -> throw new IllegalArgumentException(
+              "unknown facet type \"" + type + "\"; expected taxonomy, sortedset, or range");
+        }
+        facets.add(new FacetTask(type, spec, facetMode));
+        text = text.substring(0, i) + text.substring(j);
       }
       return facets;
     }
 
-    record FacetTask(String dimension, TestContext.FacetMode facetMode){
+    record FacetTask(String type, String spec, TestContext.FacetMode facetMode) {
       @Override
       public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof FacetTask facetTask)) return false;
-        return Objects.equals(facetMode, facetTask.facetMode) && Objects.equals(dimension, facetTask.dimension);
+        if (!(o instanceof FacetTask other)) return false;
+        return Objects.equals(type, other.type)
+            && Objects.equals(spec, other.spec)
+            && Objects.equals(facetMode, other.facetMode);
       }
 
       @Override
       public int hashCode() {
-        return Objects.hash(dimension, facetMode);
+        return Objects.hash(type, spec, facetMode);
       }
 
       @Override
       public String toString() {
-        // facetMode is ignored so that when results are parsed to python's
-        // SearchTask facets_request param was the same for all modes
-        // and results for different modes were compared in benchUtil.compareHits
-        return "FacetTask{" +
-                "dimension='" + dimension + '\'' +
-                '}';
+        // facetMode intentionally omitted so Python result comparison works
+        // across different modes for the same task (see benchUtil.compareHits)
+        return "FacetTask{type='" + type + "', spec='" + spec + "'}";
       }
     }
 

--- a/src/python/constants.py
+++ b/src/python/constants.py
@@ -133,7 +133,7 @@ if "JAVAC_EXE" not in globals():
 if "JAVA_COMMAND" not in globals():
   JAVA_COMMAND = "%s -server -Xms2g -Xmx2g --add-modules jdk.incubator.vector -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC" % JAVA_EXE
 else:
-  print("use java command %s" % JAVA_COMMAND)  # pyright: ignore[reportUnboundVariable] # TODO: fix how variables are managed here
+  print("use java command %s" % JAVA_COMMAND)  # pyright: ignore[reportUndefinedVariable] # TODO: fix how variables are managed here
 
 
 def check_java_home():

--- a/tasks/titlebdv.tasks
+++ b/tasks/titlebdv.tasks
@@ -10225,9 +10225,9 @@ Respell: titlebdvsort//20000
 Fuzzy1: titlebdvsort//2010a~1
 Fuzzy2: titlebdvsort//2010a~2
 Respell: titlebdvsort//2010a
-BrowseDateTaxoFacets: titlebdvsort//*:* +facets:Date.taxonomy
-BrowseMonthTaxoFacets: titlebdvsort//*:* +facets:Month.taxonomy
-BrowseDayOfYearTaxoFacets: titlebdvsort//*:* +facets:DayOfYear.taxonomy
-BrowseDateSSDVFacets: titlebdvsort//*:* +facets:Date.sortedset
-BrowseMonthSSDVFacets: titlebdvsort//*:* +facets:Month.sortedset
-BrowseDayOfYearSSDVFacets: titlebdvsort//*:* +facets:DayOfYear.sortedset
+BrowseDateTaxoFacets: titlebdvsort//*:* +facets:taxonomy:Date
+BrowseMonthTaxoFacets: titlebdvsort//*:* +facets:taxonomy:Month
+BrowseDayOfYearTaxoFacets: titlebdvsort//*:* +facets:taxonomy:DayOfYear
+BrowseDateSSDVFacets: titlebdvsort//*:* +facets:sortedset:Date
+BrowseMonthSSDVFacets: titlebdvsort//*:* +facets:sortedset:Month
+BrowseDayOfYearSSDVFacets: titlebdvsort//*:* +facets:sortedset:DayOfYear

--- a/tasks/wikimedium.10M.facets.tasks
+++ b/tasks/wikimedium.10M.facets.tasks
@@ -1,2004 +1,4016 @@
-BrowseDateTaxoFacets: *:* +facets:Date.taxonomy
-BrowseMonthTaxoFacets: *:* +facets:Month.taxonomy
-BrowseDayOfYearTaxoFacets: *:* +facets:DayOfYear.taxonomy
-BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
-MedTermDayTaxoFacets: most +facets:DayOfYear.taxonomy # freq=819634
-MedTermDayTaxoFacets: up +facets:DayOfYear.taxonomy # freq=818546
-MedTermDayTaxoFacets: world +facets:DayOfYear.taxonomy # freq=808563
-MedTermDayTaxoFacets: 2007 +facets:DayOfYear.taxonomy # freq=801586
-MedTermDayTaxoFacets: during +facets:DayOfYear.taxonomy # freq=798114
-MedTermDayTaxoFacets: people +facets:DayOfYear.taxonomy # freq=790960
-MedTermDayTaxoFacets: years +facets:DayOfYear.taxonomy # freq=789628
-MedTermDayTaxoFacets: such +facets:DayOfYear.taxonomy # freq=787877
-MedTermDayTaxoFacets: 12 +facets:DayOfYear.taxonomy # freq=774572
-MedTermDayTaxoFacets: over +facets:DayOfYear.taxonomy # freq=774312
-MedTermDayTaxoFacets: can +facets:DayOfYear.taxonomy # freq=765163
-MedTermDayTaxoFacets: references +facets:DayOfYear.taxonomy # freq=760306
-MedTermDayTaxoFacets: city +facets:DayOfYear.taxonomy # freq=760272
-MedTermDayTaxoFacets: 6 +facets:DayOfYear.taxonomy # freq=759234
-MedTermDayTaxoFacets: american +facets:DayOfYear.taxonomy # freq=758337
-MedTermDayTaxoFacets: news +facets:DayOfYear.taxonomy # freq=756063
-MedTermDayTaxoFacets: history +facets:DayOfYear.taxonomy # freq=755471
-MedTermDayTaxoFacets: 0 +facets:DayOfYear.taxonomy # freq=754451
-MedTermDayTaxoFacets: made +facets:DayOfYear.taxonomy # freq=742313
-MedTermDayTaxoFacets: out +facets:DayOfYear.taxonomy # freq=733775
-MedTermDayTaxoFacets: 11 +facets:DayOfYear.taxonomy # freq=730505
-MedTermDayTaxoFacets: used +facets:DayOfYear.taxonomy # freq=708455
-MedTermDayTaxoFacets: links +facets:DayOfYear.taxonomy # freq=703350
-MedTermDayTaxoFacets: state +facets:DayOfYear.taxonomy # freq=702598
-MedTermDayTaxoFacets: many +facets:DayOfYear.taxonomy # freq=694439
-MedTermDayTaxoFacets: would +facets:DayOfYear.taxonomy # freq=690480
-MedTermDayTaxoFacets: page +facets:DayOfYear.taxonomy # freq=681036
-MedTermDayTaxoFacets: national +facets:DayOfYear.taxonomy # freq=677281
-MedTermDayTaxoFacets: than +facets:DayOfYear.taxonomy # freq=676864
-MedTermDayTaxoFacets: thumb +facets:DayOfYear.taxonomy # freq=672667
-MedTermDayTaxoFacets: 7 +facets:DayOfYear.taxonomy # freq=660220
-MedTermDayTaxoFacets: place +facets:DayOfYear.taxonomy # freq=654158
-MedTermDayTaxoFacets: de +facets:DayOfYear.taxonomy # freq=652242
-MedTermDayTaxoFacets: if +facets:DayOfYear.taxonomy # freq=640551
-MedTermDayTaxoFacets: university +facets:DayOfYear.taxonomy # freq=636959
-MedTermDayTaxoFacets: 8 +facets:DayOfYear.taxonomy # freq=635822
-MedTermDayTaxoFacets: external +facets:DayOfYear.taxonomy # freq=635450
-MedTermDayTaxoFacets: between +facets:DayOfYear.taxonomy # freq=630650
-MedTermDayTaxoFacets: where +facets:DayOfYear.taxonomy # freq=630647
-MedTermDayTaxoFacets: right +facets:DayOfYear.taxonomy # freq=630423
-MedTermDayTaxoFacets: 20 +facets:DayOfYear.taxonomy # freq=624967
-MedTermDayTaxoFacets: under +facets:DayOfYear.taxonomy # freq=623872
-MedTermDayTaxoFacets: these +facets:DayOfYear.taxonomy # freq=623267
-MedTermDayTaxoFacets: march +facets:DayOfYear.taxonomy # freq=620393
-MedTermDayTaxoFacets: br +facets:DayOfYear.taxonomy # freq=617824
-MedTermDayTaxoFacets: book +facets:DayOfYear.taxonomy # freq=617297
-MedTermDayTaxoFacets: p +facets:DayOfYear.taxonomy # freq=616159
-MedTermDayTaxoFacets: article +facets:DayOfYear.taxonomy # freq=610650
-MedTermDayTaxoFacets: known +facets:DayOfYear.taxonomy # freq=607158
-MedTermDayTaxoFacets: then +facets:DayOfYear.taxonomy # freq=606159
-MedTermDayTaxoFacets: style +facets:DayOfYear.taxonomy # freq=606000
-MedTermDayTaxoFacets: later +facets:DayOfYear.taxonomy # freq=604921
-MedTermDayTaxoFacets: three +facets:DayOfYear.taxonomy # freq=598349
-MedTermDayTaxoFacets: use +facets:DayOfYear.taxonomy # freq=597053
-MedTermDayTaxoFacets: category +facets:DayOfYear.taxonomy # freq=595446
-MedTermDayTaxoFacets: john +facets:DayOfYear.taxonomy # freq=594461
-MedTermDayTaxoFacets: part +facets:DayOfYear.taxonomy # freq=594224
-MedTermDayTaxoFacets: left +facets:DayOfYear.taxonomy # freq=593967
-MedTermDayTaxoFacets: 2004 +facets:DayOfYear.taxonomy # freq=593934
-MedTermDayTaxoFacets: 15 +facets:DayOfYear.taxonomy # freq=592407
-MedTermDayTaxoFacets: december +facets:DayOfYear.taxonomy # freq=590171
-MedTermDayTaxoFacets: april +facets:DayOfYear.taxonomy # freq=587542
-MedTermDayTaxoFacets: list +facets:DayOfYear.taxonomy # freq=585922
-MedTermDayTaxoFacets: 18 +facets:DayOfYear.taxonomy # freq=585631
-MedTermDayTaxoFacets: small +facets:DayOfYear.taxonomy # freq=581643
-MedTermDayTaxoFacets: january +facets:DayOfYear.taxonomy # freq=581309
-MedTermDayTaxoFacets: before +facets:DayOfYear.taxonomy # freq=580481
-MedTermDayTaxoFacets: being +facets:DayOfYear.taxonomy # freq=580185
-MedTermDayTaxoFacets: well +facets:DayOfYear.taxonomy # freq=580011
-MedTermDayTaxoFacets: id +facets:DayOfYear.taxonomy # freq=579566
-MedTermDayTaxoFacets: while +facets:DayOfYear.taxonomy # freq=579117
-MedTermDayTaxoFacets: 9 +facets:DayOfYear.taxonomy # freq=574434
-MedTermDayTaxoFacets: death +facets:DayOfYear.taxonomy # freq=568895
-MedTermDayTaxoFacets: author +facets:DayOfYear.taxonomy # freq=567768
-MedTermDayTaxoFacets: however +facets:DayOfYear.taxonomy # freq=566494
-MedTermDayTaxoFacets: october +facets:DayOfYear.taxonomy # freq=566229
-MedTermDayTaxoFacets: north +facets:DayOfYear.taxonomy # freq=564195
-MedTermDayTaxoFacets: so +facets:DayOfYear.taxonomy # freq=562598
-MedTermDayTaxoFacets: reflist +facets:DayOfYear.taxonomy # freq=561253
-MedTermDayTaxoFacets: south +facets:DayOfYear.taxonomy # freq=560468
-MedTermDayTaxoFacets: area +facets:DayOfYear.taxonomy # freq=559023
-MedTermDayTaxoFacets: class +facets:DayOfYear.taxonomy # freq=556838
-MedTermDayTaxoFacets: september +facets:DayOfYear.taxonomy # freq=553409
-MedTermDayTaxoFacets: war +facets:DayOfYear.taxonomy # freq=547417
-MedTermDayTaxoFacets: image +facets:DayOfYear.taxonomy # freq=541747
-MedTermDayTaxoFacets: 16 +facets:DayOfYear.taxonomy # freq=540539
-MedTermDayTaxoFacets: both +facets:DayOfYear.taxonomy # freq=534900
-MedTermDayTaxoFacets: 14 +facets:DayOfYear.taxonomy # freq=534005
-MedTermDayTaxoFacets: 13 +facets:DayOfYear.taxonomy # freq=530419
-MedTermDayTaxoFacets: july +facets:DayOfYear.taxonomy # freq=529655
-MedTermDayTaxoFacets: august +facets:DayOfYear.taxonomy # freq=527806
-MedTermDayTaxoFacets: november +facets:DayOfYear.taxonomy # freq=527131
-MedTermDayTaxoFacets: end +facets:DayOfYear.taxonomy # freq=526636
-MedTermDayTaxoFacets: february +facets:DayOfYear.taxonomy # freq=524886
-MedTermDayTaxoFacets: infobox +facets:DayOfYear.taxonomy # freq=524810
-MedTermDayTaxoFacets: june +facets:DayOfYear.taxonomy # freq=522519
-MedTermDayTaxoFacets: series +facets:DayOfYear.taxonomy # freq=521861
-MedTermDayTaxoFacets: york +facets:DayOfYear.taxonomy # freq=521383
-MedTermDayTaxoFacets: including +facets:DayOfYear.taxonomy # freq=521324
-MedTermDayTaxoFacets: county +facets:DayOfYear.taxonomy # freq=521126
-MedTermDayTaxoFacets: them +facets:DayOfYear.taxonomy # freq=520298
-MedTermDayTaxoFacets: her +facets:DayOfYear.taxonomy # freq=518717
-MedTermDayTaxoFacets: through +facets:DayOfYear.taxonomy # freq=514966
-MedTermDayTaxoFacets: do +facets:DayOfYear.taxonomy # freq=511178
-MedTermDayTaxoFacets: 17 +facets:DayOfYear.taxonomy # freq=507396
-MedTermDayTaxoFacets: him +facets:DayOfYear.taxonomy # freq=507350
-MedTermDayTaxoFacets: nbsp +facets:DayOfYear.taxonomy # freq=506054
-MedTermDayTaxoFacets: second +facets:DayOfYear.taxonomy # freq=505575
-MedTermDayTaxoFacets: 22 +facets:DayOfYear.taxonomy # freq=502778
-MedTermDayTaxoFacets: html +facets:DayOfYear.taxonomy # freq=500198
-MedTermDayTaxoFacets: 2000 +facets:DayOfYear.taxonomy # freq=499639
-MedTermDayTaxoFacets: 25 +facets:DayOfYear.taxonomy # freq=491957
-MedTermDayTaxoFacets: location +facets:DayOfYear.taxonomy # freq=489791
-MedTermDayTaxoFacets: will +facets:DayOfYear.taxonomy # freq=489711
-MedTermDayTaxoFacets: center +facets:DayOfYear.taxonomy # freq=489673
-MedTermDayTaxoFacets: 30 +facets:DayOfYear.taxonomy # freq=488930
-MedTermDayTaxoFacets: since +facets:DayOfYear.taxonomy # freq=485325
-MedTermDayTaxoFacets: 19 +facets:DayOfYear.taxonomy # freq=484187
-MedTermDayTaxoFacets: now +facets:DayOfYear.taxonomy # freq=484114
-MedTermDayTaxoFacets: any +facets:DayOfYear.taxonomy # freq=483514
-MedTermDayTaxoFacets: early +facets:DayOfYear.taxonomy # freq=482793
-MedTermDayTaxoFacets: 21 +facets:DayOfYear.taxonomy # freq=482314
-MedTermDayTaxoFacets: high +facets:DayOfYear.taxonomy # freq=482152
-MedTermDayTaxoFacets: like +facets:DayOfYear.taxonomy # freq=479390
-MedTermDayTaxoFacets: life +facets:DayOfYear.taxonomy # freq=477007
-MedTermDayTaxoFacets: general +facets:DayOfYear.taxonomy # freq=476690
-MedTermDayTaxoFacets: music +facets:DayOfYear.taxonomy # freq=473240
-MedTermDayTaxoFacets: number +facets:DayOfYear.taxonomy # freq=473154
-MedTermDayTaxoFacets: 24 +facets:DayOfYear.taxonomy # freq=470708
-MedTermDayTaxoFacets: main +facets:DayOfYear.taxonomy # freq=470429
-MedTermDayTaxoFacets: isbn +facets:DayOfYear.taxonomy # freq=467574
-MedTermDayTaxoFacets: pages +facets:DayOfYear.taxonomy # freq=466290
-MedTermDayTaxoFacets: became +facets:DayOfYear.taxonomy # freq=465594
-MedTermDayTaxoFacets: short +facets:DayOfYear.taxonomy # freq=465205
-MedTermDayTaxoFacets: school +facets:DayOfYear.taxonomy # freq=462166
-MedTermDayTaxoFacets: you +facets:DayOfYear.taxonomy # freq=461587
-MedTermDayTaxoFacets: 23 +facets:DayOfYear.taxonomy # freq=457097
-MedTermDayTaxoFacets: 2003 +facets:DayOfYear.taxonomy # freq=456990
-MedTermDayTaxoFacets: called +facets:DayOfYear.taxonomy # freq=454580
-MedTermDayTaxoFacets: utc +facets:DayOfYear.taxonomy # freq=450225
-MedTermDayTaxoFacets: n +facets:DayOfYear.taxonomy # freq=449994
-MedTermDayTaxoFacets: c +facets:DayOfYear.taxonomy # freq=444247
-MedTermDayTaxoFacets: group +facets:DayOfYear.taxonomy # freq=442503
-MedTermDayTaxoFacets: m +facets:DayOfYear.taxonomy # freq=441232
-MedTermDayTaxoFacets: several +facets:DayOfYear.taxonomy # freq=436129
-MedTermDayTaxoFacets: website +facets:DayOfYear.taxonomy # freq=435941
-MedTermDayTaxoFacets: film +facets:DayOfYear.taxonomy # freq=432758
-MedTermDayTaxoFacets: west +facets:DayOfYear.taxonomy # freq=431006
-MedTermDayTaxoFacets: u.s +facets:DayOfYear.taxonomy # freq=428534
-MedTermDayTaxoFacets: she +facets:DayOfYear.taxonomy # freq=426267
-MedTermDayTaxoFacets: until +facets:DayOfYear.taxonomy # freq=425389
-MedTermDayTaxoFacets: birth +facets:DayOfYear.taxonomy # freq=425138
-MedTermDayTaxoFacets: us +facets:DayOfYear.taxonomy # freq=421210
-MedTermDayTaxoFacets: same +facets:DayOfYear.taxonomy # freq=420741
-MedTermDayTaxoFacets: country +facets:DayOfYear.taxonomy # freq=420052
-MedTermDayTaxoFacets: international +facets:DayOfYear.taxonomy # freq=418261
-MedTermDayTaxoFacets: british +facets:DayOfYear.taxonomy # freq=417307
-MedTermDayTaxoFacets: language +facets:DayOfYear.taxonomy # freq=416771
-MedTermDayTaxoFacets: following +facets:DayOfYear.taxonomy # freq=416515
-MedTermDayTaxoFacets: because +facets:DayOfYear.taxonomy # freq=413003
-MedTermDayTaxoFacets: system +facets:DayOfYear.taxonomy # freq=412862
-MedTermDayTaxoFacets: english +facets:DayOfYear.taxonomy # freq=412061
-MedTermDayTaxoFacets: 2001 +facets:DayOfYear.taxonomy # freq=410364
-MedTermDayTaxoFacets: e +facets:DayOfYear.taxonomy # freq=408741
-MedTermDayTaxoFacets: times +facets:DayOfYear.taxonomy # freq=407155
-MedTermDayTaxoFacets: 2002 +facets:DayOfYear.taxonomy # freq=406953
-MedTermDayTaxoFacets: names +facets:DayOfYear.taxonomy # freq=404796
-MedTermDayTaxoFacets: w +facets:DayOfYear.taxonomy # freq=404764
-MedTermDayTaxoFacets: day +facets:DayOfYear.taxonomy # freq=402096
-MedTermDayTaxoFacets: should +facets:DayOfYear.taxonomy # freq=401379
-MedTermDayTaxoFacets: against +facets:DayOfYear.taxonomy # freq=399228
-MedTermDayTaxoFacets: press +facets:DayOfYear.taxonomy # freq=398988
-MedTermDayTaxoFacets: based +facets:DayOfYear.taxonomy # freq=398415
-MedTermDayTaxoFacets: age +facets:DayOfYear.taxonomy # freq=395368
-MedTermDayTaxoFacets: what +facets:DayOfYear.taxonomy # freq=394675
-MedTermDayTaxoFacets: party +facets:DayOfYear.taxonomy # freq=394410
-MedTermDayTaxoFacets: company +facets:DayOfYear.taxonomy # freq=391520
-MedTermDayTaxoFacets: four +facets:DayOfYear.taxonomy # freq=389818
-MedTermDayTaxoFacets: 28 +facets:DayOfYear.taxonomy # freq=389552
-MedTermDayTaxoFacets: 26 +facets:DayOfYear.taxonomy # freq=389026
-MedTermDayTaxoFacets: family +facets:DayOfYear.taxonomy # freq=387175
-MedTermDayTaxoFacets: long +facets:DayOfYear.taxonomy # freq=385787
-MedTermDayTaxoFacets: century +facets:DayOfYear.taxonomy # freq=385541
-MedTermDayTaxoFacets: government +facets:DayOfYear.taxonomy # freq=384004
-MedTermDayTaxoFacets: 27 +facets:DayOfYear.taxonomy # freq=383042
-MedTermDayTaxoFacets: old +facets:DayOfYear.taxonomy # freq=381809
-MedTermDayTaxoFacets: team +facets:DayOfYear.taxonomy # freq=379028
-MedTermDayTaxoFacets: house +facets:DayOfYear.taxonomy # freq=377336
-MedTermDayTaxoFacets: population +facets:DayOfYear.taxonomy # freq=374481
-MedTermDayTaxoFacets: 29 +facets:DayOfYear.taxonomy # freq=372091
-MedTermDayTaxoFacets: b +facets:DayOfYear.taxonomy # freq=369454
-MedTermDayTaxoFacets: public +facets:DayOfYear.taxonomy # freq=368868
-MedTermDayTaxoFacets: home +facets:DayOfYear.taxonomy # freq=367819
-MedTermDayTaxoFacets: top +facets:DayOfYear.taxonomy # freq=364628
-MedTermDayTaxoFacets: east +facets:DayOfYear.taxonomy # freq=364582
-MedTermDayTaxoFacets: talk +facets:DayOfYear.taxonomy # freq=364194
-MedTermDayTaxoFacets: order +facets:DayOfYear.taxonomy # freq=360915
-MedTermDayTaxoFacets: line +facets:DayOfYear.taxonomy # freq=360442
-MedTermDayTaxoFacets: could +facets:DayOfYear.taxonomy # freq=356679
-MedTermDayTaxoFacets: 2012 +facets:DayOfYear.taxonomy # freq=355641
-MedTermDayTaxoFacets: description +facets:DayOfYear.taxonomy # freq=355070
-MedTermDayTaxoFacets: very +facets:DayOfYear.taxonomy # freq=354898
-MedTermDayTaxoFacets: each +facets:DayOfYear.taxonomy # freq=354583
-MedTermDayTaxoFacets: information +facets:DayOfYear.taxonomy # freq=353153
-MedTermDayTaxoFacets: another +facets:DayOfYear.taxonomy # freq=352496
-MedTermDayTaxoFacets: born +facets:DayOfYear.taxonomy # freq=352196
-MedTermDayTaxoFacets: back +facets:DayOfYear.taxonomy # freq=349276
-MedTermDayTaxoFacets: london +facets:DayOfYear.taxonomy # freq=348918
-MedTermDayTaxoFacets: just +facets:DayOfYear.taxonomy # freq=348911
-MedTermDayTaxoFacets: town +facets:DayOfYear.taxonomy # freq=348598
-MedTermDayTaxoFacets: journal +facets:DayOfYear.taxonomy # freq=348162
-MedTermDayTaxoFacets: non +facets:DayOfYear.taxonomy # freq=348142
-MedTermDayTaxoFacets: color +facets:DayOfYear.taxonomy # freq=347941
-MedTermDayTaxoFacets: 01 +facets:DayOfYear.taxonomy # freq=347922
-MedTermDayTaxoFacets: great +facets:DayOfYear.taxonomy # freq=347499
-MedTermDayTaxoFacets: although +facets:DayOfYear.taxonomy # freq=341432
-MedTermDayTaxoFacets: books +facets:DayOfYear.taxonomy # freq=341376
-MedTermDayTaxoFacets: ii +facets:DayOfYear.taxonomy # freq=340800
-MedTermDayTaxoFacets: major +facets:DayOfYear.taxonomy # freq=340345
-MedTermDayTaxoFacets: further +facets:DayOfYear.taxonomy # freq=339350
-MedTermDayTaxoFacets: 1999 +facets:DayOfYear.taxonomy # freq=334887
-MedTermDayTaxoFacets: around +facets:DayOfYear.taxonomy # freq=334840
-MedTermDayTaxoFacets: best +facets:DayOfYear.taxonomy # freq=334550
-MedTermDayTaxoFacets: former +facets:DayOfYear.taxonomy # freq=332750
-MedTermDayTaxoFacets: still +facets:DayOfYear.taxonomy # freq=332543
-MedTermDayTaxoFacets: album +facets:DayOfYear.taxonomy # freq=331360
-MedTermDayTaxoFacets: stub +facets:DayOfYear.taxonomy # freq=329768
-MedTermDayTaxoFacets: did +facets:DayOfYear.taxonomy # freq=328303
-MedTermDayTaxoFacets: j +facets:DayOfYear.taxonomy # freq=327713
-MedTermDayTaxoFacets: even +facets:DayOfYear.taxonomy # freq=326231
-MedTermDayTaxoFacets: official +facets:DayOfYear.taxonomy # freq=326177
-MedTermDayTaxoFacets: original +facets:DayOfYear.taxonomy # freq=323521
-MedTermDayTaxoFacets: user +facets:DayOfYear.taxonomy # freq=323242
-MedTermDayTaxoFacets: alternative +facets:DayOfYear.taxonomy # freq=322536
-MedTermDayTaxoFacets: released +facets:DayOfYear.taxonomy # freq=322473
-MedTermDayTaxoFacets: jpg +facets:DayOfYear.taxonomy # freq=322278
-MedTermDayTaxoFacets: issue +facets:DayOfYear.taxonomy # freq=322106
-MedTermDayTaxoFacets: own +facets:DayOfYear.taxonomy # freq=321703
-MedTermDayTaxoFacets: season +facets:DayOfYear.taxonomy # freq=320228
-MedTermDayTaxoFacets: those +facets:DayOfYear.taxonomy # freq=320013
-MedTermDayTaxoFacets: 02 +facets:DayOfYear.taxonomy # freq=319783
-MedTermDayTaxoFacets: uk +facets:DayOfYear.taxonomy # freq=319211
-MedTermDayTaxoFacets: way +facets:DayOfYear.taxonomy # freq=318344
-MedTermDayTaxoFacets: type +facets:DayOfYear.taxonomy # freq=318210
-MedTermDayTaxoFacets: 03 +facets:DayOfYear.taxonomy # freq=318112
-MedTermDayTaxoFacets: england +facets:DayOfYear.taxonomy # freq=317884
-MedTermDayTaxoFacets: much +facets:DayOfYear.taxonomy # freq=317670
-MedTermDayTaxoFacets: off +facets:DayOfYear.taxonomy # freq=315473
-MedTermDayTaxoFacets: game +facets:DayOfYear.taxonomy # freq=315157
-MedTermDayTaxoFacets: background +facets:DayOfYear.taxonomy # freq=314229
-MedTermDayTaxoFacets: 04 +facets:DayOfYear.taxonomy # freq=313827
-MedTermDayTaxoFacets: found +facets:DayOfYear.taxonomy # freq=313247
-MedTermDayTaxoFacets: volume +facets:DayOfYear.taxonomy # freq=312846
-MedTermDayTaxoFacets: named +facets:DayOfYear.taxonomy # freq=310150
-MedTermDayTaxoFacets: service +facets:DayOfYear.taxonomy # freq=309976
-MedTermDayTaxoFacets: d +facets:DayOfYear.taxonomy # freq=309729
-MedTermDayTaxoFacets: st +facets:DayOfYear.taxonomy # freq=309092
-MedTermDayTaxoFacets: large +facets:DayOfYear.taxonomy # freq=308888
-MedTermDayTaxoFacets: often +facets:DayOfYear.taxonomy # freq=307684
-MedTermDayTaxoFacets: 06 +facets:DayOfYear.taxonomy # freq=305698
-MedTermDayTaxoFacets: 05 +facets:DayOfYear.taxonomy # freq=302860
-MedTermDayTaxoFacets: 1998 +facets:DayOfYear.taxonomy # freq=300506
-MedTermDayTaxoFacets: align +facets:DayOfYear.taxonomy # freq=300455
-MedTermDayTaxoFacets: kingdom +facets:DayOfYear.taxonomy # freq=299825
-MedTermDayTaxoFacets: using +facets:DayOfYear.taxonomy # freq=299474
-MedTermDayTaxoFacets: white +facets:DayOfYear.taxonomy # freq=299411
-MedTermDayTaxoFacets: 07 +facets:DayOfYear.taxonomy # freq=299351
-MedTermDayTaxoFacets: district +facets:DayOfYear.taxonomy # freq=299108
-MedTermDayTaxoFacets: local +facets:DayOfYear.taxonomy # freq=299012
-MedTermDayTaxoFacets: metadata +facets:DayOfYear.taxonomy # freq=298533
-MedTermDayTaxoFacets: 31 +facets:DayOfYear.taxonomy # freq=298349
-MedTermDayTaxoFacets: 08 +facets:DayOfYear.taxonomy # freq=297258
-MedTermDayTaxoFacets: 09 +facets:DayOfYear.taxonomy # freq=296300
-MedTermDayTaxoFacets: r +facets:DayOfYear.taxonomy # freq=296283
-MedTermDayTaxoFacets: set +facets:DayOfYear.taxonomy # freq=294255
-MedTermDayTaxoFacets: show +facets:DayOfYear.taxonomy # freq=293934
-MedTermDayTaxoFacets: david +facets:DayOfYear.taxonomy # freq=292847
-MedTermDayTaxoFacets: make +facets:DayOfYear.taxonomy # freq=292607
-MedTermDayTaxoFacets: story +facets:DayOfYear.taxonomy # freq=292404
-MedTermDayTaxoFacets: citation +facets:DayOfYear.taxonomy # freq=291478
-MedTermDayTaxoFacets: within +facets:DayOfYear.taxonomy # freq=291049
-MedTermDayTaxoFacets: due +facets:DayOfYear.taxonomy # freq=290531
-MedTermDayTaxoFacets: link +facets:DayOfYear.taxonomy # freq=287552
-MedTermDayTaxoFacets: 1997 +facets:DayOfYear.taxonomy # freq=286789
-MedTermDayTaxoFacets: members +facets:DayOfYear.taxonomy # freq=286028
-MedTermDayTaxoFacets: william +facets:DayOfYear.taxonomy # freq=284592
-MedTermDayTaxoFacets: along +facets:DayOfYear.taxonomy # freq=284442
-MedTermDayTaxoFacets: v +facets:DayOfYear.taxonomy # freq=284318
-MedTermDayTaxoFacets: located +facets:DayOfYear.taxonomy # freq=283899
-MedTermDayTaxoFacets: single +facets:DayOfYear.taxonomy # freq=283824
-MedTermDayTaxoFacets: per +facets:DayOfYear.taxonomy # freq=283568
-MedTermDayTaxoFacets: established +facets:DayOfYear.taxonomy # freq=282471
-MedTermDayTaxoFacets: james +facets:DayOfYear.taxonomy # freq=281597
-MedTermDayTaxoFacets: needed +facets:DayOfYear.taxonomy # freq=281051
-MedTermDayTaxoFacets: down +facets:DayOfYear.taxonomy # freq=280662
-MedTermDayTaxoFacets: present +facets:DayOfYear.taxonomy # freq=278449
-MedTermDayTaxoFacets: man +facets:DayOfYear.taxonomy # freq=278112
-MedTermDayTaxoFacets: college +facets:DayOfYear.taxonomy # freq=278094
-MedTermDayTaxoFacets: f +facets:DayOfYear.taxonomy # freq=278015
-MedTermDayTaxoFacets: site +facets:DayOfYear.taxonomy # freq=277788
-MedTermDayTaxoFacets: football +facets:DayOfYear.taxonomy # freq=277738
-MedTermDayTaxoFacets: en +facets:DayOfYear.taxonomy # freq=277463
-MedTermDayTaxoFacets: result +facets:DayOfYear.taxonomy # freq=276803
-MedTermDayTaxoFacets: include +facets:DayOfYear.taxonomy # freq=276466
-MedTermDayTaxoFacets: began +facets:DayOfYear.taxonomy # freq=276036
-MedTermDayTaxoFacets: my +facets:DayOfYear.taxonomy # freq=274256
-MedTermDayTaxoFacets: x +facets:DayOfYear.taxonomy # freq=272695
-MedTermDayTaxoFacets: central +facets:DayOfYear.taxonomy # freq=272531
-MedTermDayTaxoFacets: band +facets:DayOfYear.taxonomy # freq=272207
-MedTermDayTaxoFacets: 1996 +facets:DayOfYear.taxonomy # freq=271980
-MedTermDayTaxoFacets: form +facets:DayOfYear.taxonomy # freq=271966
-MedTermDayTaxoFacets: member +facets:DayOfYear.taxonomy # freq=271607
-MedTermDayTaxoFacets: television +facets:DayOfYear.taxonomy # freq=271426
-MedTermDayTaxoFacets: league +facets:DayOfYear.taxonomy # freq=270223
-MedTermDayTaxoFacets: free +facets:DayOfYear.taxonomy # freq=270199
-MedTermDayTaxoFacets: political +facets:DayOfYear.taxonomy # freq=269665
-MedTermDayTaxoFacets: font +facets:DayOfYear.taxonomy # freq=269439
-MedTermDayTaxoFacets: 100 +facets:DayOfYear.taxonomy # freq=268978
-MedTermDayTaxoFacets: convert +facets:DayOfYear.taxonomy # freq=267974
-MedTermDayTaxoFacets: red +facets:DayOfYear.taxonomy # freq=266177
-MedTermDayTaxoFacets: president +facets:DayOfYear.taxonomy # freq=263341
-MedTermDayTaxoFacets: five +facets:DayOfYear.taxonomy # freq=262923
-MedTermDayTaxoFacets: t +facets:DayOfYear.taxonomy # freq=262832
-MedTermDayTaxoFacets: power +facets:DayOfYear.taxonomy # freq=262586
-MedTermDayTaxoFacets: river +facets:DayOfYear.taxonomy # freq=262231
-MedTermDayTaxoFacets: we +facets:DayOfYear.taxonomy # freq=261001
-MedTermDayTaxoFacets: song +facets:DayOfYear.taxonomy # freq=260741
-MedTermDayTaxoFacets: next +facets:DayOfYear.taxonomy # freq=259039
-MedTermDayTaxoFacets: articles +facets:DayOfYear.taxonomy # freq=258949
-MedTermDayTaxoFacets: point +facets:DayOfYear.taxonomy # freq=258471
-MedTermDayTaxoFacets: text +facets:DayOfYear.taxonomy # freq=257803
-MedTermDayTaxoFacets: according +facets:DayOfYear.taxonomy # freq=256949
-MedTermDayTaxoFacets: black +facets:DayOfYear.taxonomy # freq=256526
-MedTermDayTaxoFacets: george +facets:DayOfYear.taxonomy # freq=256196
-MedTermDayTaxoFacets: different +facets:DayOfYear.taxonomy # freq=255951
-MedTermDayTaxoFacets: ndash +facets:DayOfYear.taxonomy # freq=255747
-MedTermDayTaxoFacets: third +facets:DayOfYear.taxonomy # freq=255690
-MedTermDayTaxoFacets: tv +facets:DayOfYear.taxonomy # freq=255429
-MedTermDayTaxoFacets: law +facets:DayOfYear.taxonomy # freq=255248
-MedTermDayTaxoFacets: canada +facets:DayOfYear.taxonomy # freq=254867
-MedTermDayTaxoFacets: near +facets:DayOfYear.taxonomy # freq=254492
-MedTermDayTaxoFacets: built +facets:DayOfYear.taxonomy # freq=254491
-MedTermDayTaxoFacets: 1995 +facets:DayOfYear.taxonomy # freq=252837
-MedTermDayTaxoFacets: how +facets:DayOfYear.taxonomy # freq=252284
-MedTermDayTaxoFacets: record +facets:DayOfYear.taxonomy # freq=250484
-MedTermDayTaxoFacets: french +facets:DayOfYear.taxonomy # freq=250453
-MedTermDayTaxoFacets: air +facets:DayOfYear.taxonomy # freq=250411
-MedTermDayTaxoFacets: king +facets:DayOfYear.taxonomy # freq=250321
-MedTermDayTaxoFacets: without +facets:DayOfYear.taxonomy # freq=249926
-MedTermDayTaxoFacets: though +facets:DayOfYear.taxonomy # freq=248968
-MedTermDayTaxoFacets: played +facets:DayOfYear.taxonomy # freq=248191
-MedTermDayTaxoFacets: park +facets:DayOfYear.taxonomy # freq=247801
-MedTermDayTaxoFacets: took +facets:DayOfYear.taxonomy # freq=247388
-MedTermDayTaxoFacets: association +facets:DayOfYear.taxonomy # freq=247156
-MedTermDayTaxoFacets: military +facets:DayOfYear.taxonomy # freq=246727
-MedTermDayTaxoFacets: robert +facets:DayOfYear.taxonomy # freq=246405
-MedTermDayTaxoFacets: above +facets:DayOfYear.taxonomy # freq=246135
-MedTermDayTaxoFacets: persondata +facets:DayOfYear.taxonomy # freq=246119
-MedTermDayTaxoFacets: career +facets:DayOfYear.taxonomy # freq=245439
-MedTermDayTaxoFacets: version +facets:DayOfYear.taxonomy # freq=244541
-MedTermDayTaxoFacets: again +facets:DayOfYear.taxonomy # freq=244255
-MedTermDayTaxoFacets: late +facets:DayOfYear.taxonomy # freq=243636
-MedTermDayTaxoFacets: published +facets:DayOfYear.taxonomy # freq=243548
-MedTermDayTaxoFacets: live +facets:DayOfYear.taxonomy # freq=242147
-MedTermDayTaxoFacets: h +facets:DayOfYear.taxonomy # freq=241946
-MedTermDayTaxoFacets: good +facets:DayOfYear.taxonomy # freq=241649
-MedTermDayTaxoFacets: player +facets:DayOfYear.taxonomy # freq=241451
-MedTermDayTaxoFacets: others +facets:DayOfYear.taxonomy # freq=240487
-MedTermDayTaxoFacets: america +facets:DayOfYear.taxonomy # freq=240374
-MedTermDayTaxoFacets: review +facets:DayOfYear.taxonomy # freq=240157
-MedTermDayTaxoFacets: station +facets:DayOfYear.taxonomy # freq=239572
-MedTermDayTaxoFacets: among +facets:DayOfYear.taxonomy # freq=238986
-MedTermDayTaxoFacets: section +facets:DayOfYear.taxonomy # freq=238874
-MedTermDayTaxoFacets: border +facets:DayOfYear.taxonomy # freq=238540
-MedTermDayTaxoFacets: your +facets:DayOfYear.taxonomy # freq=237723
-MedTermDayTaxoFacets: size +facets:DayOfYear.taxonomy # freq=237662
-MedTermDayTaxoFacets: births +facets:DayOfYear.taxonomy # freq=237033
-MedTermDayTaxoFacets: support +facets:DayOfYear.taxonomy # freq=236989
-MedTermDayTaxoFacets: german +facets:DayOfYear.taxonomy # freq=236721
-MedTermDayTaxoFacets: california +facets:DayOfYear.taxonomy # freq=236086
-MedTermDayTaxoFacets: given +facets:DayOfYear.taxonomy # freq=235719
-MedTermDayTaxoFacets: commons +facets:DayOfYear.taxonomy # freq=235235
-MedTermDayTaxoFacets: 1994 +facets:DayOfYear.taxonomy # freq=235100
-MedTermDayTaxoFacets: start +facets:DayOfYear.taxonomy # freq=233925
-MedTermDayTaxoFacets: km +facets:DayOfYear.taxonomy # freq=233831
-MedTermDayTaxoFacets: said +facets:DayOfYear.taxonomy # freq=233066
-MedTermDayTaxoFacets: western +facets:DayOfYear.taxonomy # freq=232781
-MedTermDayTaxoFacets: won +facets:DayOfYear.taxonomy # freq=232751
-MedTermDayTaxoFacets: la +facets:DayOfYear.taxonomy # freq=232610
-MedTermDayTaxoFacets: held +facets:DayOfYear.taxonomy # freq=232354
-MedTermDayTaxoFacets: children +facets:DayOfYear.taxonomy # freq=232342
-MedTermDayTaxoFacets: does +facets:DayOfYear.taxonomy # freq=232202
-MedTermDayTaxoFacets: club +facets:DayOfYear.taxonomy # freq=232173
-MedTermDayTaxoFacets: source +facets:DayOfYear.taxonomy # freq=231838
-MedTermDayTaxoFacets: church +facets:DayOfYear.taxonomy # freq=231667
-MedTermDayTaxoFacets: format +facets:DayOfYear.taxonomy # freq=231300
-MedTermDayTaxoFacets: example +facets:DayOfYear.taxonomy # freq=230457
-MedTermDayTaxoFacets: development +facets:DayOfYear.taxonomy # freq=230286
-MedTermDayTaxoFacets: land +facets:DayOfYear.taxonomy # freq=230284
-MedTermDayTaxoFacets: total +facets:DayOfYear.taxonomy # freq=230013
-MedTermDayTaxoFacets: final +facets:DayOfYear.taxonomy # freq=230006
-MedTermDayTaxoFacets: 50 +facets:DayOfYear.taxonomy # freq=229614
-MedTermDayTaxoFacets: please +facets:DayOfYear.taxonomy # freq=229602
-MedTermDayTaxoFacets: region +facets:DayOfYear.taxonomy # freq=229561
-MedTermDayTaxoFacets: here +facets:DayOfYear.taxonomy # freq=229505
-MedTermDayTaxoFacets: me +facets:DayOfYear.taxonomy # freq=229204
-MedTermDayTaxoFacets: caption +facets:DayOfYear.taxonomy # freq=229172
-MedTermDayTaxoFacets: must +facets:DayOfYear.taxonomy # freq=228491
-MedTermDayTaxoFacets: army +facets:DayOfYear.taxonomy # freq=228105
-MedTermDayTaxoFacets: l +facets:DayOfYear.taxonomy # freq=227974
-MedTermDayTaxoFacets: side +facets:DayOfYear.taxonomy # freq=227747
-MedTermDayTaxoFacets: society +facets:DayOfYear.taxonomy # freq=226742
-MedTermDayTaxoFacets: full +facets:DayOfYear.taxonomy # freq=226457
-MedTermDayTaxoFacets: few +facets:DayOfYear.taxonomy # freq=226422
-MedTermDayTaxoFacets: records +facets:DayOfYear.taxonomy # freq=225886
-MedTermDayTaxoFacets: below +facets:DayOfYear.taxonomy # freq=225843
-MedTermDayTaxoFacets: community +facets:DayOfYear.taxonomy # freq=225571
-MedTermDayTaxoFacets: office +facets:DayOfYear.taxonomy # freq=225338
-MedTermDayTaxoFacets: 1992 +facets:DayOfYear.taxonomy # freq=225200
-MedTermDayTaxoFacets: road +facets:DayOfYear.taxonomy # freq=225050
-MedTermDayTaxoFacets: research +facets:DayOfYear.taxonomy # freq=224925
-MedTermDayTaxoFacets: various +facets:DayOfYear.taxonomy # freq=224593
-MedTermDayTaxoFacets: take +facets:DayOfYear.taxonomy # freq=224260
-MedTermDayTaxoFacets: wikipedia:persondata +facets:DayOfYear.taxonomy # freq=222385
-MedTermDayTaxoFacets: 1990 +facets:DayOfYear.taxonomy # freq=222154
-MedTermDayTaxoFacets: 40 +facets:DayOfYear.taxonomy # freq=221687
-MedTermDayTaxoFacets: created +facets:DayOfYear.taxonomy # freq=220831
-MedTermDayTaxoFacets: 1993 +facets:DayOfYear.taxonomy # freq=220776
-MedTermDayTaxoFacets: france +facets:DayOfYear.taxonomy # freq=220058
-MedTermDayTaxoFacets: science +facets:DayOfYear.taxonomy # freq=219988
-MedTermDayTaxoFacets: every +facets:DayOfYear.taxonomy # freq=219884
-MedTermDayTaxoFacets: become +facets:DayOfYear.taxonomy # freq=219753
-MedTermDayTaxoFacets: modern +facets:DayOfYear.taxonomy # freq=218831
-MedTermDayTaxoFacets: post +facets:DayOfYear.taxonomy # freq=218570
-MedTermDayTaxoFacets: games +facets:DayOfYear.taxonomy # freq=218434
-MedTermDayTaxoFacets: michael +facets:DayOfYear.taxonomy # freq=217311
-MedTermDayTaxoFacets: current +facets:DayOfYear.taxonomy # freq=217174
-MedTermDayTaxoFacets: included +facets:DayOfYear.taxonomy # freq=216978
-MedTermDayTaxoFacets: ja +facets:DayOfYear.taxonomy # freq=216549
-MedTermDayTaxoFacets: magazine +facets:DayOfYear.taxonomy # freq=215725
-MedTermDayTaxoFacets: position +facets:DayOfYear.taxonomy # freq=215493
-MedTermDayTaxoFacets: australia +facets:DayOfYear.taxonomy # freq=215391
-MedTermDayTaxoFacets: archive +facets:DayOfYear.taxonomy # freq=215381
-MedTermDayTaxoFacets: union +facets:DayOfYear.taxonomy # freq=214164
-MedTermDayTaxoFacets: having +facets:DayOfYear.taxonomy # freq=213416
-MedTermDayTaxoFacets: g +facets:DayOfYear.taxonomy # freq=212936
-MedTermDayTaxoFacets: popular +facets:DayOfYear.taxonomy # freq=212493
-MedTermDayTaxoFacets: royal +facets:DayOfYear.taxonomy # freq=211710
-MedTermDayTaxoFacets: period +facets:DayOfYear.taxonomy # freq=211690
-MedTermDayTaxoFacets: little +facets:DayOfYear.taxonomy # freq=211124
-MedTermDayTaxoFacets: wikitable +facets:DayOfYear.taxonomy # freq=210990
-MedTermDayTaxoFacets: rock +facets:DayOfYear.taxonomy # freq=210815
-MedTermDayTaxoFacets: artist +facets:DayOfYear.taxonomy # freq=210591
-MedTermDayTaxoFacets: play +facets:DayOfYear.taxonomy # freq=210199
-MedTermDayTaxoFacets: led +facets:DayOfYear.taxonomy # freq=210033
-MedTermDayTaxoFacets: notes +facets:DayOfYear.taxonomy # freq=210029
-MedTermDayTaxoFacets: water +facets:DayOfYear.taxonomy # freq=209444
-MedTermDayTaxoFacets: business +facets:DayOfYear.taxonomy # freq=209353
-MedTermDayTaxoFacets: art +facets:DayOfYear.taxonomy # freq=209322
-MedTermDayTaxoFacets: common +facets:DayOfYear.taxonomy # freq=209310
-MedTermDayTaxoFacets: co +facets:DayOfYear.taxonomy # freq=209086
-MedTermDayTaxoFacets: education +facets:DayOfYear.taxonomy # freq=208909
-MedTermDayTaxoFacets: role +facets:DayOfYear.taxonomy # freq=208579
-MedTermDayTaxoFacets: 1991 +facets:DayOfYear.taxonomy # freq=207589
-MedTermDayTaxoFacets: case +facets:DayOfYear.taxonomy # freq=207307
-MedTermDayTaxoFacets: paul +facets:DayOfYear.taxonomy # freq=207229
-MedTermDayTaxoFacets: media +facets:DayOfYear.taxonomy # freq=206574
-MedTermDayTaxoFacets: div +facets:DayOfYear.taxonomy # freq=206057
-MedTermDayTaxoFacets: census +facets:DayOfYear.taxonomy # freq=205166
-MedTermDayTaxoFacets: charles +facets:DayOfYear.taxonomy # freq=204987
-MedTermDayTaxoFacets: written +facets:DayOfYear.taxonomy # freq=204891
-MedTermDayTaxoFacets: pp +facets:DayOfYear.taxonomy # freq=204742
-MedTermDayTaxoFacets: green +facets:DayOfYear.taxonomy # freq=203371
-MedTermDayTaxoFacets: island +facets:DayOfYear.taxonomy # freq=203023
-MedTermDayTaxoFacets: never +facets:DayOfYear.taxonomy # freq=203017
-MedTermDayTaxoFacets: making +facets:DayOfYear.taxonomy # freq=203003
-MedTermDayTaxoFacets: term +facets:DayOfYear.taxonomy # freq=202691
-MedTermDayTaxoFacets: video +facets:DayOfYear.taxonomy # freq=202380
-MedTermDayTaxoFacets: son +facets:DayOfYear.taxonomy # freq=202340
-MedTermDayTaxoFacets: discussion +facets:DayOfYear.taxonomy # freq=202145
-MedTermDayTaxoFacets: died +facets:DayOfYear.taxonomy # freq=202125
-MedTermDayTaxoFacets: view +facets:DayOfYear.taxonomy # freq=201593
-MedTermDayTaxoFacets: street +facets:DayOfYear.taxonomy # freq=200985
-MedTermDayTaxoFacets: council +facets:DayOfYear.taxonomy # freq=200706
-MedTermDayTaxoFacets: re +facets:DayOfYear.taxonomy # freq=199632
-MedTermDayTaxoFacets: award +facets:DayOfYear.taxonomy # freq=199318
-MedTermDayTaxoFacets: works +facets:DayOfYear.taxonomy # freq=199177
-MedTermDayTaxoFacets: special +facets:DayOfYear.taxonomy # freq=198917
-MedTermDayTaxoFacets: force +facets:DayOfYear.taxonomy # freq=198556
-MedTermDayTaxoFacets: six +facets:DayOfYear.taxonomy # freq=197970
-MedTermDayTaxoFacets: came +facets:DayOfYear.taxonomy # freq=197126
-MedTermDayTaxoFacets: building +facets:DayOfYear.taxonomy # freq=196508
-MedTermDayTaxoFacets: young +facets:DayOfYear.taxonomy # freq=196428
-MedTermDayTaxoFacets: together +facets:DayOfYear.taxonomy # freq=195949
-MedTermDayTaxoFacets: important +facets:DayOfYear.taxonomy # freq=195851
-MedTermDayTaxoFacets: star +facets:DayOfYear.taxonomy # freq=195768
-MedTermDayTaxoFacets: similar +facets:DayOfYear.taxonomy # freq=195171
-MedTermDayTaxoFacets: received +facets:DayOfYear.taxonomy # freq=194983
-MedTermDayTaxoFacets: sup +facets:DayOfYear.taxonomy # freq=194723
-MedTermDayTaxoFacets: head +facets:DayOfYear.taxonomy # freq=194682
-AndHighHighDayTaxoFacets: +of +s +facets:DayOfYear.taxonomy # freq=8184358 freq=1581243
-AndHighHighDayTaxoFacets: +date +he +facets:DayOfYear.taxonomy # freq=2020626 freq=1659434
-AndHighHighDayTaxoFacets: +cite +2005 +facets:DayOfYear.taxonomy # freq=1741194 freq=835460
-AndHighHighDayTaxoFacets: +i +10 +facets:DayOfYear.taxonomy # freq=956148 freq=918339
-AndHighHighDayTaxoFacets: +date +2009 +facets:DayOfYear.taxonomy # freq=2020626 freq=887702
-AndHighHighDayTaxoFacets: +for +cite +facets:DayOfYear.taxonomy # freq=4380011 freq=1741194
-AndHighHighDayTaxoFacets: +as +its +facets:DayOfYear.taxonomy # freq=3925535 freq=1173450
-AndHighHighDayTaxoFacets: +which +2011 +facets:DayOfYear.taxonomy # freq=1963428 freq=871410
-AndHighHighDayTaxoFacets: +have +see +facets:DayOfYear.taxonomy # freq=1297121 freq=1044180
-AndHighHighDayTaxoFacets: +first +accessdate +facets:DayOfYear.taxonomy # freq=1933372 freq=1228887
-AndHighHighDayTaxoFacets: +also +no +facets:DayOfYear.taxonomy # freq=1959419 freq=1045000
-AndHighHighDayTaxoFacets: +first +new +facets:DayOfYear.taxonomy # freq=1933372 freq=1657293
-AndHighHighDayTaxoFacets: +publisher +web +facets:DayOfYear.taxonomy # freq=1289029 freq=1118334
-AndHighHighDayTaxoFacets: +states +work +facets:DayOfYear.taxonomy # freq=1034872 freq=853422
-AndHighHighDayTaxoFacets: +more +work +facets:DayOfYear.taxonomy # freq=963533 freq=853422
-AndHighHighDayTaxoFacets: +1 +their +facets:DayOfYear.taxonomy # freq=1641090 freq=1158682
-AndHighHighDayTaxoFacets: +http +an +facets:DayOfYear.taxonomy # freq=3493581 freq=2628056
-AndHighHighDayTaxoFacets: +year +5 +facets:DayOfYear.taxonomy # freq=1235231 freq=891361
-AndHighHighDayTaxoFacets: +4 +there +facets:DayOfYear.taxonomy # freq=986452 freq=956153
-AndHighHighDayTaxoFacets: +s +who +facets:DayOfYear.taxonomy # freq=1581243 freq=1196171
-AndHighHighDayTaxoFacets: +who +may +facets:DayOfYear.taxonomy # freq=1196171 freq=1071932
-AndHighHighDayTaxoFacets: +united +time +facets:DayOfYear.taxonomy # freq=1196944 freq=1032071
-AndHighHighDayTaxoFacets: +other +no +facets:DayOfYear.taxonomy # freq=1269961 freq=1045000
-AndHighHighDayTaxoFacets: +time +when +facets:DayOfYear.taxonomy # freq=1032071 freq=1027487
-AndHighHighDayTaxoFacets: +that +cite +facets:DayOfYear.taxonomy # freq=2931020 freq=1741194
-AndHighHighDayTaxoFacets: +to +its +facets:DayOfYear.taxonomy # freq=6155577 freq=1173450
-AndHighHighDayTaxoFacets: +2011 +2008 +facets:DayOfYear.taxonomy # freq=871410 freq=831253
-AndHighHighDayTaxoFacets: +been +2005 +facets:DayOfYear.taxonomy # freq=1041183 freq=835460
-AndHighHighDayTaxoFacets: +1 +year +facets:DayOfYear.taxonomy # freq=1641090 freq=1235231
-AndHighHighDayTaxoFacets: +was +more +facets:DayOfYear.taxonomy # freq=3763623 freq=963533
-AndHighHighDayTaxoFacets: +3 +2005 +facets:DayOfYear.taxonomy # freq=1148799 freq=835460
-AndHighHighDayTaxoFacets: +a +they +facets:DayOfYear.taxonomy # freq=6560531 freq=1021945
-AndHighHighDayTaxoFacets: +s +time +facets:DayOfYear.taxonomy # freq=1581243 freq=1032071
-AndHighHighDayTaxoFacets: +in +2011 +facets:DayOfYear.taxonomy # freq=7320987 freq=871410
-AndHighHighDayTaxoFacets: +a +work +facets:DayOfYear.taxonomy # freq=6560531 freq=853422
-AndHighHighDayTaxoFacets: +they +4 +facets:DayOfYear.taxonomy # freq=1021945 freq=986452
-AndHighHighDayTaxoFacets: +and +2 +facets:DayOfYear.taxonomy # freq=7318061 freq=1549245
-AndHighHighDayTaxoFacets: +to +an +facets:DayOfYear.taxonomy # freq=6155577 freq=2628056
-AndHighHighDayTaxoFacets: +an +which +facets:DayOfYear.taxonomy # freq=2628056 freq=1963428
-AndHighHighDayTaxoFacets: +was +also +facets:DayOfYear.taxonomy # freq=3763623 freq=1959419
-AndHighHighDayTaxoFacets: +this +see +facets:DayOfYear.taxonomy # freq=2224932 freq=1044180
-AndHighHighDayTaxoFacets: +all +2010 +facets:DayOfYear.taxonomy # freq=1203572 freq=950573
-AndHighHighDayTaxoFacets: +2 +2010 +facets:DayOfYear.taxonomy # freq=1549245 freq=950573
-AndHighHighDayTaxoFacets: +first +work +facets:DayOfYear.taxonomy # freq=1933372 freq=853422
-AndHighHighDayTaxoFacets: +he +10 +facets:DayOfYear.taxonomy # freq=1659434 freq=918339
-AndHighHighDayTaxoFacets: +http +that +facets:DayOfYear.taxonomy # freq=3493581 freq=2931020
-AndHighHighDayTaxoFacets: +new +2011 +facets:DayOfYear.taxonomy # freq=1657293 freq=871410
-AndHighHighDayTaxoFacets: +as +by +facets:DayOfYear.taxonomy # freq=3925535 freq=3826691
-AndHighHighDayTaxoFacets: +there +2008 +facets:DayOfYear.taxonomy # freq=956153 freq=831253
-AndHighHighDayTaxoFacets: +is +they +facets:DayOfYear.taxonomy # freq=4074455 freq=1021945
-AndHighHighDayTaxoFacets: +2010 +2011 +facets:DayOfYear.taxonomy # freq=950573 freq=871410
-AndHighHighDayTaxoFacets: +accessdate +2005 +facets:DayOfYear.taxonomy # freq=1228887 freq=835460
-AndHighHighDayTaxoFacets: +at +this +facets:DayOfYear.taxonomy # freq=2857534 freq=2224932
-AndHighHighDayTaxoFacets: +as +some +facets:DayOfYear.taxonomy # freq=3925535 freq=839919
-AndHighHighDayTaxoFacets: +after +all +facets:DayOfYear.taxonomy # freq=1247398 freq=1203572
-AndHighHighDayTaxoFacets: +year +they +facets:DayOfYear.taxonomy # freq=1235231 freq=1021945
-AndHighHighDayTaxoFacets: +1 +accessdate +facets:DayOfYear.taxonomy # freq=1641090 freq=1228887
-AndHighHighDayTaxoFacets: +on +web +facets:DayOfYear.taxonomy # freq=4074624 freq=1118334
-AndHighHighDayTaxoFacets: +first +5 +facets:DayOfYear.taxonomy # freq=1933372 freq=891361
-AndHighHighDayTaxoFacets: +he +but +facets:DayOfYear.taxonomy # freq=1659434 freq=1456553
-AndHighHighDayTaxoFacets: +title +when +facets:DayOfYear.taxonomy # freq=2397378 freq=1027487
-AndHighHighDayTaxoFacets: +who +two +facets:DayOfYear.taxonomy # freq=1196171 freq=1104053
-AndHighHighDayTaxoFacets: +last +2006 +facets:DayOfYear.taxonomy # freq=958437 freq=889954
-AndHighHighDayTaxoFacets: +from +name +facets:DayOfYear.taxonomy # freq=3224339 freq=2827713
-AndHighHighDayTaxoFacets: +new +i +facets:DayOfYear.taxonomy # freq=1657293 freq=956148
-AndHighHighDayTaxoFacets: +was +publisher +facets:DayOfYear.taxonomy # freq=3763623 freq=1289029
-AndHighHighDayTaxoFacets: +and +not +facets:DayOfYear.taxonomy # freq=7318061 freq=1713264
-AndHighHighDayTaxoFacets: +is +their +facets:DayOfYear.taxonomy # freq=4074455 freq=1158682
-AndHighHighDayTaxoFacets: +ref +that +facets:DayOfYear.taxonomy # freq=3793973 freq=2931020
-AndHighHighDayTaxoFacets: +of +for +facets:DayOfYear.taxonomy # freq=8184358 freq=4380011
-AndHighHighDayTaxoFacets: +name +which +facets:DayOfYear.taxonomy # freq=2827713 freq=1963428
-AndHighHighDayTaxoFacets: +after +2008 +facets:DayOfYear.taxonomy # freq=1247398 freq=831253
-AndHighHighDayTaxoFacets: +that +an +facets:DayOfYear.taxonomy # freq=2931020 freq=2628056
-AndHighHighDayTaxoFacets: +by +2006 +facets:DayOfYear.taxonomy # freq=3826691 freq=889954
-AndHighHighDayTaxoFacets: +that +or +facets:DayOfYear.taxonomy # freq=2931020 freq=1858841
-AndHighHighDayTaxoFacets: +be +which +facets:DayOfYear.taxonomy # freq=2051702 freq=1963428
-AndHighHighDayTaxoFacets: +with +2010 +facets:DayOfYear.taxonomy # freq=3709421 freq=950573
-AndHighHighDayTaxoFacets: +by +with +facets:DayOfYear.taxonomy # freq=3826691 freq=3709421
-AndHighHighDayTaxoFacets: +by +4 +facets:DayOfYear.taxonomy # freq=3826691 freq=986452
-AndHighHighDayTaxoFacets: +was +cite +facets:DayOfYear.taxonomy # freq=3763623 freq=1741194
-AndHighHighDayTaxoFacets: +was +they +facets:DayOfYear.taxonomy # freq=3763623 freq=1021945
-AndHighHighDayTaxoFacets: +on +was +facets:DayOfYear.taxonomy # freq=4074624 freq=3763623
-AndHighHighDayTaxoFacets: +is +time +facets:DayOfYear.taxonomy # freq=4074455 freq=1032071
-AndHighHighDayTaxoFacets: +the +be +facets:DayOfYear.taxonomy # freq=8217362 freq=2051702
-AndHighHighDayTaxoFacets: +were +2010 +facets:DayOfYear.taxonomy # freq=1524630 freq=950573
-AndHighHighDayTaxoFacets: +they +2006 +facets:DayOfYear.taxonomy # freq=1021945 freq=889954
-AndHighHighDayTaxoFacets: +he +may +facets:DayOfYear.taxonomy # freq=1659434 freq=1071932
-AndHighHighDayTaxoFacets: +an +title +facets:DayOfYear.taxonomy # freq=2628056 freq=2397378
-AndHighHighDayTaxoFacets: +into +some +facets:DayOfYear.taxonomy # freq=888684 freq=839919
-AndHighHighDayTaxoFacets: +first +some +facets:DayOfYear.taxonomy # freq=1933372 freq=839919
-AndHighHighDayTaxoFacets: +name +new +facets:DayOfYear.taxonomy # freq=2827713 freq=1657293
-AndHighHighDayTaxoFacets: +cite +3 +facets:DayOfYear.taxonomy # freq=1741194 freq=1148799
-AndHighHighDayTaxoFacets: +to +web +facets:DayOfYear.taxonomy # freq=6155577 freq=1118334
-AndHighHighDayTaxoFacets: +for +it +facets:DayOfYear.taxonomy # freq=4380011 freq=2675552
-AndHighHighDayTaxoFacets: +year +there +facets:DayOfYear.taxonomy # freq=1235231 freq=956153
-AndHighHighDayTaxoFacets: +but +been +facets:DayOfYear.taxonomy # freq=1456553 freq=1041183
-AndHighHighDayTaxoFacets: +this +who +facets:DayOfYear.taxonomy # freq=2224932 freq=1196171
-AndHighHighDayTaxoFacets: +ref +web +facets:DayOfYear.taxonomy # freq=3793973 freq=1118334
-AndHighHighDayTaxoFacets: +cite +2011 +facets:DayOfYear.taxonomy # freq=1741194 freq=871410
-AndHighHighDayTaxoFacets: +by +he +facets:DayOfYear.taxonomy # freq=3826691 freq=1659434
-AndHighHighDayTaxoFacets: +name +first +facets:DayOfYear.taxonomy # freq=2827713 freq=1933372
-AndHighHighDayTaxoFacets: +has +about +facets:DayOfYear.taxonomy # freq=1502961 freq=850283
-AndHighHighDayTaxoFacets: +were +two +facets:DayOfYear.taxonomy # freq=1524630 freq=1104053
-AndHighHighDayTaxoFacets: +two +work +facets:DayOfYear.taxonomy # freq=1104053 freq=853422
-AndHighHighDayTaxoFacets: +he +been +facets:DayOfYear.taxonomy # freq=1659434 freq=1041183
-AndHighHighDayTaxoFacets: +from +2 +facets:DayOfYear.taxonomy # freq=3224339 freq=1549245
-AndHighHighDayTaxoFacets: +all +some +facets:DayOfYear.taxonomy # freq=1203572 freq=839919
-AndHighHighDayTaxoFacets: +on +only +facets:DayOfYear.taxonomy # freq=4074624 freq=875561
-AndHighHighDayTaxoFacets: +was +no +facets:DayOfYear.taxonomy # freq=3763623 freq=1045000
-AndHighHighDayTaxoFacets: +name +see +facets:DayOfYear.taxonomy # freq=2827713 freq=1044180
-AndHighHighDayTaxoFacets: +of +as +facets:DayOfYear.taxonomy # freq=8184358 freq=3925535
-AndHighHighDayTaxoFacets: +be +has +facets:DayOfYear.taxonomy # freq=2051702 freq=1502961
-AndHighHighDayTaxoFacets: +url +into +facets:DayOfYear.taxonomy # freq=1513595 freq=888684
-AndHighHighDayTaxoFacets: +of +2006 +facets:DayOfYear.taxonomy # freq=8184358 freq=889954
-AndHighHighDayTaxoFacets: +ref +or +facets:DayOfYear.taxonomy # freq=3793973 freq=1858841
-AndHighHighDayTaxoFacets: +by +url +facets:DayOfYear.taxonomy # freq=3826691 freq=1513595
-AndHighHighDayTaxoFacets: +3 +into +facets:DayOfYear.taxonomy # freq=1148799 freq=888684
-AndHighHighDayTaxoFacets: +which +year +facets:DayOfYear.taxonomy # freq=1963428 freq=1235231
-AndHighHighDayTaxoFacets: +at +only +facets:DayOfYear.taxonomy # freq=2857534 freq=875561
-AndHighHighDayTaxoFacets: +http +publisher +facets:DayOfYear.taxonomy # freq=3493581 freq=1289029
-AndHighHighDayTaxoFacets: +with +accessdate +facets:DayOfYear.taxonomy # freq=3709421 freq=1228887
-AndHighHighDayTaxoFacets: +had +work +facets:DayOfYear.taxonomy # freq=1246743 freq=853422
-AndHighHighDayTaxoFacets: +as +they +facets:DayOfYear.taxonomy # freq=3925535 freq=1021945
-AndHighHighDayTaxoFacets: +the +2009 +facets:DayOfYear.taxonomy # freq=8217362 freq=887702
-AndHighHighDayTaxoFacets: +are +but +facets:DayOfYear.taxonomy # freq=1877802 freq=1456553
-AndHighHighDayTaxoFacets: +other +10 +facets:DayOfYear.taxonomy # freq=1269961 freq=918339
-AndHighHighDayTaxoFacets: +two +they +facets:DayOfYear.taxonomy # freq=1104053 freq=1021945
-AndHighHighDayTaxoFacets: +all +they +facets:DayOfYear.taxonomy # freq=1203572 freq=1021945
-AndHighHighDayTaxoFacets: +2011 +about +facets:DayOfYear.taxonomy # freq=871410 freq=850283
-AndHighHighDayTaxoFacets: +name +states +facets:DayOfYear.taxonomy # freq=2827713 freq=1034872
-AndHighHighDayTaxoFacets: +were +may +facets:DayOfYear.taxonomy # freq=1524630 freq=1071932
-AndHighHighDayTaxoFacets: +the +into +facets:DayOfYear.taxonomy # freq=8217362 freq=888684
-AndHighHighDayTaxoFacets: +new +united +facets:DayOfYear.taxonomy # freq=1657293 freq=1196944
-AndHighHighDayTaxoFacets: +their +only +facets:DayOfYear.taxonomy # freq=1158682 freq=875561
-AndHighHighDayTaxoFacets: +be +10 +facets:DayOfYear.taxonomy # freq=2051702 freq=918339
-AndHighHighDayTaxoFacets: +that +not +facets:DayOfYear.taxonomy # freq=2931020 freq=1713264
-AndHighHighDayTaxoFacets: +title +all +facets:DayOfYear.taxonomy # freq=2397378 freq=1203572
-AndHighHighDayTaxoFacets: +with +have +facets:DayOfYear.taxonomy # freq=3709421 freq=1297121
-AndHighHighDayTaxoFacets: +as +been +facets:DayOfYear.taxonomy # freq=3925535 freq=1041183
-AndHighHighDayTaxoFacets: +it +more +facets:DayOfYear.taxonomy # freq=2675552 freq=963533
-AndHighHighDayTaxoFacets: +all +united +facets:DayOfYear.taxonomy # freq=1203572 freq=1196944
-AndHighHighDayTaxoFacets: +other +two +facets:DayOfYear.taxonomy # freq=1269961 freq=1104053
-AndHighHighDayTaxoFacets: +he +url +facets:DayOfYear.taxonomy # freq=1659434 freq=1513595
-AndHighHighDayTaxoFacets: +to +3 +facets:DayOfYear.taxonomy # freq=6155577 freq=1148799
-AndHighHighDayTaxoFacets: +in +from +facets:DayOfYear.taxonomy # freq=7320987 freq=3224339
-AndHighHighDayTaxoFacets: +not +there +facets:DayOfYear.taxonomy # freq=1713264 freq=956153
-AndHighHighDayTaxoFacets: +other +see +facets:DayOfYear.taxonomy # freq=1269961 freq=1044180
-AndHighHighDayTaxoFacets: +its +i +facets:DayOfYear.taxonomy # freq=1173450 freq=956148
-AndHighHighDayTaxoFacets: +as +2008 +facets:DayOfYear.taxonomy # freq=3925535 freq=831253
-AndHighHighDayTaxoFacets: +http +s +facets:DayOfYear.taxonomy # freq=3493581 freq=1581243
-AndHighHighDayTaxoFacets: +or +web +facets:DayOfYear.taxonomy # freq=1858841 freq=1118334
-AndHighHighDayTaxoFacets: +new +publisher +facets:DayOfYear.taxonomy # freq=1657293 freq=1289029
-AndHighHighDayTaxoFacets: +of +who +facets:DayOfYear.taxonomy # freq=8184358 freq=1196171
-AndHighHighDayTaxoFacets: +10 +2009 +facets:DayOfYear.taxonomy # freq=918339 freq=887702
-AndHighHighDayTaxoFacets: +that +he +facets:DayOfYear.taxonomy # freq=2931020 freq=1659434
-AndHighHighDayTaxoFacets: +url +2005 +facets:DayOfYear.taxonomy # freq=1513595 freq=835460
-AndHighHighDayTaxoFacets: +the +a +facets:DayOfYear.taxonomy # freq=8217362 freq=6560531
-AndHighHighDayTaxoFacets: +more +there +facets:DayOfYear.taxonomy # freq=963533 freq=956153
-AndHighHighDayTaxoFacets: +and +an +facets:DayOfYear.taxonomy # freq=7318061 freq=2628056
-AndHighHighDayTaxoFacets: +with +they +facets:DayOfYear.taxonomy # freq=3709421 freq=1021945
-AndHighHighDayTaxoFacets: +title +time +facets:DayOfYear.taxonomy # freq=2397378 freq=1032071
-AndHighHighDayTaxoFacets: +states +4 +facets:DayOfYear.taxonomy # freq=1034872 freq=986452
-AndHighHighDayTaxoFacets: +united +when +facets:DayOfYear.taxonomy # freq=1196944 freq=1027487
-AndHighHighDayTaxoFacets: +is +title +facets:DayOfYear.taxonomy # freq=4074455 freq=2397378
-AndHighHighDayTaxoFacets: +from +who +facets:DayOfYear.taxonomy # freq=3224339 freq=1196171
-AndHighHighDayTaxoFacets: +more +some +facets:DayOfYear.taxonomy # freq=963533 freq=839919
-AndHighHighDayTaxoFacets: +title +year +facets:DayOfYear.taxonomy # freq=2397378 freq=1235231
-AndHighHighDayTaxoFacets: +one +after +facets:DayOfYear.taxonomy # freq=1527689 freq=1247398
-AndHighHighDayTaxoFacets: +with +title +facets:DayOfYear.taxonomy # freq=3709421 freq=2397378
-AndHighHighDayTaxoFacets: +in +first +facets:DayOfYear.taxonomy # freq=7320987 freq=1933372
-AndHighHighDayTaxoFacets: +are +i +facets:DayOfYear.taxonomy # freq=1877802 freq=956148
-AndHighHighDayTaxoFacets: +the +two +facets:DayOfYear.taxonomy # freq=8217362 freq=1104053
-AndHighHighDayTaxoFacets: +but +there +facets:DayOfYear.taxonomy # freq=1456553 freq=956153
-AndHighHighDayTaxoFacets: +from +all +facets:DayOfYear.taxonomy # freq=3224339 freq=1203572
-AndHighHighDayTaxoFacets: +2 +more +facets:DayOfYear.taxonomy # freq=1549245 freq=963533
-AndHighHighDayTaxoFacets: +had +its +facets:DayOfYear.taxonomy # freq=1246743 freq=1173450
-AndHighHighDayTaxoFacets: +in +no +facets:DayOfYear.taxonomy # freq=7320987 freq=1045000
-AndHighHighDayTaxoFacets: +other +more +facets:DayOfYear.taxonomy # freq=1269961 freq=963533
-AndHighHighDayTaxoFacets: +his +united +facets:DayOfYear.taxonomy # freq=1777780 freq=1196944
-AndHighHighDayTaxoFacets: +more +last +facets:DayOfYear.taxonomy # freq=963533 freq=958437
-AndHighHighDayTaxoFacets: +ref +more +facets:DayOfYear.taxonomy # freq=3793973 freq=963533
-AndHighHighDayTaxoFacets: +ref +been +facets:DayOfYear.taxonomy # freq=3793973 freq=1041183
-AndHighHighDayTaxoFacets: +cite +time +facets:DayOfYear.taxonomy # freq=1741194 freq=1032071
-AndHighHighDayTaxoFacets: +http +3 +facets:DayOfYear.taxonomy # freq=3493581 freq=1148799
-AndHighHighDayTaxoFacets: +has +they +facets:DayOfYear.taxonomy # freq=1502961 freq=1021945
-AndHighHighDayTaxoFacets: +and +2011 +facets:DayOfYear.taxonomy # freq=7318061 freq=871410
-AndHighHighDayTaxoFacets: +be +accessdate +facets:DayOfYear.taxonomy # freq=2051702 freq=1228887
-AndHighHighDayTaxoFacets: +are +2010 +facets:DayOfYear.taxonomy # freq=1877802 freq=950573
-AndHighHighDayTaxoFacets: +at +2009 +facets:DayOfYear.taxonomy # freq=2857534 freq=887702
-AndHighHighDayTaxoFacets: +also +united +facets:DayOfYear.taxonomy # freq=1959419 freq=1196944
-AndHighHighDayTaxoFacets: +united +been +facets:DayOfYear.taxonomy # freq=1196944 freq=1041183
-AndHighHighDayTaxoFacets: +also +1 +facets:DayOfYear.taxonomy # freq=1959419 freq=1641090
-AndHighHighDayTaxoFacets: +he +last +facets:DayOfYear.taxonomy # freq=1659434 freq=958437
-AndHighHighDayTaxoFacets: +was +from +facets:DayOfYear.taxonomy # freq=3763623 freq=3224339
-AndHighHighDayTaxoFacets: +ref +when +facets:DayOfYear.taxonomy # freq=3793973 freq=1027487
-AndHighHighDayTaxoFacets: +not +they +facets:DayOfYear.taxonomy # freq=1713264 freq=1021945
-AndHighHighDayTaxoFacets: +the +other +facets:DayOfYear.taxonomy # freq=8217362 freq=1269961
-AndHighHighDayTaxoFacets: +cite +work +facets:DayOfYear.taxonomy # freq=1741194 freq=853422
-AndHighHighDayTaxoFacets: +was +were +facets:DayOfYear.taxonomy # freq=3763623 freq=1524630
-AndHighHighDayTaxoFacets: +in +after +facets:DayOfYear.taxonomy # freq=7320987 freq=1247398
-AndHighHighDayTaxoFacets: +and +first +facets:DayOfYear.taxonomy # freq=7318061 freq=1933372
-AndHighHighDayTaxoFacets: +have +their +facets:DayOfYear.taxonomy # freq=1297121 freq=1158682
-AndHighHighDayTaxoFacets: +also +4 +facets:DayOfYear.taxonomy # freq=1959419 freq=986452
-AndHighHighDayTaxoFacets: +he +2006 +facets:DayOfYear.taxonomy # freq=1659434 freq=889954
-AndHighHighDayTaxoFacets: +may +time +facets:DayOfYear.taxonomy # freq=1071932 freq=1032071
-AndHighHighDayTaxoFacets: +is +url +facets:DayOfYear.taxonomy # freq=4074455 freq=1513595
-AndHighHighDayTaxoFacets: +for +has +facets:DayOfYear.taxonomy # freq=4380011 freq=1502961
-AndHighHighDayTaxoFacets: +and +be +facets:DayOfYear.taxonomy # freq=7318061 freq=2051702
-AndHighHighDayTaxoFacets: +url +had +facets:DayOfYear.taxonomy # freq=1513595 freq=1246743
-AndHighHighDayTaxoFacets: +his +5 +facets:DayOfYear.taxonomy # freq=1777780 freq=891361
-AndHighHighDayTaxoFacets: +on +he +facets:DayOfYear.taxonomy # freq=4074624 freq=1659434
-AndHighHighDayTaxoFacets: +this +first +facets:DayOfYear.taxonomy # freq=2224932 freq=1933372
-AndHighHighDayTaxoFacets: +new +its +facets:DayOfYear.taxonomy # freq=1657293 freq=1173450
-AndHighHighDayTaxoFacets: +s +2009 +facets:DayOfYear.taxonomy # freq=1581243 freq=887702
-AndHighHighDayTaxoFacets: +see +2010 +facets:DayOfYear.taxonomy # freq=1044180 freq=950573
-AndHighHighDayTaxoFacets: +or +but +facets:DayOfYear.taxonomy # freq=1858841 freq=1456553
-AndHighHighDayTaxoFacets: +its +into +facets:DayOfYear.taxonomy # freq=1173450 freq=888684
-AndHighHighDayTaxoFacets: +on +accessdate +facets:DayOfYear.taxonomy # freq=4074624 freq=1228887
-AndHighHighDayTaxoFacets: +are +accessdate +facets:DayOfYear.taxonomy # freq=1877802 freq=1228887
-AndHighHighDayTaxoFacets: +2 +there +facets:DayOfYear.taxonomy # freq=1549245 freq=956153
-AndHighHighDayTaxoFacets: +united +3 +facets:DayOfYear.taxonomy # freq=1196944 freq=1148799
-AndHighHighDayTaxoFacets: +which +no +facets:DayOfYear.taxonomy # freq=1963428 freq=1045000
-AndHighHighDayTaxoFacets: +s +2006 +facets:DayOfYear.taxonomy # freq=1581243 freq=889954
-AndHighHighDayTaxoFacets: +ref +there +facets:DayOfYear.taxonomy # freq=3793973 freq=956153
-AndHighHighDayTaxoFacets: +he +more +facets:DayOfYear.taxonomy # freq=1659434 freq=963533
-AndHighHighDayTaxoFacets: +had +two +facets:DayOfYear.taxonomy # freq=1246743 freq=1104053
-AndHighHighDayTaxoFacets: +the +only +facets:DayOfYear.taxonomy # freq=8217362 freq=875561
-AndHighHighDayTaxoFacets: +be +about +facets:DayOfYear.taxonomy # freq=2051702 freq=850283
-AndHighHighDayTaxoFacets: +in +has +facets:DayOfYear.taxonomy # freq=7320987 freq=1502961
-AndHighHighDayTaxoFacets: +2009 +work +facets:DayOfYear.taxonomy # freq=887702 freq=853422
-AndHighHighDayTaxoFacets: +on +10 +facets:DayOfYear.taxonomy # freq=4074624 freq=918339
-AndHighHighDayTaxoFacets: +ref +2010 +facets:DayOfYear.taxonomy # freq=3793973 freq=950573
-AndHighHighDayTaxoFacets: +other +2006 +facets:DayOfYear.taxonomy # freq=1269961 freq=889954
-AndHighHighDayTaxoFacets: +with +all +facets:DayOfYear.taxonomy # freq=3709421 freq=1203572
-AndHighHighDayTaxoFacets: +in +work +facets:DayOfYear.taxonomy # freq=7320987 freq=853422
-AndHighHighDayTaxoFacets: +url +about +facets:DayOfYear.taxonomy # freq=1513595 freq=850283
-AndHighHighDayTaxoFacets: +after +some +facets:DayOfYear.taxonomy # freq=1247398 freq=839919
-AndHighHighDayTaxoFacets: +this +when +facets:DayOfYear.taxonomy # freq=2224932 freq=1027487
-AndHighHighDayTaxoFacets: +not +1 +facets:DayOfYear.taxonomy # freq=1713264 freq=1641090
-AndHighHighDayTaxoFacets: +1 +more +facets:DayOfYear.taxonomy # freq=1641090 freq=963533
-AndHighHighDayTaxoFacets: +not +2 +facets:DayOfYear.taxonomy # freq=1713264 freq=1549245
-AndHighHighDayTaxoFacets: +publisher +2005 +facets:DayOfYear.taxonomy # freq=1289029 freq=835460
-AndHighHighDayTaxoFacets: +in +at +facets:DayOfYear.taxonomy # freq=7320987 freq=2857534
-AndHighHighDayTaxoFacets: +1 +some +facets:DayOfYear.taxonomy # freq=1641090 freq=839919
-AndHighHighDayTaxoFacets: +s +its +facets:DayOfYear.taxonomy # freq=1581243 freq=1173450
-AndHighHighDayTaxoFacets: +date +more +facets:DayOfYear.taxonomy # freq=2020626 freq=963533
-AndHighHighDayTaxoFacets: +from +his +facets:DayOfYear.taxonomy # freq=3224339 freq=1777780
-AndHighHighDayTaxoFacets: +was +when +facets:DayOfYear.taxonomy # freq=3763623 freq=1027487
-AndHighHighDayTaxoFacets: +time +2010 +facets:DayOfYear.taxonomy # freq=1032071 freq=950573
-AndHighHighDayTaxoFacets: +it +2 +facets:DayOfYear.taxonomy # freq=2675552 freq=1549245
-AndHighHighDayTaxoFacets: +of +http +facets:DayOfYear.taxonomy # freq=8184358 freq=3493581
-AndHighHighDayTaxoFacets: +2 +2011 +facets:DayOfYear.taxonomy # freq=1549245 freq=871410
-AndHighHighDayTaxoFacets: +who +2009 +facets:DayOfYear.taxonomy # freq=1196171 freq=887702
-AndHighHighDayTaxoFacets: +in +2009 +facets:DayOfYear.taxonomy # freq=7320987 freq=887702
-AndHighHighDayTaxoFacets: +by +3 +facets:DayOfYear.taxonomy # freq=3826691 freq=1148799
-AndHighHighDayTaxoFacets: +when +2011 +facets:DayOfYear.taxonomy # freq=1027487 freq=871410
-AndHighHighDayTaxoFacets: +not +have +facets:DayOfYear.taxonomy # freq=1713264 freq=1297121
-AndHighHighDayTaxoFacets: +all +their +facets:DayOfYear.taxonomy # freq=1203572 freq=1158682
-AndHighHighDayTaxoFacets: +an +2005 +facets:DayOfYear.taxonomy # freq=2628056 freq=835460
-AndHighHighDayTaxoFacets: +of +is +facets:DayOfYear.taxonomy # freq=8184358 freq=4074455
-AndHighHighDayTaxoFacets: +of +url +facets:DayOfYear.taxonomy # freq=8184358 freq=1513595
-AndHighHighDayTaxoFacets: +also +year +facets:DayOfYear.taxonomy # freq=1959419 freq=1235231
-AndHighHighDayTaxoFacets: +is +new +facets:DayOfYear.taxonomy # freq=4074455 freq=1657293
-AndHighHighDayTaxoFacets: +http +name +facets:DayOfYear.taxonomy # freq=3493581 freq=2827713
-AndHighHighDayTaxoFacets: +i +into +facets:DayOfYear.taxonomy # freq=956148 freq=888684
-AndHighHighDayTaxoFacets: +are +united +facets:DayOfYear.taxonomy # freq=1877802 freq=1196944
-AndHighHighDayTaxoFacets: +or +only +facets:DayOfYear.taxonomy # freq=1858841 freq=875561
-AndHighHighDayTaxoFacets: +who +their +facets:DayOfYear.taxonomy # freq=1196171 freq=1158682
-AndHighHighDayTaxoFacets: +name +been +facets:DayOfYear.taxonomy # freq=2827713 freq=1041183
-AndHighHighDayTaxoFacets: +last +2009 +facets:DayOfYear.taxonomy # freq=958437 freq=887702
-AndHighHighDayTaxoFacets: +they +2005 +facets:DayOfYear.taxonomy # freq=1021945 freq=835460
-AndHighHighDayTaxoFacets: +new +1 +facets:DayOfYear.taxonomy # freq=1657293 freq=1641090
-AndHighHighDayTaxoFacets: +title +some +facets:DayOfYear.taxonomy # freq=2397378 freq=839919
-AndHighHighDayTaxoFacets: +name +5 +facets:DayOfYear.taxonomy # freq=2827713 freq=891361
-AndHighHighDayTaxoFacets: +and +or +facets:DayOfYear.taxonomy # freq=7318061 freq=1858841
-AndHighHighDayTaxoFacets: +3 +2006 +facets:DayOfYear.taxonomy # freq=1148799 freq=889954
-AndHighHighDayTaxoFacets: +of +has +facets:DayOfYear.taxonomy # freq=8184358 freq=1502961
-AndHighHighDayTaxoFacets: +which +i +facets:DayOfYear.taxonomy # freq=1963428 freq=956148
-AndHighHighDayTaxoFacets: +see +5 +facets:DayOfYear.taxonomy # freq=1044180 freq=891361
-AndHighHighDayTaxoFacets: +has +2011 +facets:DayOfYear.taxonomy # freq=1502961 freq=871410
-AndHighHighDayTaxoFacets: +new +accessdate +facets:DayOfYear.taxonomy # freq=1657293 freq=1228887
-AndHighHighDayTaxoFacets: +united +i +facets:DayOfYear.taxonomy # freq=1196944 freq=956148
-AndHighHighDayTaxoFacets: +are +10 +facets:DayOfYear.taxonomy # freq=1877802 freq=918339
-AndHighHighDayTaxoFacets: +the +is +facets:DayOfYear.taxonomy # freq=8217362 freq=4074455
-AndHighHighDayTaxoFacets: +other +web +facets:DayOfYear.taxonomy # freq=1269961 freq=1118334
-AndHighHighDayTaxoFacets: +i +2006 +facets:DayOfYear.taxonomy # freq=956148 freq=889954
-AndHighHighDayTaxoFacets: +were +publisher +facets:DayOfYear.taxonomy # freq=1524630 freq=1289029
-AndHighHighDayTaxoFacets: +be +when +facets:DayOfYear.taxonomy # freq=2051702 freq=1027487
-AndHighHighDayTaxoFacets: +to +date +facets:DayOfYear.taxonomy # freq=6155577 freq=2020626
-AndHighHighDayTaxoFacets: +for +2006 +facets:DayOfYear.taxonomy # freq=4380011 freq=889954
-AndHighHighDayTaxoFacets: +for +at +facets:DayOfYear.taxonomy # freq=4380011 freq=2857534
-AndHighHighDayTaxoFacets: +his +s +facets:DayOfYear.taxonomy # freq=1777780 freq=1581243
-AndHighHighDayTaxoFacets: +from +or +facets:DayOfYear.taxonomy # freq=3224339 freq=1858841
-AndHighHighDayTaxoFacets: +ref +an +facets:DayOfYear.taxonomy # freq=3793973 freq=2628056
-AndHighHighDayTaxoFacets: +which +had +facets:DayOfYear.taxonomy # freq=1963428 freq=1246743
-AndHighHighDayTaxoFacets: +an +were +facets:DayOfYear.taxonomy # freq=2628056 freq=1524630
-AndHighHighDayTaxoFacets: +web +only +facets:DayOfYear.taxonomy # freq=1118334 freq=875561
-AndHighHighDayTaxoFacets: +ref +one +facets:DayOfYear.taxonomy # freq=3793973 freq=1527689
-AndHighHighDayTaxoFacets: +a +one +facets:DayOfYear.taxonomy # freq=6560531 freq=1527689
-AndHighHighDayTaxoFacets: +they +into +facets:DayOfYear.taxonomy # freq=1021945 freq=888684
-AndHighHighDayTaxoFacets: +of +2008 +facets:DayOfYear.taxonomy # freq=8184358 freq=831253
-AndHighHighDayTaxoFacets: +in +which +facets:DayOfYear.taxonomy # freq=7320987 freq=1963428
-AndHighHighDayTaxoFacets: +united +2010 +facets:DayOfYear.taxonomy # freq=1196944 freq=950573
-AndHighHighDayTaxoFacets: +after +i +facets:DayOfYear.taxonomy # freq=1247398 freq=956148
-AndHighHighDayTaxoFacets: +he +web +facets:DayOfYear.taxonomy # freq=1659434 freq=1118334
-AndHighHighDayTaxoFacets: +are +states +facets:DayOfYear.taxonomy # freq=1877802 freq=1034872
-AndHighHighDayTaxoFacets: +after +time +facets:DayOfYear.taxonomy # freq=1247398 freq=1032071
-AndHighHighDayTaxoFacets: +its +web +facets:DayOfYear.taxonomy # freq=1173450 freq=1118334
-AndHighHighDayTaxoFacets: +for +when +facets:DayOfYear.taxonomy # freq=4380011 freq=1027487
-AndHighHighDayTaxoFacets: +has +states +facets:DayOfYear.taxonomy # freq=1502961 freq=1034872
-AndHighHighDayTaxoFacets: +the +no +facets:DayOfYear.taxonomy # freq=8217362 freq=1045000
-AndHighHighDayTaxoFacets: +title +one +facets:DayOfYear.taxonomy # freq=2397378 freq=1527689
-AndHighHighDayTaxoFacets: +i +2009 +facets:DayOfYear.taxonomy # freq=956148 freq=887702
-AndHighHighDayTaxoFacets: +1 +states +facets:DayOfYear.taxonomy # freq=1641090 freq=1034872
-AndHighHighDayTaxoFacets: +other +only +facets:DayOfYear.taxonomy # freq=1269961 freq=875561
-AndHighHighDayTaxoFacets: +by +they +facets:DayOfYear.taxonomy # freq=3826691 freq=1021945
-AndHighHighDayTaxoFacets: +http +its +facets:DayOfYear.taxonomy # freq=3493581 freq=1173450
-AndHighHighDayTaxoFacets: +for +two +facets:DayOfYear.taxonomy # freq=4380011 freq=1104053
-AndHighHighDayTaxoFacets: +all +may +facets:DayOfYear.taxonomy # freq=1203572 freq=1071932
-AndHighHighDayTaxoFacets: +after +last +facets:DayOfYear.taxonomy # freq=1247398 freq=958437
-AndHighHighDayTaxoFacets: +there +only +facets:DayOfYear.taxonomy # freq=956153 freq=875561
-AndHighHighDayTaxoFacets: +2 +no +facets:DayOfYear.taxonomy # freq=1549245 freq=1045000
-AndHighHighDayTaxoFacets: +an +he +facets:DayOfYear.taxonomy # freq=2628056 freq=1659434
-AndHighHighDayTaxoFacets: +his +i +facets:DayOfYear.taxonomy # freq=1777780 freq=956148
-AndHighHighDayTaxoFacets: +first +not +facets:DayOfYear.taxonomy # freq=1933372 freq=1713264
-AndHighHighDayTaxoFacets: +a +5 +facets:DayOfYear.taxonomy # freq=6560531 freq=891361
-AndHighHighDayTaxoFacets: +from +2005 +facets:DayOfYear.taxonomy # freq=3224339 freq=835460
-AndHighHighDayTaxoFacets: +after +web +facets:DayOfYear.taxonomy # freq=1247398 freq=1118334
-AndHighHighDayTaxoFacets: +to +which +facets:DayOfYear.taxonomy # freq=6155577 freq=1963428
-AndHighHighDayTaxoFacets: +this +into +facets:DayOfYear.taxonomy # freq=2224932 freq=888684
-AndHighHighDayTaxoFacets: +its +last +facets:DayOfYear.taxonomy # freq=1173450 freq=958437
-AndHighHighDayTaxoFacets: +it +there +facets:DayOfYear.taxonomy # freq=2675552 freq=956153
-AndHighHighDayTaxoFacets: +name +are +facets:DayOfYear.taxonomy # freq=2827713 freq=1877802
-AndHighHighDayTaxoFacets: +are +4 +facets:DayOfYear.taxonomy # freq=1877802 freq=986452
-AndHighHighDayTaxoFacets: +name +cite +facets:DayOfYear.taxonomy # freq=2827713 freq=1741194
-AndHighHighDayTaxoFacets: +more +2008 +facets:DayOfYear.taxonomy # freq=963533 freq=831253
-AndHighHighDayTaxoFacets: +of +that +facets:DayOfYear.taxonomy # freq=8184358 freq=2931020
-AndHighHighDayTaxoFacets: +ref +at +facets:DayOfYear.taxonomy # freq=3793973 freq=2857534
-AndHighHighDayTaxoFacets: +new +web +facets:DayOfYear.taxonomy # freq=1657293 freq=1118334
-AndHighHighDayTaxoFacets: +the +2 +facets:DayOfYear.taxonomy # freq=8217362 freq=1549245
-AndHighHighDayTaxoFacets: +for +1 +facets:DayOfYear.taxonomy # freq=4380011 freq=1641090
-AndHighHighDayTaxoFacets: +by +no +facets:DayOfYear.taxonomy # freq=3826691 freq=1045000
-AndHighHighDayTaxoFacets: +all +i +facets:DayOfYear.taxonomy # freq=1203572 freq=956148
-AndHighHighDayTaxoFacets: +5 +2006 +facets:DayOfYear.taxonomy # freq=891361 freq=889954
-AndHighHighDayTaxoFacets: +4 +work +facets:DayOfYear.taxonomy # freq=986452 freq=853422
-AndHighHighDayTaxoFacets: +was +new +facets:DayOfYear.taxonomy # freq=3763623 freq=1657293
-AndHighHighDayTaxoFacets: +year +see +facets:DayOfYear.taxonomy # freq=1235231 freq=1044180
-AndHighHighDayTaxoFacets: +s +had +facets:DayOfYear.taxonomy # freq=1581243 freq=1246743
-AndHighHighDayTaxoFacets: +an +last +facets:DayOfYear.taxonomy # freq=2628056 freq=958437
-AndHighHighDayTaxoFacets: +had +4 +facets:DayOfYear.taxonomy # freq=1246743 freq=986452
-AndHighHighDayTaxoFacets: +from +publisher +facets:DayOfYear.taxonomy # freq=3224339 freq=1289029
-AndHighHighDayTaxoFacets: +new +url +facets:DayOfYear.taxonomy # freq=1657293 freq=1513595
-AndHighHighDayTaxoFacets: +4 +5 +facets:DayOfYear.taxonomy # freq=986452 freq=891361
-AndHighHighDayTaxoFacets: +by +cite +facets:DayOfYear.taxonomy # freq=3826691 freq=1741194
-AndHighHighDayTaxoFacets: +2010 +2009 +facets:DayOfYear.taxonomy # freq=950573 freq=887702
-AndHighHighDayTaxoFacets: +their +4 +facets:DayOfYear.taxonomy # freq=1158682 freq=986452
-AndHighHighDayTaxoFacets: +publisher +who +facets:DayOfYear.taxonomy # freq=1289029 freq=1196171
-AndHighHighDayTaxoFacets: +that +more +facets:DayOfYear.taxonomy # freq=2931020 freq=963533
-AndHighHighDayTaxoFacets: +ref +see +facets:DayOfYear.taxonomy # freq=3793973 freq=1044180
-AndHighHighDayTaxoFacets: +publisher +last +facets:DayOfYear.taxonomy # freq=1289029 freq=958437
-AndHighHighDayTaxoFacets: +but +their +facets:DayOfYear.taxonomy # freq=1456553 freq=1158682
-AndHighHighDayTaxoFacets: +is +1 +facets:DayOfYear.taxonomy # freq=4074455 freq=1641090
-AndHighHighDayTaxoFacets: +new +have +facets:DayOfYear.taxonomy # freq=1657293 freq=1297121
-AndHighHighDayTaxoFacets: +title +also +facets:DayOfYear.taxonomy # freq=2397378 freq=1959419
-AndHighHighDayTaxoFacets: +also +i +facets:DayOfYear.taxonomy # freq=1959419 freq=956148
-AndHighHighDayTaxoFacets: +had +into +facets:DayOfYear.taxonomy # freq=1246743 freq=888684
-AndHighHighDayTaxoFacets: +first +when +facets:DayOfYear.taxonomy # freq=1933372 freq=1027487
-AndHighHighDayTaxoFacets: +in +be +facets:DayOfYear.taxonomy # freq=7320987 freq=2051702
-AndHighHighDayTaxoFacets: +are +2008 +facets:DayOfYear.taxonomy # freq=1877802 freq=831253
-AndHighHighDayTaxoFacets: +two +2006 +facets:DayOfYear.taxonomy # freq=1104053 freq=889954
-AndHighHighDayTaxoFacets: +date +about +facets:DayOfYear.taxonomy # freq=2020626 freq=850283
-AndHighHighDayTaxoFacets: +its +only +facets:DayOfYear.taxonomy # freq=1173450 freq=875561
-AndHighHighDayTaxoFacets: +title +new +facets:DayOfYear.taxonomy # freq=2397378 freq=1657293
-AndHighHighDayTaxoFacets: +2 +10 +facets:DayOfYear.taxonomy # freq=1549245 freq=918339
-AndHighHighDayTaxoFacets: +2 +one +facets:DayOfYear.taxonomy # freq=1549245 freq=1527689
-AndHighHighDayTaxoFacets: +is +an +facets:DayOfYear.taxonomy # freq=4074455 freq=2628056
-AndHighHighDayTaxoFacets: +at +no +facets:DayOfYear.taxonomy # freq=2857534 freq=1045000
-AndHighHighDayTaxoFacets: +has +its +facets:DayOfYear.taxonomy # freq=1502961 freq=1173450
-AndHighHighDayTaxoFacets: +were +there +facets:DayOfYear.taxonomy # freq=1524630 freq=956153
-AndHighHighDayTaxoFacets: +with +were +facets:DayOfYear.taxonomy # freq=3709421 freq=1524630
-AndHighHighDayTaxoFacets: +on +i +facets:DayOfYear.taxonomy # freq=4074624 freq=956148
-AndHighHighDayTaxoFacets: +as +was +facets:DayOfYear.taxonomy # freq=3925535 freq=3763623
-AndHighHighDayTaxoFacets: +date +cite +facets:DayOfYear.taxonomy # freq=2020626 freq=1741194
-AndHighHighDayTaxoFacets: +or +united +facets:DayOfYear.taxonomy # freq=1858841 freq=1196944
-AndHighHighDayTaxoFacets: +to +http +facets:DayOfYear.taxonomy # freq=6155577 freq=3493581
-AndHighHighDayTaxoFacets: +he +have +facets:DayOfYear.taxonomy # freq=1659434 freq=1297121
-AndHighHighDayTaxoFacets: +s +about +facets:DayOfYear.taxonomy # freq=1581243 freq=850283
-AndHighHighDayTaxoFacets: +this +s +facets:DayOfYear.taxonomy # freq=2224932 freq=1581243
-AndHighHighDayTaxoFacets: +is +but +facets:DayOfYear.taxonomy # freq=4074455 freq=1456553
-AndHighHighDayTaxoFacets: +web +2010 +facets:DayOfYear.taxonomy # freq=1118334 freq=950573
-AndHighHighDayTaxoFacets: +first +are +facets:DayOfYear.taxonomy # freq=1933372 freq=1877802
-AndHighHighDayTaxoFacets: +have +2008 +facets:DayOfYear.taxonomy # freq=1297121 freq=831253
-AndHighHighDayTaxoFacets: +to +no +facets:DayOfYear.taxonomy # freq=6155577 freq=1045000
-AndHighHighDayTaxoFacets: +or +2 +facets:DayOfYear.taxonomy # freq=1858841 freq=1549245
-AndHighHighDayTaxoFacets: +was +about +facets:DayOfYear.taxonomy # freq=3763623 freq=850283
-AndHighHighDayTaxoFacets: +cite +more +facets:DayOfYear.taxonomy # freq=1741194 freq=963533
-AndHighHighDayTaxoFacets: +date +their +facets:DayOfYear.taxonomy # freq=2020626 freq=1158682
-AndHighHighDayTaxoFacets: +from +work +facets:DayOfYear.taxonomy # freq=3224339 freq=853422
-AndHighHighDayTaxoFacets: +at +2010 +facets:DayOfYear.taxonomy # freq=2857534 freq=950573
-AndHighHighDayTaxoFacets: +other +last +facets:DayOfYear.taxonomy # freq=1269961 freq=958437
-AndHighHighDayTaxoFacets: +date +into +facets:DayOfYear.taxonomy # freq=2020626 freq=888684
-AndHighHighDayTaxoFacets: +they +more +facets:DayOfYear.taxonomy # freq=1021945 freq=963533
-AndHighHighDayTaxoFacets: +to +ref +facets:DayOfYear.taxonomy # freq=6155577 freq=3793973
-AndHighHighDayTaxoFacets: +be +but +facets:DayOfYear.taxonomy # freq=2051702 freq=1456553
-AndHighHighDayTaxoFacets: +or +into +facets:DayOfYear.taxonomy # freq=1858841 freq=888684
-AndHighHighDayTaxoFacets: +has +last +facets:DayOfYear.taxonomy # freq=1502961 freq=958437
-AndHighHighDayTaxoFacets: +to +time +facets:DayOfYear.taxonomy # freq=6155577 freq=1032071
-AndHighHighDayTaxoFacets: +the +some +facets:DayOfYear.taxonomy # freq=8217362 freq=839919
-AndHighHighDayTaxoFacets: +ref +united +facets:DayOfYear.taxonomy # freq=3793973 freq=1196944
-AndHighHighDayTaxoFacets: +all +last +facets:DayOfYear.taxonomy # freq=1203572 freq=958437
-AndHighHighDayTaxoFacets: +url +all +facets:DayOfYear.taxonomy # freq=1513595 freq=1203572
-AndHighHighDayTaxoFacets: +other +some +facets:DayOfYear.taxonomy # freq=1269961 freq=839919
-AndHighHighDayTaxoFacets: +cite +new +facets:DayOfYear.taxonomy # freq=1741194 freq=1657293
-AndHighHighDayTaxoFacets: +and +by +facets:DayOfYear.taxonomy # freq=7318061 freq=3826691
-AndHighHighDayTaxoFacets: +publisher +i +facets:DayOfYear.taxonomy # freq=1289029 freq=956148
-AndHighHighDayTaxoFacets: +to +publisher +facets:DayOfYear.taxonomy # freq=6155577 freq=1289029
-AndHighHighDayTaxoFacets: +the +about +facets:DayOfYear.taxonomy # freq=8217362 freq=850283
-AndHighHighDayTaxoFacets: +as +are +facets:DayOfYear.taxonomy # freq=3925535 freq=1877802
-AndHighHighDayTaxoFacets: +it +title +facets:DayOfYear.taxonomy # freq=2675552 freq=2397378
-AndHighHighDayTaxoFacets: +by +are +facets:DayOfYear.taxonomy # freq=3826691 freq=1877802
-AndHighHighDayTaxoFacets: +has +have +facets:DayOfYear.taxonomy # freq=1502961 freq=1297121
-AndHighHighDayTaxoFacets: +one +2011 +facets:DayOfYear.taxonomy # freq=1527689 freq=871410
-AndHighHighDayTaxoFacets: +are +2005 +facets:DayOfYear.taxonomy # freq=1877802 freq=835460
-AndHighHighDayTaxoFacets: +had +some +facets:DayOfYear.taxonomy # freq=1246743 freq=839919
-AndHighHighDayTaxoFacets: +by +when +facets:DayOfYear.taxonomy # freq=3826691 freq=1027487
-AndHighHighDayTaxoFacets: +it +2011 +facets:DayOfYear.taxonomy # freq=2675552 freq=871410
-AndHighHighDayTaxoFacets: +1 +they +facets:DayOfYear.taxonomy # freq=1641090 freq=1021945
-AndHighHighDayTaxoFacets: +on +their +facets:DayOfYear.taxonomy # freq=4074624 freq=1158682
-AndHighHighDayTaxoFacets: +been +10 +facets:DayOfYear.taxonomy # freq=1041183 freq=918339
-AndHighHighDayTaxoFacets: +was +only +facets:DayOfYear.taxonomy # freq=3763623 freq=875561
-AndHighHighDayTaxoFacets: +also +other +facets:DayOfYear.taxonomy # freq=1959419 freq=1269961
-AndHighHighDayTaxoFacets: +who +its +facets:DayOfYear.taxonomy # freq=1196171 freq=1173450
-AndHighHighDayTaxoFacets: +3 +may +facets:DayOfYear.taxonomy # freq=1148799 freq=1071932
-AndHighHighDayTaxoFacets: +with +2006 +facets:DayOfYear.taxonomy # freq=3709421 freq=889954
-AndHighHighDayTaxoFacets: +from +but +facets:DayOfYear.taxonomy # freq=3224339 freq=1456553
-AndHighHighDayTaxoFacets: +was +work +facets:DayOfYear.taxonomy # freq=3763623 freq=853422
-AndHighHighDayTaxoFacets: +as +also +facets:DayOfYear.taxonomy # freq=3925535 freq=1959419
-AndHighHighDayTaxoFacets: +which +into +facets:DayOfYear.taxonomy # freq=1963428 freq=888684
-AndHighHighDayTaxoFacets: +see +i +facets:DayOfYear.taxonomy # freq=1044180 freq=956148
-AndHighHighDayTaxoFacets: +have +more +facets:DayOfYear.taxonomy # freq=1297121 freq=963533
-AndHighHighDayTaxoFacets: +were +after +facets:DayOfYear.taxonomy # freq=1524630 freq=1247398
-AndHighHighDayTaxoFacets: +on +2010 +facets:DayOfYear.taxonomy # freq=4074624 freq=950573
-AndHighHighDayTaxoFacets: +is +had +facets:DayOfYear.taxonomy # freq=4074455 freq=1246743
-AndHighHighDayTaxoFacets: +he +5 +facets:DayOfYear.taxonomy # freq=1659434 freq=891361
-AndHighHighDayTaxoFacets: +first +year +facets:DayOfYear.taxonomy # freq=1933372 freq=1235231
-AndHighHighDayTaxoFacets: +not +url +facets:DayOfYear.taxonomy # freq=1713264 freq=1513595
-AndHighHighDayTaxoFacets: +first +his +facets:DayOfYear.taxonomy # freq=1933372 freq=1777780
-AndHighHighDayTaxoFacets: +date +10 +facets:DayOfYear.taxonomy # freq=2020626 freq=918339
-AndHighHighDayTaxoFacets: +was +not +facets:DayOfYear.taxonomy # freq=3763623 freq=1713264
-AndHighHighDayTaxoFacets: +and +may +facets:DayOfYear.taxonomy # freq=7318061 freq=1071932
-AndHighHighDayTaxoFacets: +no +more +facets:DayOfYear.taxonomy # freq=1045000 freq=963533
-AndHighHighDayTaxoFacets: +it +url +facets:DayOfYear.taxonomy # freq=2675552 freq=1513595
-AndHighHighDayTaxoFacets: +as +no +facets:DayOfYear.taxonomy # freq=3925535 freq=1045000
-AndHighHighDayTaxoFacets: +other +all +facets:DayOfYear.taxonomy # freq=1269961 freq=1203572
-AndHighHighDayTaxoFacets: +as +2 +facets:DayOfYear.taxonomy # freq=3925535 freq=1549245
-AndHighHighDayTaxoFacets: +for +as +facets:DayOfYear.taxonomy # freq=4380011 freq=3925535
-AndHighHighDayTaxoFacets: +for +there +facets:DayOfYear.taxonomy # freq=4380011 freq=956153
-AndHighHighDayTaxoFacets: +the +new +facets:DayOfYear.taxonomy # freq=8217362 freq=1657293
-AndHighHighDayTaxoFacets: +is +no +facets:DayOfYear.taxonomy # freq=4074455 freq=1045000
-AndHighHighDayTaxoFacets: +also +their +facets:DayOfYear.taxonomy # freq=1959419 freq=1158682
-AndHighHighDayTaxoFacets: +that +2010 +facets:DayOfYear.taxonomy # freq=2931020 freq=950573
-AndHighHighDayTaxoFacets: +s +2008 +facets:DayOfYear.taxonomy # freq=1581243 freq=831253
-AndHighHighDayTaxoFacets: +were +2009 +facets:DayOfYear.taxonomy # freq=1524630 freq=887702
-AndHighHighDayTaxoFacets: +of +after +facets:DayOfYear.taxonomy # freq=8184358 freq=1247398
-AndHighHighDayTaxoFacets: +of +an +facets:DayOfYear.taxonomy # freq=8184358 freq=2628056
-AndHighHighDayTaxoFacets: +the +10 +facets:DayOfYear.taxonomy # freq=8217362 freq=918339
-AndHighHighDayTaxoFacets: +title +web +facets:DayOfYear.taxonomy # freq=2397378 freq=1118334
-AndHighHighDayTaxoFacets: +on +they +facets:DayOfYear.taxonomy # freq=4074624 freq=1021945
-AndHighHighDayTaxoFacets: +to +have +facets:DayOfYear.taxonomy # freq=6155577 freq=1297121
-AndHighHighDayTaxoFacets: +was +its +facets:DayOfYear.taxonomy # freq=3763623 freq=1173450
-AndHighHighDayTaxoFacets: +at +time +facets:DayOfYear.taxonomy # freq=2857534 freq=1032071
-AndHighHighDayTaxoFacets: +2 +accessdate +facets:DayOfYear.taxonomy # freq=1549245 freq=1228887
-AndHighHighDayTaxoFacets: +with +united +facets:DayOfYear.taxonomy # freq=3709421 freq=1196944
-AndHighHighDayTaxoFacets: +in +about +facets:DayOfYear.taxonomy # freq=7320987 freq=850283
-AndHighHighDayTaxoFacets: +in +2005 +facets:DayOfYear.taxonomy # freq=7320987 freq=835460
-AndHighHighDayTaxoFacets: +for +last +facets:DayOfYear.taxonomy # freq=4380011 freq=958437
-AndHighHighDayTaxoFacets: +and +when +facets:DayOfYear.taxonomy # freq=7318061 freq=1027487
-AndHighHighDayTaxoFacets: +an +their +facets:DayOfYear.taxonomy # freq=2628056 freq=1158682
-AndHighHighDayTaxoFacets: +2010 +into +facets:DayOfYear.taxonomy # freq=950573 freq=888684
-AndHighHighDayTaxoFacets: +web +two +facets:DayOfYear.taxonomy # freq=1118334 freq=1104053
-AndHighHighDayTaxoFacets: +two +4 +facets:DayOfYear.taxonomy # freq=1104053 freq=986452
-AndHighHighDayTaxoFacets: +1 +there +facets:DayOfYear.taxonomy # freq=1641090 freq=956153
-AndHighHighDayTaxoFacets: +name +url +facets:DayOfYear.taxonomy # freq=2827713 freq=1513595
-AndHighHighDayTaxoFacets: +united +who +facets:DayOfYear.taxonomy # freq=1196944 freq=1196171
-AndHighHighDayTaxoFacets: +they +there +facets:DayOfYear.taxonomy # freq=1021945 freq=956153
-AndHighHighDayTaxoFacets: +http +5 +facets:DayOfYear.taxonomy # freq=3493581 freq=891361
-AndHighHighDayTaxoFacets: +not +2008 +facets:DayOfYear.taxonomy # freq=1713264 freq=831253
-AndHighHighDayTaxoFacets: +are +2009 +facets:DayOfYear.taxonomy # freq=1877802 freq=887702
-AndHighHighDayTaxoFacets: +on +may +facets:DayOfYear.taxonomy # freq=4074624 freq=1071932
-AndHighHighDayTaxoFacets: +is +are +facets:DayOfYear.taxonomy # freq=4074455 freq=1877802
-AndHighHighDayTaxoFacets: +been +there +facets:DayOfYear.taxonomy # freq=1041183 freq=956153
-AndHighHighDayTaxoFacets: +other +into +facets:DayOfYear.taxonomy # freq=1269961 freq=888684
-AndHighHighDayTaxoFacets: +be +their +facets:DayOfYear.taxonomy # freq=2051702 freq=1158682
-AndHighHighDayTaxoFacets: +new +other +facets:DayOfYear.taxonomy # freq=1657293 freq=1269961
-AndHighHighDayTaxoFacets: +its +2011 +facets:DayOfYear.taxonomy # freq=1173450 freq=871410
-AndHighHighDayTaxoFacets: +ref +3 +facets:DayOfYear.taxonomy # freq=3793973 freq=1148799
-AndHighHighDayTaxoFacets: +name +be +facets:DayOfYear.taxonomy # freq=2827713 freq=2051702
-AndHighHighDayTaxoFacets: +had +see +facets:DayOfYear.taxonomy # freq=1246743 freq=1044180
-AndHighHighDayTaxoFacets: +also +or +facets:DayOfYear.taxonomy # freq=1959419 freq=1858841
-AndHighHighDayTaxoFacets: +but +4 +facets:DayOfYear.taxonomy # freq=1456553 freq=986452
-AndHighMedDayTaxoFacets: +has +please +facets:DayOfYear.taxonomy # freq=1502961 freq=229602
-AndHighMedDayTaxoFacets: +he +battle +facets:DayOfYear.taxonomy # freq=1659434 freq=192357
-AndHighMedDayTaxoFacets: +be +century +facets:DayOfYear.taxonomy # freq=2051702 freq=385541
-AndHighMedDayTaxoFacets: +may +studio +facets:DayOfYear.taxonomy # freq=1071932 freq=101979
-AndHighMedDayTaxoFacets: +have +level +facets:DayOfYear.taxonomy # freq=1297121 freq=175382
-AndHighMedDayTaxoFacets: +web +place +facets:DayOfYear.taxonomy # freq=1118334 freq=654158
-AndHighMedDayTaxoFacets: +all +close +facets:DayOfYear.taxonomy # freq=1203572 freq=136706
-AndHighMedDayTaxoFacets: +as +chart +facets:DayOfYear.taxonomy # freq=3925535 freq=84194
-AndHighMedDayTaxoFacets: +ref +appropriate +facets:DayOfYear.taxonomy # freq=3793973 freq=135343
-AndHighMedDayTaxoFacets: +be +put +facets:DayOfYear.taxonomy # freq=2051702 freq=139882
-AndHighMedDayTaxoFacets: +and +called +facets:DayOfYear.taxonomy # freq=7318061 freq=454580
-AndHighMedDayTaxoFacets: +been +four +facets:DayOfYear.taxonomy # freq=1041183 freq=389818
-AndHighMedDayTaxoFacets: +url +whether +facets:DayOfYear.taxonomy # freq=1513595 freq=93965
-AndHighMedDayTaxoFacets: +with +day +facets:DayOfYear.taxonomy # freq=3709421 freq=402096
-AndHighMedDayTaxoFacets: +a +famous +facets:DayOfYear.taxonomy # freq=6560531 freq=139092
-AndHighMedDayTaxoFacets: +it +nature +facets:DayOfYear.taxonomy # freq=2675552 freq=107428
-AndHighMedDayTaxoFacets: +his +although +facets:DayOfYear.taxonomy # freq=1777780 freq=341432
-AndHighMedDayTaxoFacets: +1 +artists +facets:DayOfYear.taxonomy # freq=1641090 freq=107145
-AndHighMedDayTaxoFacets: +title +digital +facets:DayOfYear.taxonomy # freq=2397378 freq=82650
-AndHighMedDayTaxoFacets: +that +37 +facets:DayOfYear.taxonomy # freq=2931020 freq=126429
-AndHighMedDayTaxoFacets: +was +free +facets:DayOfYear.taxonomy # freq=3763623 freq=270199
-AndHighMedDayTaxoFacets: +5 +west +facets:DayOfYear.taxonomy # freq=891361 freq=431006
-AndHighMedDayTaxoFacets: +had +reference +facets:DayOfYear.taxonomy # freq=1246743 freq=111493
-AndHighMedDayTaxoFacets: +in +sports +facets:DayOfYear.taxonomy # freq=7320987 freq=178542
-AndHighMedDayTaxoFacets: +its +interview +facets:DayOfYear.taxonomy # freq=1173450 freq=98846
-AndHighMedDayTaxoFacets: +url +took +facets:DayOfYear.taxonomy # freq=1513595 freq=247388
-AndHighMedDayTaxoFacets: +and +los +facets:DayOfYear.taxonomy # freq=7318061 freq=145404
-AndHighMedDayTaxoFacets: +last +english +facets:DayOfYear.taxonomy # freq=958437 freq=412061
-AndHighMedDayTaxoFacets: +not +lee +facets:DayOfYear.taxonomy # freq=1713264 freq=90461
-AndHighMedDayTaxoFacets: +their +few +facets:DayOfYear.taxonomy # freq=1158682 freq=226422
-AndHighMedDayTaxoFacets: +they +round +facets:DayOfYear.taxonomy # freq=1021945 freq=122499
-AndHighMedDayTaxoFacets: +cite +area +facets:DayOfYear.taxonomy # freq=1741194 freq=559023
-AndHighMedDayTaxoFacets: +two +lake +facets:DayOfYear.taxonomy # freq=1104053 freq=131603
-AndHighMedDayTaxoFacets: +time +8 +facets:DayOfYear.taxonomy # freq=1032071 freq=635822
-AndHighMedDayTaxoFacets: +this +winning +facets:DayOfYear.taxonomy # freq=2224932 freq=95704
-AndHighMedDayTaxoFacets: +only +performed +facets:DayOfYear.taxonomy # freq=875561 freq=104044
-AndHighMedDayTaxoFacets: +when +books.google.com +facets:DayOfYear.taxonomy # freq=1027487 freq=119391
-AndHighMedDayTaxoFacets: +who +legal +facets:DayOfYear.taxonomy # freq=1196171 freq=90645
-AndHighMedDayTaxoFacets: +2009 +keep +facets:DayOfYear.taxonomy # freq=887702 freq=177996
-AndHighMedDayTaxoFacets: +http +running +facets:DayOfYear.taxonomy # freq=3493581 freq=101764
-AndHighMedDayTaxoFacets: +5 +grand +facets:DayOfYear.taxonomy # freq=891361 freq=139202
-AndHighMedDayTaxoFacets: +it +man +facets:DayOfYear.taxonomy # freq=2675552 freq=278112
-AndHighMedDayTaxoFacets: +had +entertainment +facets:DayOfYear.taxonomy # freq=1246743 freq=117931
-AndHighMedDayTaxoFacets: +with +200px +facets:DayOfYear.taxonomy # freq=3709421 freq=102661
-AndHighMedDayTaxoFacets: +had +van +facets:DayOfYear.taxonomy # freq=1246743 freq=116920
-AndHighMedDayTaxoFacets: +was +track +facets:DayOfYear.taxonomy # freq=3763623 freq=148840
-AndHighMedDayTaxoFacets: +10 +corporation +facets:DayOfYear.taxonomy # freq=918339 freq=107425
-AndHighMedDayTaxoFacets: +other +make +facets:DayOfYear.taxonomy # freq=1269961 freq=292607
-AndHighMedDayTaxoFacets: +first +results +facets:DayOfYear.taxonomy # freq=1933372 freq=137248
-AndHighMedDayTaxoFacets: +2010 +unreferenced +facets:DayOfYear.taxonomy # freq=950573 freq=107803
-AndHighMedDayTaxoFacets: +first +top +facets:DayOfYear.taxonomy # freq=1933372 freq=364628
-AndHighMedDayTaxoFacets: +his +en +facets:DayOfYear.taxonomy # freq=1777780 freq=277463
-AndHighMedDayTaxoFacets: +other +airport +facets:DayOfYear.taxonomy # freq=1269961 freq=88205
-AndHighMedDayTaxoFacets: +10 +march +facets:DayOfYear.taxonomy # freq=918339 freq=620393
-AndHighMedDayTaxoFacets: +all +recently +facets:DayOfYear.taxonomy # freq=1203572 freq=90249
-AndHighMedDayTaxoFacets: +were +genre +facets:DayOfYear.taxonomy # freq=1524630 freq=121233
-AndHighMedDayTaxoFacets: +and +program +facets:DayOfYear.taxonomy # freq=7318061 freq=173553
-AndHighMedDayTaxoFacets: +i +09 +facets:DayOfYear.taxonomy # freq=956148 freq=296300
-AndHighMedDayTaxoFacets: +to +ended +facets:DayOfYear.taxonomy # freq=6155577 freq=84664
-AndHighMedDayTaxoFacets: +not +playing +facets:DayOfYear.taxonomy # freq=1713264 freq=133330
-AndHighMedDayTaxoFacets: +time +companies +facets:DayOfYear.taxonomy # freq=1032071 freq=98905
-AndHighMedDayTaxoFacets: +to +living +facets:DayOfYear.taxonomy # freq=6155577 freq=181427
-AndHighMedDayTaxoFacets: +of +silver +facets:DayOfYear.taxonomy # freq=8184358 freq=85967
-AndHighMedDayTaxoFacets: +in +images +facets:DayOfYear.taxonomy # freq=7320987 freq=125154
-AndHighMedDayTaxoFacets: +2008 +debate +facets:DayOfYear.taxonomy # freq=831253 freq=177827
-AndHighMedDayTaxoFacets: +some +los +facets:DayOfYear.taxonomy # freq=839919 freq=145404
-AndHighMedDayTaxoFacets: +2008 +simply +facets:DayOfYear.taxonomy # freq=831253 freq=84090
-AndHighMedDayTaxoFacets: +first +producer +facets:DayOfYear.taxonomy # freq=1933372 freq=137098
-AndHighMedDayTaxoFacets: +last +seven +facets:DayOfYear.taxonomy # freq=958437 freq=134402
-AndHighMedDayTaxoFacets: +more +soon +facets:DayOfYear.taxonomy # freq=963533 freq=123657
-AndHighMedDayTaxoFacets: +date +talk +facets:DayOfYear.taxonomy # freq=2020626 freq=364194
-AndHighMedDayTaxoFacets: +its +49 +facets:DayOfYear.taxonomy # freq=1173450 freq=103612
-AndHighMedDayTaxoFacets: +publisher +car +facets:DayOfYear.taxonomy # freq=1289029 freq=121250
-AndHighMedDayTaxoFacets: +were +v +facets:DayOfYear.taxonomy # freq=1524630 freq=284318
-AndHighMedDayTaxoFacets: +more +says +facets:DayOfYear.taxonomy # freq=963533 freq=84589
-AndHighMedDayTaxoFacets: +3 +man +facets:DayOfYear.taxonomy # freq=1148799 freq=278112
-AndHighMedDayTaxoFacets: +but +1974 +facets:DayOfYear.taxonomy # freq=1456553 freq=132835
-AndHighMedDayTaxoFacets: +but +02 +facets:DayOfYear.taxonomy # freq=1456553 freq=319783
-AndHighMedDayTaxoFacets: +see +historic +facets:DayOfYear.taxonomy # freq=1044180 freq=112292
-AndHighMedDayTaxoFacets: +which +wife +facets:DayOfYear.taxonomy # freq=1963428 freq=130807
-AndHighMedDayTaxoFacets: +1 +grand +facets:DayOfYear.taxonomy # freq=1641090 freq=139202
-AndHighMedDayTaxoFacets: +it +real +facets:DayOfYear.taxonomy # freq=2675552 freq=151505
-AndHighMedDayTaxoFacets: +its +development +facets:DayOfYear.taxonomy # freq=1173450 freq=230286
-AndHighMedDayTaxoFacets: +3 +office +facets:DayOfYear.taxonomy # freq=1148799 freq=225338
-AndHighMedDayTaxoFacets: +10 +class +facets:DayOfYear.taxonomy # freq=918339 freq=556838
-AndHighMedDayTaxoFacets: +not +abbr +facets:DayOfYear.taxonomy # freq=1713264 freq=96135
-AndHighMedDayTaxoFacets: +accessdate +hand +facets:DayOfYear.taxonomy # freq=1228887 freq=119947
-AndHighMedDayTaxoFacets: +2011 +trade +facets:DayOfYear.taxonomy # freq=871410 freq=106384
-AndHighMedDayTaxoFacets: +that +love +facets:DayOfYear.taxonomy # freq=2931020 freq=177242
-AndHighMedDayTaxoFacets: +from +took +facets:DayOfYear.taxonomy # freq=3224339 freq=247388
-AndHighMedDayTaxoFacets: +united +id +facets:DayOfYear.taxonomy # freq=1196944 freq=579566
-AndHighMedDayTaxoFacets: +s +mi +facets:DayOfYear.taxonomy # freq=1581243 freq=97131
-AndHighMedDayTaxoFacets: +as +young +facets:DayOfYear.taxonomy # freq=3925535 freq=196428
-AndHighMedDayTaxoFacets: +3 +opening +facets:DayOfYear.taxonomy # freq=1148799 freq=84576
-AndHighMedDayTaxoFacets: +other +european +facets:DayOfYear.taxonomy # freq=1269961 freq=193975
-AndHighMedDayTaxoFacets: +ref +chart +facets:DayOfYear.taxonomy # freq=3793973 freq=84194
-AndHighMedDayTaxoFacets: +about +thought +facets:DayOfYear.taxonomy # freq=850283 freq=108963
-AndHighMedDayTaxoFacets: +for +should +facets:DayOfYear.taxonomy # freq=4380011 freq=401379
-AndHighMedDayTaxoFacets: +united +lead +facets:DayOfYear.taxonomy # freq=1196944 freq=141336
-AndHighMedDayTaxoFacets: +this +movie +facets:DayOfYear.taxonomy # freq=2224932 freq=133291
-AndHighMedDayTaxoFacets: +2011 +winning +facets:DayOfYear.taxonomy # freq=871410 freq=95704
-AndHighMedDayTaxoFacets: +new +shows +facets:DayOfYear.taxonomy # freq=1657293 freq=131923
-AndHighMedDayTaxoFacets: +no +him +facets:DayOfYear.taxonomy # freq=1045000 freq=507350
-AndHighMedDayTaxoFacets: +has +always +facets:DayOfYear.taxonomy # freq=1502961 freq=112388
-AndHighMedDayTaxoFacets: +ref +above +facets:DayOfYear.taxonomy # freq=3793973 freq=246135
-AndHighMedDayTaxoFacets: +have +uses +facets:DayOfYear.taxonomy # freq=1297121 freq=134331
-AndHighMedDayTaxoFacets: +who +80 +facets:DayOfYear.taxonomy # freq=1196171 freq=104865
-AndHighMedDayTaxoFacets: +2008 +series +facets:DayOfYear.taxonomy # freq=831253 freq=521861
-AndHighMedDayTaxoFacets: +ref +40 +facets:DayOfYear.taxonomy # freq=3793973 freq=221687
-AndHighMedDayTaxoFacets: +when +second +facets:DayOfYear.taxonomy # freq=1027487 freq=505575
-AndHighMedDayTaxoFacets: +at +parliament +facets:DayOfYear.taxonomy # freq=2857534 freq=127008
-AndHighMedDayTaxoFacets: +were +pacific +facets:DayOfYear.taxonomy # freq=1524630 freq=107648
-AndHighMedDayTaxoFacets: +2 +recent +facets:DayOfYear.taxonomy # freq=1549245 freq=113385
-AndHighMedDayTaxoFacets: +http +close +facets:DayOfYear.taxonomy # freq=3493581 freq=136706
-AndHighMedDayTaxoFacets: +has +power +facets:DayOfYear.taxonomy # freq=1502961 freq=262586
-AndHighMedDayTaxoFacets: +or +words +facets:DayOfYear.taxonomy # freq=1858841 freq=104783
-AndHighMedDayTaxoFacets: +after +mary +facets:DayOfYear.taxonomy # freq=1247398 freq=96445
-AndHighMedDayTaxoFacets: +3 +state +facets:DayOfYear.taxonomy # freq=1148799 freq=702598
-AndHighMedDayTaxoFacets: +its +directed +facets:DayOfYear.taxonomy # freq=1173450 freq=86592
-AndHighMedDayTaxoFacets: +more +army +facets:DayOfYear.taxonomy # freq=963533 freq=228105
-AndHighMedDayTaxoFacets: +see +genre +facets:DayOfYear.taxonomy # freq=1044180 freq=121233
-AndHighMedDayTaxoFacets: +5 +natural +facets:DayOfYear.taxonomy # freq=891361 freq=125503
-AndHighMedDayTaxoFacets: +into +ship +facets:DayOfYear.taxonomy # freq=888684 freq=113012
-AndHighMedDayTaxoFacets: +2005 +construction +facets:DayOfYear.taxonomy # freq=835460 freq=124179
-AndHighMedDayTaxoFacets: +some +found +facets:DayOfYear.taxonomy # freq=839919 freq=313247
-AndHighMedDayTaxoFacets: +2 +actor +facets:DayOfYear.taxonomy # freq=1549245 freq=144573
-AndHighMedDayTaxoFacets: +and +owned +facets:DayOfYear.taxonomy # freq=7318061 freq=93981
-AndHighMedDayTaxoFacets: +which +authority +facets:DayOfYear.taxonomy # freq=1963428 freq=85540
-AndHighMedDayTaxoFacets: +have +r +facets:DayOfYear.taxonomy # freq=1297121 freq=296283
-AndHighMedDayTaxoFacets: +is +approximately +facets:DayOfYear.taxonomy # freq=4074455 freq=88426
-AndHighMedDayTaxoFacets: +he +deletion +facets:DayOfYear.taxonomy # freq=1659434 freq=166633
-AndHighMedDayTaxoFacets: +and +jean +facets:DayOfYear.taxonomy # freq=7318061 freq=84299
-AndHighMedDayTaxoFacets: +have +43 +facets:DayOfYear.taxonomy # freq=1297121 freq=115496
-AndHighMedDayTaxoFacets: +only +daily +facets:DayOfYear.taxonomy # freq=875561 freq=111717
-AndHighMedDayTaxoFacets: +united +zealand +facets:DayOfYear.taxonomy # freq=1196944 freq=92761
-AndHighMedDayTaxoFacets: +also +read +facets:DayOfYear.taxonomy # freq=1959419 freq=86513
-AndHighMedDayTaxoFacets: +are +division +facets:DayOfYear.taxonomy # freq=1877802 freq=182624
-AndHighMedDayTaxoFacets: +for +seat +facets:DayOfYear.taxonomy # freq=4380011 freq=91288
-AndHighMedDayTaxoFacets: +2005 +hand +facets:DayOfYear.taxonomy # freq=835460 freq=119947
-AndHighMedDayTaxoFacets: +publisher +usually +facets:DayOfYear.taxonomy # freq=1289029 freq=176058
-AndHighMedDayTaxoFacets: +from +teams +facets:DayOfYear.taxonomy # freq=3224339 freq=105245
-AndHighMedDayTaxoFacets: +in +wife +facets:DayOfYear.taxonomy # freq=7320987 freq=130807
-AndHighMedDayTaxoFacets: +2006 +james +facets:DayOfYear.taxonomy # freq=889954 freq=281597
-AndHighMedDayTaxoFacets: +2005 +found +facets:DayOfYear.taxonomy # freq=835460 freq=313247
-AndHighMedDayTaxoFacets: +after +replaced +facets:DayOfYear.taxonomy # freq=1247398 freq=112506
-AndHighMedDayTaxoFacets: +5 +played +facets:DayOfYear.taxonomy # freq=891361 freq=248191
-AndHighMedDayTaxoFacets: +last +1945 +facets:DayOfYear.taxonomy # freq=958437 freq=106881
-AndHighMedDayTaxoFacets: +not +william +facets:DayOfYear.taxonomy # freq=1713264 freq=284592
-AndHighMedDayTaxoFacets: +may +changed +facets:DayOfYear.taxonomy # freq=1071932 freq=112032
-AndHighMedDayTaxoFacets: +one +might +facets:DayOfYear.taxonomy # freq=1527689 freq=114290
-AndHighMedDayTaxoFacets: +one +1966 +facets:DayOfYear.taxonomy # freq=1527689 freq=106672
-AndHighMedDayTaxoFacets: +2006 +mother +facets:DayOfYear.taxonomy # freq=889954 freq=122930
-AndHighMedDayTaxoFacets: +no +hi +facets:DayOfYear.taxonomy # freq=1045000 freq=91593
-AndHighMedDayTaxoFacets: +they +my +facets:DayOfYear.taxonomy # freq=1021945 freq=274256
-AndHighMedDayTaxoFacets: +it +london +facets:DayOfYear.taxonomy # freq=2675552 freq=348918
-AndHighMedDayTaxoFacets: +but +according +facets:DayOfYear.taxonomy # freq=1456553 freq=256949
-AndHighMedDayTaxoFacets: +an +results +facets:DayOfYear.taxonomy # freq=2628056 freq=137248
-AndHighMedDayTaxoFacets: +from +you +facets:DayOfYear.taxonomy # freq=3224339 freq=461587
-AndHighMedDayTaxoFacets: +web +single +facets:DayOfYear.taxonomy # freq=1118334 freq=283824
-AndHighMedDayTaxoFacets: +two +old +facets:DayOfYear.taxonomy # freq=1104053 freq=381809
-AndHighMedDayTaxoFacets: +some +daughter +facets:DayOfYear.taxonomy # freq=839919 freq=103883
-AndHighMedDayTaxoFacets: +url +various +facets:DayOfYear.taxonomy # freq=1513595 freq=224593
-AndHighMedDayTaxoFacets: +have +would +facets:DayOfYear.taxonomy # freq=1297121 freq=690480
-AndHighMedDayTaxoFacets: +to +released +facets:DayOfYear.taxonomy # freq=6155577 freq=322473
-AndHighMedDayTaxoFacets: +had +refer +facets:DayOfYear.taxonomy # freq=1246743 freq=110259
-AndHighMedDayTaxoFacets: +url +article +facets:DayOfYear.taxonomy # freq=1513595 freq=610650
-AndHighMedDayTaxoFacets: +when +designed +facets:DayOfYear.taxonomy # freq=1027487 freq=118748
-AndHighMedDayTaxoFacets: +which +party +facets:DayOfYear.taxonomy # freq=1963428 freq=394410
-AndHighMedDayTaxoFacets: +a +florida +facets:DayOfYear.taxonomy # freq=6560531 freq=92166
-AndHighMedDayTaxoFacets: +the +image_caption +facets:DayOfYear.taxonomy # freq=8217362 freq=87977
-AndHighMedDayTaxoFacets: +last +width +facets:DayOfYear.taxonomy # freq=958437 freq=172609
-AndHighMedDayTaxoFacets: +may +r +facets:DayOfYear.taxonomy # freq=1071932 freq=296283
-AndHighMedDayTaxoFacets: +at +inside +facets:DayOfYear.taxonomy # freq=2857534 freq=84712
-AndHighMedDayTaxoFacets: +3 +p +facets:DayOfYear.taxonomy # freq=1148799 freq=616159
-AndHighMedDayTaxoFacets: +2009 +imperial +facets:DayOfYear.taxonomy # freq=887702 freq=86508
-AndHighMedDayTaxoFacets: +for +access +facets:DayOfYear.taxonomy # freq=4380011 freq=100041
-AndHighMedDayTaxoFacets: +some +former +facets:DayOfYear.taxonomy # freq=839919 freq=332750
-AndHighMedDayTaxoFacets: +url +important +facets:DayOfYear.taxonomy # freq=1513595 freq=195851
-AndHighMedDayTaxoFacets: +which +recorded +facets:DayOfYear.taxonomy # freq=1963428 freq=160249
-AndHighMedDayTaxoFacets: +of +family +facets:DayOfYear.taxonomy # freq=8184358 freq=387175
-AndHighMedDayTaxoFacets: +2 +family +facets:DayOfYear.taxonomy # freq=1549245 freq=387175
-AndHighMedDayTaxoFacets: +was +old +facets:DayOfYear.taxonomy # freq=3763623 freq=381809
-AndHighMedDayTaxoFacets: +more +jpg +facets:DayOfYear.taxonomy # freq=963533 freq=322278
-AndHighMedDayTaxoFacets: +2005 +1979 +facets:DayOfYear.taxonomy # freq=835460 freq=145407
-AndHighMedDayTaxoFacets: +are +became +facets:DayOfYear.taxonomy # freq=1877802 freq=465594
-AndHighMedDayTaxoFacets: +new +products +facets:DayOfYear.taxonomy # freq=1657293 freq=88448
-AndHighMedDayTaxoFacets: +first +mexico +facets:DayOfYear.taxonomy # freq=1933372 freq=88689
-AndHighMedDayTaxoFacets: +10 +nbsp +facets:DayOfYear.taxonomy # freq=918339 freq=506054
-AndHighMedDayTaxoFacets: +by +25 +facets:DayOfYear.taxonomy # freq=3826691 freq=491957
-AndHighMedDayTaxoFacets: +was +language +facets:DayOfYear.taxonomy # freq=3763623 freq=416771
-AndHighMedDayTaxoFacets: +and +future +facets:DayOfYear.taxonomy # freq=7318061 freq=136421
-AndHighMedDayTaxoFacets: +their +flight +facets:DayOfYear.taxonomy # freq=1158682 freq=84316
-AndHighMedDayTaxoFacets: +2011 +hold +facets:DayOfYear.taxonomy # freq=871410 freq=82579
-AndHighMedDayTaxoFacets: +there +programs +facets:DayOfYear.taxonomy # freq=956153 freq=83974
-AndHighMedDayTaxoFacets: +after +original +facets:DayOfYear.taxonomy # freq=1247398 freq=323521
-AndHighMedDayTaxoFacets: +only +ten +facets:DayOfYear.taxonomy # freq=875561 freq=114388
-AndHighMedDayTaxoFacets: +to +traditional +facets:DayOfYear.taxonomy # freq=6155577 freq=110425
-AndHighMedDayTaxoFacets: +also +centre +facets:DayOfYear.taxonomy # freq=1959419 freq=159597
-AndHighMedDayTaxoFacets: +all +isbn +facets:DayOfYear.taxonomy # freq=1203572 freq=467574
-AndHighMedDayTaxoFacets: +this +direct +facets:DayOfYear.taxonomy # freq=2224932 freq=82292
-AndHighMedDayTaxoFacets: +http +earlier +facets:DayOfYear.taxonomy # freq=3493581 freq=100372
-AndHighMedDayTaxoFacets: +cite +system +facets:DayOfYear.taxonomy # freq=1741194 freq=412862
-AndHighMedDayTaxoFacets: +were +library +facets:DayOfYear.taxonomy # freq=1524630 freq=138468
-AndHighMedDayTaxoFacets: +first +alone +facets:DayOfYear.taxonomy # freq=1933372 freq=93166
-AndHighMedDayTaxoFacets: +new +century +facets:DayOfYear.taxonomy # freq=1657293 freq=385541
-AndHighMedDayTaxoFacets: +s +reached +facets:DayOfYear.taxonomy # freq=1581243 freq=89854
-AndHighMedDayTaxoFacets: +united +le +facets:DayOfYear.taxonomy # freq=1196944 freq=84979
-AndHighMedDayTaxoFacets: +url +auto +facets:DayOfYear.taxonomy # freq=1513595 freq=103107
-AndHighMedDayTaxoFacets: +3 +practice +facets:DayOfYear.taxonomy # freq=1148799 freq=93287
-AndHighMedDayTaxoFacets: +http +working +facets:DayOfYear.taxonomy # freq=3493581 freq=144617
-AndHighMedDayTaxoFacets: +in +fire +facets:DayOfYear.taxonomy # freq=7320987 freq=133712
-AndHighMedDayTaxoFacets: +10 +52 +facets:DayOfYear.taxonomy # freq=918339 freq=108395
-AndHighMedDayTaxoFacets: +more +singer +facets:DayOfYear.taxonomy # freq=963533 freq=114006
-AndHighMedDayTaxoFacets: +new +low +facets:DayOfYear.taxonomy # freq=1657293 freq=157852
-AndHighMedDayTaxoFacets: +with +previously +facets:DayOfYear.taxonomy # freq=3709421 freq=96083
-AndHighMedDayTaxoFacets: +first +original +facets:DayOfYear.taxonomy # freq=1933372 freq=323521
-AndHighMedDayTaxoFacets: +2008 +wikitable +facets:DayOfYear.taxonomy # freq=831253 freq=210990
-AndHighMedDayTaxoFacets: +http +can +facets:DayOfYear.taxonomy # freq=3493581 freq=765163
-AndHighMedDayTaxoFacets: +year +1965 +facets:DayOfYear.taxonomy # freq=1235231 freq=104539
-AndHighMedDayTaxoFacets: +have +mother +facets:DayOfYear.taxonomy # freq=1297121 freq=122930
-AndHighMedDayTaxoFacets: +states +lived +facets:DayOfYear.taxonomy # freq=1034872 freq=91327
-AndHighMedDayTaxoFacets: +to +me +facets:DayOfYear.taxonomy # freq=6155577 freq=229204
-AndHighMedDayTaxoFacets: +4 +race +facets:DayOfYear.taxonomy # freq=986452 freq=148763
-AndHighMedDayTaxoFacets: +of +54 +facets:DayOfYear.taxonomy # freq=8184358 freq=101462
-AndHighMedDayTaxoFacets: +some +series +facets:DayOfYear.taxonomy # freq=839919 freq=521861
-AndHighMedDayTaxoFacets: +2 +big +facets:DayOfYear.taxonomy # freq=1549245 freq=163394
-AndHighMedDayTaxoFacets: +some +without +facets:DayOfYear.taxonomy # freq=839919 freq=249926
-AndHighMedDayTaxoFacets: +2011 +font +facets:DayOfYear.taxonomy # freq=871410 freq=269439
-AndHighMedDayTaxoFacets: +http +votes +facets:DayOfYear.taxonomy # freq=3493581 freq=93844
-AndHighMedDayTaxoFacets: +2009 +19th +facets:DayOfYear.taxonomy # freq=887702 freq=93290
-AndHighMedDayTaxoFacets: +an +central +facets:DayOfYear.taxonomy # freq=2628056 freq=272531
-AndHighMedDayTaxoFacets: +some +1959 +facets:DayOfYear.taxonomy # freq=839919 freq=87097
-AndHighMedDayTaxoFacets: +cite +out +facets:DayOfYear.taxonomy # freq=1741194 freq=733775
-AndHighMedDayTaxoFacets: +was +cross +facets:DayOfYear.taxonomy # freq=3763623 freq=127216
-AndHighMedDayTaxoFacets: +3 +1950 +facets:DayOfYear.taxonomy # freq=1148799 freq=89746
-AndHighMedDayTaxoFacets: +there +market +facets:DayOfYear.taxonomy # freq=956153 freq=118467
-AndHighMedDayTaxoFacets: +new +mid +facets:DayOfYear.taxonomy # freq=1657293 freq=126355
-AndHighMedDayTaxoFacets: +or +sent +facets:DayOfYear.taxonomy # freq=1858841 freq=103620
-AndHighMedDayTaxoFacets: +may +pp +facets:DayOfYear.taxonomy # freq=1071932 freq=204742
-AndHighMedDayTaxoFacets: +the +flagicon +facets:DayOfYear.taxonomy # freq=8217362 freq=107428
-AndHighMedDayTaxoFacets: +who +genre +facets:DayOfYear.taxonomy # freq=1196171 freq=121233
-AndHighMedDayTaxoFacets: +last +library +facets:DayOfYear.taxonomy # freq=958437 freq=138468
-AndHighMedDayTaxoFacets: +and +none +facets:DayOfYear.taxonomy # freq=7318061 freq=100192
-AndHighMedDayTaxoFacets: +an +majority +facets:DayOfYear.taxonomy # freq=2628056 freq=105058
-AndHighMedDayTaxoFacets: +it +religion +facets:DayOfYear.taxonomy # freq=2675552 freq=96655
-AndHighMedDayTaxoFacets: +first +brown +facets:DayOfYear.taxonomy # freq=1933372 freq=116178
-AndHighMedDayTaxoFacets: +more +standard +facets:DayOfYear.taxonomy # freq=963533 freq=185039
-AndHighMedDayTaxoFacets: +into +process +facets:DayOfYear.taxonomy # freq=888684 freq=152588
-AndHighMedDayTaxoFacets: +for +website +facets:DayOfYear.taxonomy # freq=4380011 freq=435941
-AndHighMedDayTaxoFacets: +name +parts +facets:DayOfYear.taxonomy # freq=2827713 freq=123891
-AndHighMedDayTaxoFacets: +for +few +facets:DayOfYear.taxonomy # freq=4380011 freq=226422
-AndHighMedDayTaxoFacets: +web +available +facets:DayOfYear.taxonomy # freq=1118334 freq=175514
-AndHighMedDayTaxoFacets: +other +christian +facets:DayOfYear.taxonomy # freq=1269961 freq=140312
-AndHighMedDayTaxoFacets: +2 +imperial +facets:DayOfYear.taxonomy # freq=1549245 freq=86508
-AndHighMedDayTaxoFacets: +at +space +facets:DayOfYear.taxonomy # freq=2857534 freq=163436
-AndHighMedDayTaxoFacets: +but +paul +facets:DayOfYear.taxonomy # freq=1456553 freq=207229
-AndHighMedDayTaxoFacets: +into +70 +facets:DayOfYear.taxonomy # freq=888684 freq=90305
-AndHighMedDayTaxoFacets: +s +mdash +facets:DayOfYear.taxonomy # freq=1581243 freq=111708
-AndHighMedDayTaxoFacets: +5 +brown +facets:DayOfYear.taxonomy # freq=891361 freq=116178
-AndHighMedDayTaxoFacets: +2005 +hill +facets:DayOfYear.taxonomy # freq=835460 freq=133714
-AndHighMedDayTaxoFacets: +2006 +eight +facets:DayOfYear.taxonomy # freq=889954 freq=106268
-AndHighMedDayTaxoFacets: +two +era +facets:DayOfYear.taxonomy # freq=1104053 freq=95989
-AndHighMedDayTaxoFacets: +time +100 +facets:DayOfYear.taxonomy # freq=1032071 freq=268978
-AndHighMedDayTaxoFacets: +title +70 +facets:DayOfYear.taxonomy # freq=2397378 freq=90305
-AndHighMedDayTaxoFacets: +3 +empire +facets:DayOfYear.taxonomy # freq=1148799 freq=143207
-AndHighMedDayTaxoFacets: +in +di +facets:DayOfYear.taxonomy # freq=7320987 freq=83139
-AndHighMedDayTaxoFacets: +and +included +facets:DayOfYear.taxonomy # freq=7318061 freq=216978
-AndHighMedDayTaxoFacets: +that +play +facets:DayOfYear.taxonomy # freq=2931020 freq=210199
-AndHighMedDayTaxoFacets: +an +might +facets:DayOfYear.taxonomy # freq=2628056 freq=114290
-AndHighMedDayTaxoFacets: +other +country +facets:DayOfYear.taxonomy # freq=1269961 freq=420052
-AndHighMedDayTaxoFacets: +also +success +facets:DayOfYear.taxonomy # freq=1959419 freq=112195
-AndHighMedDayTaxoFacets: +also +27 +facets:DayOfYear.taxonomy # freq=1959419 freq=383042
-AndHighMedDayTaxoFacets: +more +stations +facets:DayOfYear.taxonomy # freq=963533 freq=92011
-AndHighMedDayTaxoFacets: +they +system +facets:DayOfYear.taxonomy # freq=1021945 freq=412862
-AndHighMedDayTaxoFacets: +in +31 +facets:DayOfYear.taxonomy # freq=7320987 freq=298349
-AndHighMedDayTaxoFacets: +all +provided +facets:DayOfYear.taxonomy # freq=1203572 freq=110088
-AndHighMedDayTaxoFacets: +i +u.s +facets:DayOfYear.taxonomy # freq=956148 freq=428534
-AndHighMedDayTaxoFacets: +a +certain +facets:DayOfYear.taxonomy # freq=6560531 freq=105714
-AndHighMedDayTaxoFacets: +his +summary +facets:DayOfYear.taxonomy # freq=1777780 freq=106702
-AndHighMedDayTaxoFacets: +2009 +america +facets:DayOfYear.taxonomy # freq=887702 freq=240374
-AndHighMedDayTaxoFacets: +1 +chicago +facets:DayOfYear.taxonomy # freq=1641090 freq=117756
-AndHighMedDayTaxoFacets: +other +2000 +facets:DayOfYear.taxonomy # freq=1269961 freq=499639
-AndHighMedDayTaxoFacets: +year +men +facets:DayOfYear.taxonomy # freq=1235231 freq=182445
-AndHighMedDayTaxoFacets: +4 +upon +facets:DayOfYear.taxonomy # freq=986452 freq=169174
-AndHighMedDayTaxoFacets: +in +seems +facets:DayOfYear.taxonomy # freq=7320987 freq=83963
-AndHighMedDayTaxoFacets: +he +bank +facets:DayOfYear.taxonomy # freq=1659434 freq=88080
-AndHighMedDayTaxoFacets: +name +both +facets:DayOfYear.taxonomy # freq=2827713 freq=534900
-AndHighMedDayTaxoFacets: +publisher +e +facets:DayOfYear.taxonomy # freq=1289029 freq=408741
-AndHighMedDayTaxoFacets: +who +computer +facets:DayOfYear.taxonomy # freq=1196171 freq=126524
-AndHighMedDayTaxoFacets: +about +type +facets:DayOfYear.taxonomy # freq=850283 freq=318210
-AndHighMedDayTaxoFacets: +this +people +facets:DayOfYear.taxonomy # freq=2224932 freq=790960
-AndHighMedDayTaxoFacets: +their +1978 +facets:DayOfYear.taxonomy # freq=1158682 freq=135223
-AndHighMedDayTaxoFacets: +url +museum +facets:DayOfYear.taxonomy # freq=1513595 freq=135250
-AndHighMedDayTaxoFacets: +4 +least +facets:DayOfYear.taxonomy # freq=986452 freq=146209
-AndHighMedDayTaxoFacets: +2011 +money +facets:DayOfYear.taxonomy # freq=871410 freq=100440
-AndHighMedDayTaxoFacets: +first +referred +facets:DayOfYear.taxonomy # freq=1933372 freq=94811
-AndHighMedDayTaxoFacets: +he +20 +facets:DayOfYear.taxonomy # freq=1659434 freq=624967
-AndHighMedDayTaxoFacets: +were +events +facets:DayOfYear.taxonomy # freq=1524630 freq=158248
-AndHighMedDayTaxoFacets: +it +because +facets:DayOfYear.taxonomy # freq=2675552 freq=413003
-AndHighMedDayTaxoFacets: +accessdate +large +facets:DayOfYear.taxonomy # freq=1228887 freq=308888
-AndHighMedDayTaxoFacets: +there +usa +facets:DayOfYear.taxonomy # freq=956153 freq=191220
-AndHighMedDayTaxoFacets: +he +association +facets:DayOfYear.taxonomy # freq=1659434 freq=247156
-AndHighMedDayTaxoFacets: +2010 +rest +facets:DayOfYear.taxonomy # freq=950573 freq=95113
-AndHighMedDayTaxoFacets: +he +face +facets:DayOfYear.taxonomy # freq=1659434 freq=95144
-AndHighMedDayTaxoFacets: +title +out +facets:DayOfYear.taxonomy # freq=2397378 freq=733775
-AndHighMedDayTaxoFacets: +first +christian +facets:DayOfYear.taxonomy # freq=1933372 freq=140312
-AndHighMedDayTaxoFacets: +has +april +facets:DayOfYear.taxonomy # freq=1502961 freq=587542
-AndHighMedDayTaxoFacets: +in +very +facets:DayOfYear.taxonomy # freq=7320987 freq=354898
-AndHighMedDayTaxoFacets: +no +century +facets:DayOfYear.taxonomy # freq=1045000 freq=385541
-AndHighMedDayTaxoFacets: +accessdate +recording +facets:DayOfYear.taxonomy # freq=1228887 freq=90757
-AndHighMedDayTaxoFacets: +by +55 +facets:DayOfYear.taxonomy # freq=3826691 freq=110526
-AndHighMedDayTaxoFacets: +2005 +54 +facets:DayOfYear.taxonomy # freq=835460 freq=101462
-AndHighMedDayTaxoFacets: +this +x +facets:DayOfYear.taxonomy # freq=2224932 freq=272695
-AndHighMedDayTaxoFacets: +url +following +facets:DayOfYear.taxonomy # freq=1513595 freq=416515
-AndHighMedDayTaxoFacets: +s +per +facets:DayOfYear.taxonomy # freq=1581243 freq=283568
-AndHighMedDayTaxoFacets: +2005 +bureau +facets:DayOfYear.taxonomy # freq=835460 freq=83671
-AndHighMedDayTaxoFacets: +1 +09 +facets:DayOfYear.taxonomy # freq=1641090 freq=296300
-AndHighMedDayTaxoFacets: +title +buildings +facets:DayOfYear.taxonomy # freq=2397378 freq=89046
-AndHighMedDayTaxoFacets: +by +appears +facets:DayOfYear.taxonomy # freq=3826691 freq=104511
-AndHighMedDayTaxoFacets: +year +taken +facets:DayOfYear.taxonomy # freq=1235231 freq=166217
-AndHighMedDayTaxoFacets: +on +size +facets:DayOfYear.taxonomy # freq=4074624 freq=237662
-AndHighMedDayTaxoFacets: +2005 +thomas +facets:DayOfYear.taxonomy # freq=835460 freq=191625
-AndHighMedDayTaxoFacets: +2008 +chicago +facets:DayOfYear.taxonomy # freq=831253 freq=117756
-AndHighMedDayTaxoFacets: +2 +1991 +facets:DayOfYear.taxonomy # freq=1549245 freq=207589
-AndHighMedDayTaxoFacets: +only +2003 +facets:DayOfYear.taxonomy # freq=875561 freq=456990
-AndHighMedDayTaxoFacets: +their +found +facets:DayOfYear.taxonomy # freq=1158682 freq=313247
-AndHighMedDayTaxoFacets: +for +long +facets:DayOfYear.taxonomy # freq=4380011 freq=385787
-AndHighMedDayTaxoFacets: +2011 +low +facets:DayOfYear.taxonomy # freq=871410 freq=157852
-AndHighMedDayTaxoFacets: +for +iii +facets:DayOfYear.taxonomy # freq=4380011 freq=123618
-AndHighMedDayTaxoFacets: +is +1990s +facets:DayOfYear.taxonomy # freq=4074455 freq=83166
-AndHighMedDayTaxoFacets: +some +instead +facets:DayOfYear.taxonomy # freq=839919 freq=149345
-AndHighMedDayTaxoFacets: +publisher +historical +facets:DayOfYear.taxonomy # freq=1289029 freq=159636
-AndHighMedDayTaxoFacets: +are +please +facets:DayOfYear.taxonomy # freq=1877802 freq=229602
-AndHighMedDayTaxoFacets: +who +brown +facets:DayOfYear.taxonomy # freq=1196171 freq=116178
-AndHighMedDayTaxoFacets: +an +professional +facets:DayOfYear.taxonomy # freq=2628056 freq=138520
-AndHighMedDayTaxoFacets: +name +security +facets:DayOfYear.taxonomy # freq=2827713 freq=89382
-AndHighMedDayTaxoFacets: +name +8 +facets:DayOfYear.taxonomy # freq=2827713 freq=635822
-AndHighMedDayTaxoFacets: +from +china +facets:DayOfYear.taxonomy # freq=3224339 freq=130849
-AndHighMedDayTaxoFacets: +a +early +facets:DayOfYear.taxonomy # freq=6560531 freq=482793
-AndHighMedDayTaxoFacets: +cite +changes +facets:DayOfYear.taxonomy # freq=1741194 freq=105677
-AndHighMedDayTaxoFacets: +it +debate +facets:DayOfYear.taxonomy # freq=2675552 freq=177827
-AndHighMedDayTaxoFacets: +by +total +facets:DayOfYear.taxonomy # freq=3826691 freq=230013
-AndHighMedDayTaxoFacets: +it +event +facets:DayOfYear.taxonomy # freq=2675552 freq=114340
-AndHighMedDayTaxoFacets: +2005 +cup +facets:DayOfYear.taxonomy # freq=835460 freq=141942
-AndHighMedDayTaxoFacets: +publisher +1950 +facets:DayOfYear.taxonomy # freq=1289029 freq=89746
-AndHighMedDayTaxoFacets: +no +christian +facets:DayOfYear.taxonomy # freq=1045000 freq=140312
-AndHighMedDayTaxoFacets: +from +forces +facets:DayOfYear.taxonomy # freq=3224339 freq=152939
-AndHighMedDayTaxoFacets: +when +between +facets:DayOfYear.taxonomy # freq=1027487 freq=630650
-AndHighMedDayTaxoFacets: +its +words +facets:DayOfYear.taxonomy # freq=1173450 freq=104783
-AndHighMedDayTaxoFacets: +a +she +facets:DayOfYear.taxonomy # freq=6560531 freq=426267
-AndHighMedDayTaxoFacets: +s +align +facets:DayOfYear.taxonomy # freq=1581243 freq=300455
-AndHighMedDayTaxoFacets: +http +served +facets:DayOfYear.taxonomy # freq=3493581 freq=188351
-AndHighMedDayTaxoFacets: +of +finally +facets:DayOfYear.taxonomy # freq=8184358 freq=99185
-AndHighMedDayTaxoFacets: +some +pre +facets:DayOfYear.taxonomy # freq=839919 freq=90549
-AndHighMedDayTaxoFacets: +which +am +facets:DayOfYear.taxonomy # freq=1963428 freq=127152
-AndHighMedDayTaxoFacets: +with +governor +facets:DayOfYear.taxonomy # freq=3709421 freq=102274
-AndHighMedDayTaxoFacets: +publisher +f.c +facets:DayOfYear.taxonomy # freq=1289029 freq=83548
-AndHighMedDayTaxoFacets: +on +player +facets:DayOfYear.taxonomy # freq=4074624 freq=241451
-AndHighMedDayTaxoFacets: +time +including +facets:DayOfYear.taxonomy # freq=1032071 freq=521324
-AndHighMedDayTaxoFacets: +work +1950 +facets:DayOfYear.taxonomy # freq=853422 freq=89746
-AndHighMedDayTaxoFacets: +http +now +facets:DayOfYear.taxonomy # freq=3493581 freq=484114
-AndHighMedDayTaxoFacets: +is +separate +facets:DayOfYear.taxonomy # freq=4074455 freq=88604
-AndHighMedDayTaxoFacets: +be +having +facets:DayOfYear.taxonomy # freq=2051702 freq=213416
-AndHighMedDayTaxoFacets: +its +practice +facets:DayOfYear.taxonomy # freq=1173450 freq=93287
-AndHighMedDayTaxoFacets: +new +30 +facets:DayOfYear.taxonomy # freq=1657293 freq=488930
-AndHighMedDayTaxoFacets: +date +most +facets:DayOfYear.taxonomy # freq=2020626 freq=819634
-AndHighMedDayTaxoFacets: +by +railway +facets:DayOfYear.taxonomy # freq=3826691 freq=125543
-AndHighMedDayTaxoFacets: +that +related +facets:DayOfYear.taxonomy # freq=2931020 freq=174856
-AndHighMedDayTaxoFacets: +other +data +facets:DayOfYear.taxonomy # freq=1269961 freq=159657
-AndHighMedDayTaxoFacets: +an +daily +facets:DayOfYear.taxonomy # freq=2628056 freq=111717
-AndHighMedDayTaxoFacets: +web +performance +facets:DayOfYear.taxonomy # freq=1118334 freq=130862
-AndHighMedDayTaxoFacets: +their +engine +facets:DayOfYear.taxonomy # freq=1158682 freq=100930
-AndHighMedDayTaxoFacets: +states +found +facets:DayOfYear.taxonomy # freq=1034872 freq=313247
-AndHighMedDayTaxoFacets: +name +takes +facets:DayOfYear.taxonomy # freq=2827713 freq=95889
-AndHighMedDayTaxoFacets: +cite +editor +facets:DayOfYear.taxonomy # freq=1741194 freq=119419
-AndHighMedDayTaxoFacets: +last +canadian +facets:DayOfYear.taxonomy # freq=958437 freq=181906
-AndHighMedDayTaxoFacets: +2 +jersey +facets:DayOfYear.taxonomy # freq=1549245 freq=88847
-AndHighMedDayTaxoFacets: +5 +far +facets:DayOfYear.taxonomy # freq=891361 freq=143873
-AndHighMedDayTaxoFacets: +it +3rd +facets:DayOfYear.taxonomy # freq=2675552 freq=90723
-AndHighMedDayTaxoFacets: +ref +say +facets:DayOfYear.taxonomy # freq=3793973 freq=110895
-AndHighMedDayTaxoFacets: +be +forces +facets:DayOfYear.taxonomy # freq=2051702 freq=152939
-AndHighMedDayTaxoFacets: +2010 +where +facets:DayOfYear.taxonomy # freq=950573 freq=630647
-AndHighMedDayTaxoFacets: +states +earlier +facets:DayOfYear.taxonomy # freq=1034872 freq=100372
-AndHighMedDayTaxoFacets: +has +organization +facets:DayOfYear.taxonomy # freq=1502961 freq=119614
-AndHighMedDayTaxoFacets: +its +fiction +facets:DayOfYear.taxonomy # freq=1173450 freq=87227
-AndHighMedDayTaxoFacets: +it +star +facets:DayOfYear.taxonomy # freq=2675552 freq=195768
-AndHighMedDayTaxoFacets: +have +speed +facets:DayOfYear.taxonomy # freq=1297121 freq=99899
-AndHighMedDayTaxoFacets: +into +2nd +facets:DayOfYear.taxonomy # freq=888684 freq=167463
-AndHighMedDayTaxoFacets: +name +having +facets:DayOfYear.taxonomy # freq=2827713 freq=213416
-AndHighMedDayTaxoFacets: +his +head +facets:DayOfYear.taxonomy # freq=1777780 freq=194682
-AndHighMedDayTaxoFacets: +when +change +facets:DayOfYear.taxonomy # freq=1027487 freq=182336
-AndHighMedDayTaxoFacets: +2005 +edit +facets:DayOfYear.taxonomy # freq=835460 freq=129064
-AndHighMedDayTaxoFacets: +about +mass +facets:DayOfYear.taxonomy # freq=850283 freq=82794
-AndHighMedDayTaxoFacets: +not +profile +facets:DayOfYear.taxonomy # freq=1713264 freq=86788
-AndHighMedDayTaxoFacets: +of +mayor +facets:DayOfYear.taxonomy # freq=8184358 freq=88578
-AndHighMedDayTaxoFacets: +no +woman +facets:DayOfYear.taxonomy # freq=1045000 freq=92071
-AndHighMedDayTaxoFacets: +from +these +facets:DayOfYear.taxonomy # freq=3224339 freq=623267
-AndHighMedDayTaxoFacets: +2005 +literature +facets:DayOfYear.taxonomy # freq=835460 freq=96743
-AndHighMedDayTaxoFacets: +an +07 +facets:DayOfYear.taxonomy # freq=2628056 freq=299351
-AndHighMedDayTaxoFacets: +that +age +facets:DayOfYear.taxonomy # freq=2931020 freq=395368
-AndHighMedDayTaxoFacets: +2008 +august +facets:DayOfYear.taxonomy # freq=831253 freq=527806
-AndHighMedDayTaxoFacets: +date +type +facets:DayOfYear.taxonomy # freq=2020626 freq=318210
-AndHighMedDayTaxoFacets: +other +most +facets:DayOfYear.taxonomy # freq=1269961 freq=819634
-AndHighMedDayTaxoFacets: +his +mark +facets:DayOfYear.taxonomy # freq=1777780 freq=160033
-AndHighMedDayTaxoFacets: +was +elected +facets:DayOfYear.taxonomy # freq=3763623 freq=119941
-AndHighMedDayTaxoFacets: +title +parliament +facets:DayOfYear.taxonomy # freq=2397378 freq=127008
-AndHighMedDayTaxoFacets: +been +27 +facets:DayOfYear.taxonomy # freq=1041183 freq=383042
-AndHighMedDayTaxoFacets: +publisher +western +facets:DayOfYear.taxonomy # freq=1289029 freq=232781
-AndHighMedDayTaxoFacets: +its +done +facets:DayOfYear.taxonomy # freq=1173450 freq=102033
-AndHighMedDayTaxoFacets: +more +web.archive.org +facets:DayOfYear.taxonomy # freq=963533 freq=95902
-AndHighMedDayTaxoFacets: +date +half +facets:DayOfYear.taxonomy # freq=2020626 freq=155387
-AndHighMedDayTaxoFacets: +that +lower +facets:DayOfYear.taxonomy # freq=2931020 freq=127260
-AndHighMedDayTaxoFacets: +more +already +facets:DayOfYear.taxonomy # freq=963533 freq=126694
-AndHighMedDayTaxoFacets: +for +report +facets:DayOfYear.taxonomy # freq=4380011 freq=153204
-AndHighMedDayTaxoFacets: +5 +ed +facets:DayOfYear.taxonomy # freq=891361 freq=134224
-AndHighMedDayTaxoFacets: +http +1965 +facets:DayOfYear.taxonomy # freq=3493581 freq=104539
-AndHighMedDayTaxoFacets: +s +debate +facets:DayOfYear.taxonomy # freq=1581243 freq=177827
-AndHighMedDayTaxoFacets: +only +official +facets:DayOfYear.taxonomy # freq=875561 freq=326177
-AndHighMedDayTaxoFacets: +2006 +seat +facets:DayOfYear.taxonomy # freq=889954 freq=91288
-AndHighMedDayTaxoFacets: +in +27 +facets:DayOfYear.taxonomy # freq=7320987 freq=383042
-AndHighMedDayTaxoFacets: +cite +fields +facets:DayOfYear.taxonomy # freq=1741194 freq=86938
-AndHighMedDayTaxoFacets: +states +remained +facets:DayOfYear.taxonomy # freq=1034872 freq=107736
-AndHighMedDayTaxoFacets: +for +hold +facets:DayOfYear.taxonomy # freq=4380011 freq=82579
-AndHighMedDayTaxoFacets: +2011 +joseph +facets:DayOfYear.taxonomy # freq=871410 freq=121533
-AndHighMedDayTaxoFacets: +2009 +met +facets:DayOfYear.taxonomy # freq=887702 freq=84001
-AndHighMedDayTaxoFacets: +an +31 +facets:DayOfYear.taxonomy # freq=2628056 freq=298349
-AndHighMedDayTaxoFacets: +there +hill +facets:DayOfYear.taxonomy # freq=956153 freq=133714
-AndHighMedDayTaxoFacets: +3 +allowed +facets:DayOfYear.taxonomy # freq=1148799 freq=98720
-AndHighMedDayTaxoFacets: +4 +table +facets:DayOfYear.taxonomy # freq=986452 freq=99163
-AndHighMedDayTaxoFacets: +accessdate +later +facets:DayOfYear.taxonomy # freq=1228887 freq=604921
-AndHighMedDayTaxoFacets: +2008 +rather +facets:DayOfYear.taxonomy # freq=831253 freq=174136
-AndHighMedDayTaxoFacets: +also +late +facets:DayOfYear.taxonomy # freq=1959419 freq=243636
-AndHighMedDayTaxoFacets: +2008 +60 +facets:DayOfYear.taxonomy # freq=831253 freq=118403
-AndHighMedDayTaxoFacets: +1 +why +facets:DayOfYear.taxonomy # freq=1641090 freq=108161
-AndHighMedDayTaxoFacets: +new +winning +facets:DayOfYear.taxonomy # freq=1657293 freq=95704
-AndHighMedDayTaxoFacets: +accessdate +towards +facets:DayOfYear.taxonomy # freq=1228887 freq=95574
-AndHighMedDayTaxoFacets: +date +t +facets:DayOfYear.taxonomy # freq=2020626 freq=262832
-AndHighMedDayTaxoFacets: +2 +nbsp +facets:DayOfYear.taxonomy # freq=1549245 freq=506054
-AndHighMedDayTaxoFacets: +time +website +facets:DayOfYear.taxonomy # freq=1032071 freq=435941
-AndHighMedDayTaxoFacets: +5 +republic +facets:DayOfYear.taxonomy # freq=891361 freq=166154
-AndHighMedDayTaxoFacets: +were +hold +facets:DayOfYear.taxonomy # freq=1524630 freq=82579
-AndHighMedDayTaxoFacets: +the +whom +facets:DayOfYear.taxonomy # freq=8217362 freq=95520
-AndHighMedDayTaxoFacets: +http +free +facets:DayOfYear.taxonomy # freq=3493581 freq=270199
-AndHighMedDayTaxoFacets: +his +self +facets:DayOfYear.taxonomy # freq=1777780 freq=135012
-AndHighMedDayTaxoFacets: +with +music +facets:DayOfYear.taxonomy # freq=3709421 freq=473240
-AndHighMedDayTaxoFacets: +is +academy +facets:DayOfYear.taxonomy # freq=4074455 freq=119055
-AndHighMedDayTaxoFacets: +year +appearance +facets:DayOfYear.taxonomy # freq=1235231 freq=89229
-AndHighMedDayTaxoFacets: +year +square +facets:DayOfYear.taxonomy # freq=1235231 freq=123538
-AndHighMedDayTaxoFacets: +i +h +facets:DayOfYear.taxonomy # freq=956148 freq=241946
-AndHighMedDayTaxoFacets: +by +35 +facets:DayOfYear.taxonomy # freq=3826691 freq=155506
-AndHighMedDayTaxoFacets: +2005 +sports +facets:DayOfYear.taxonomy # freq=835460 freq=178542
-AndHighMedDayTaxoFacets: +united +series +facets:DayOfYear.taxonomy # freq=1196944 freq=521861
-AndHighMedDayTaxoFacets: +may +congress +facets:DayOfYear.taxonomy # freq=1071932 freq=92382
-AndHighMedDayTaxoFacets: +title +la +facets:DayOfYear.taxonomy # freq=2397378 freq=232610
-AndHighMedDayTaxoFacets: +its +category:american +facets:DayOfYear.taxonomy # freq=1173450 freq=107823
-AndHighMedDayTaxoFacets: +the +lake +facets:DayOfYear.taxonomy # freq=8217362 freq=131603
-AndHighMedDayTaxoFacets: +who +foundation +facets:DayOfYear.taxonomy # freq=1196171 freq=107123
-AndHighMedDayTaxoFacets: +3 +57 +facets:DayOfYear.taxonomy # freq=1148799 freq=93708
-AndHighMedDayTaxoFacets: +date +flag +facets:DayOfYear.taxonomy # freq=2020626 freq=104210
-AndHighMedDayTaxoFacets: +10 +dq +facets:DayOfYear.taxonomy # freq=918339 freq=88557
-AndHighMedDayTaxoFacets: +that +study +facets:DayOfYear.taxonomy # freq=2931020 freq=137170
-AndHighMedDayTaxoFacets: +first +france +facets:DayOfYear.taxonomy # freq=1933372 freq=220058
-AndHighMedDayTaxoFacets: +on +culture +facets:DayOfYear.taxonomy # freq=4074624 freq=157773
-AndHighMedDayTaxoFacets: +to +1984 +facets:DayOfYear.taxonomy # freq=6155577 freq=161404
-AndHighMedDayTaxoFacets: +all +u.s +facets:DayOfYear.taxonomy # freq=1203572 freq=428534
-AndHighMedDayTaxoFacets: +name +era +facets:DayOfYear.taxonomy # freq=2827713 freq=95989
-AndHighMedDayTaxoFacets: +url +02 +facets:DayOfYear.taxonomy # freq=1513595 freq=319783
-AndHighMedDayTaxoFacets: +a +teams +facets:DayOfYear.taxonomy # freq=6560531 freq=105245
-AndHighMedDayTaxoFacets: +name +paul +facets:DayOfYear.taxonomy # freq=2827713 freq=207229
-AndHighMedDayTaxoFacets: +2008 +command +facets:DayOfYear.taxonomy # freq=831253 freq=87496
-AndHighMedDayTaxoFacets: +after +today +facets:DayOfYear.taxonomy # freq=1247398 freq=168864
-AndHighMedDayTaxoFacets: +no +native +facets:DayOfYear.taxonomy # freq=1045000 freq=129103
-AndHighMedDayTaxoFacets: +into +st +facets:DayOfYear.taxonomy # freq=888684 freq=309092
-AndHighMedDayTaxoFacets: +accessdate +m +facets:DayOfYear.taxonomy # freq=1228887 freq=441232
-AndHighMedDayTaxoFacets: +a +heart +facets:DayOfYear.taxonomy # freq=6560531 freq=95365
-AndHighMedDayTaxoFacets: +2010 +1986 +facets:DayOfYear.taxonomy # freq=950573 freq=167724
-AndHighMedDayTaxoFacets: +2008 +remained +facets:DayOfYear.taxonomy # freq=831253 freq=107736
-AndHighMedDayTaxoFacets: +this +college +facets:DayOfYear.taxonomy # freq=2224932 freq=278094
-AndHighMedDayTaxoFacets: +date +note +facets:DayOfYear.taxonomy # freq=2020626 freq=194472
-AndHighMedDayTaxoFacets: +5 +coast +facets:DayOfYear.taxonomy # freq=891361 freq=119047
-AndHighMedDayTaxoFacets: +time +sometimes +facets:DayOfYear.taxonomy # freq=1032071 freq=144078
-AndHighMedDayTaxoFacets: +3 +look +facets:DayOfYear.taxonomy # freq=1148799 freq=91122
-AndHighMedDayTaxoFacets: +states +people +facets:DayOfYear.taxonomy # freq=1034872 freq=790960
-AndHighMedDayTaxoFacets: +to +specific +facets:DayOfYear.taxonomy # freq=6155577 freq=93622
-AndHighMedDayTaxoFacets: +year +between +facets:DayOfYear.taxonomy # freq=1235231 freq=630650
-AndHighMedDayTaxoFacets: +publisher +led +facets:DayOfYear.taxonomy # freq=1289029 freq=210033
-AndHighMedDayTaxoFacets: +a +given +facets:DayOfYear.taxonomy # freq=6560531 freq=235719
-AndHighMedDayTaxoFacets: +2008 +stations +facets:DayOfYear.taxonomy # freq=831253 freq=92011
-AndHighMedDayTaxoFacets: +his +england +facets:DayOfYear.taxonomy # freq=1777780 freq=317884
-AndHighMedDayTaxoFacets: +states +geo +facets:DayOfYear.taxonomy # freq=1034872 freq=83404
-AndHighMedDayTaxoFacets: +at +1960 +facets:DayOfYear.taxonomy # freq=2857534 freq=109083
-AndHighMedDayTaxoFacets: +be +60 +facets:DayOfYear.taxonomy # freq=2051702 freq=118403
-AndHighMedDayTaxoFacets: +there +schools +facets:DayOfYear.taxonomy # freq=956153 freq=141308
-AndHighMedDayTaxoFacets: +that +value +facets:DayOfYear.taxonomy # freq=2931020 freq=86806
-AndHighMedDayTaxoFacets: +no +needed +facets:DayOfYear.taxonomy # freq=1045000 freq=281051
-AndHighMedDayTaxoFacets: +2011 +31 +facets:DayOfYear.taxonomy # freq=871410 freq=298349
-AndHighMedDayTaxoFacets: +year +16 +facets:DayOfYear.taxonomy # freq=1235231 freq=540539
-AndHighMedDayTaxoFacets: +title +set +facets:DayOfYear.taxonomy # freq=2397378 freq=294255
-AndHighMedDayTaxoFacets: +work +sport +facets:DayOfYear.taxonomy # freq=853422 freq=106696
-AndHighMedDayTaxoFacets: +all +42 +facets:DayOfYear.taxonomy # freq=1203572 freq=124253
-OrHighMedDayTaxoFacets: there background +facets:DayOfYear.taxonomy # freq=956153 freq=314229
-OrHighMedDayTaxoFacets: be important +facets:DayOfYear.taxonomy # freq=2051702 freq=195851
-OrHighMedDayTaxoFacets: name cd +facets:DayOfYear.taxonomy # freq=2827713 freq=87105
-OrHighMedDayTaxoFacets: when regular +facets:DayOfYear.taxonomy # freq=1027487 freq=93809
-OrHighMedDayTaxoFacets: 1 called +facets:DayOfYear.taxonomy # freq=1641090 freq=454580
-OrHighMedDayTaxoFacets: may force +facets:DayOfYear.taxonomy # freq=1071932 freq=198556
-OrHighMedDayTaxoFacets: 1 regular +facets:DayOfYear.taxonomy # freq=1641090 freq=93809
-OrHighMedDayTaxoFacets: s 1986 +facets:DayOfYear.taxonomy # freq=1581243 freq=167724
-OrHighMedDayTaxoFacets: 2011 co +facets:DayOfYear.taxonomy # freq=871410 freq=209086
-OrHighMedDayTaxoFacets: he artist +facets:DayOfYear.taxonomy # freq=1659434 freq=210591
-OrHighMedDayTaxoFacets: 2009 him +facets:DayOfYear.taxonomy # freq=887702 freq=507350
-OrHighMedDayTaxoFacets: at interest +facets:DayOfYear.taxonomy # freq=2857534 freq=108551
-OrHighMedDayTaxoFacets: and 1959 +facets:DayOfYear.taxonomy # freq=7318061 freq=87097
-OrHighMedDayTaxoFacets: had few +facets:DayOfYear.taxonomy # freq=1246743 freq=226422
-OrHighMedDayTaxoFacets: this era +facets:DayOfYear.taxonomy # freq=2224932 freq=95989
-OrHighMedDayTaxoFacets: also video +facets:DayOfYear.taxonomy # freq=1959419 freq=202380
-OrHighMedDayTaxoFacets: into capital +facets:DayOfYear.taxonomy # freq=888684 freq=120421
-OrHighMedDayTaxoFacets: who los +facets:DayOfYear.taxonomy # freq=1196171 freq=145404
-OrHighMedDayTaxoFacets: that ii +facets:DayOfYear.taxonomy # freq=2931020 freq=340800
-OrHighMedDayTaxoFacets: as working +facets:DayOfYear.taxonomy # freq=3925535 freq=144617
-OrHighMedDayTaxoFacets: accessdate status +facets:DayOfYear.taxonomy # freq=1228887 freq=133818
-OrHighMedDayTaxoFacets: not put +facets:DayOfYear.taxonomy # freq=1713264 freq=139882
-OrHighMedDayTaxoFacets: cite soviet +facets:DayOfYear.taxonomy # freq=1741194 freq=89070
-OrHighMedDayTaxoFacets: see reading +facets:DayOfYear.taxonomy # freq=1044180 freq=101214
-OrHighMedDayTaxoFacets: all area +facets:DayOfYear.taxonomy # freq=1203572 freq=559023
-OrHighMedDayTaxoFacets: his influence +facets:DayOfYear.taxonomy # freq=1777780 freq=83101
-OrHighMedDayTaxoFacets: new less +facets:DayOfYear.taxonomy # freq=1657293 freq=170266
-OrHighMedDayTaxoFacets: states 14 +facets:DayOfYear.taxonomy # freq=1034872 freq=534005
-OrHighMedDayTaxoFacets: no april +facets:DayOfYear.taxonomy # freq=1045000 freq=587542
-OrHighMedDayTaxoFacets: http wife +facets:DayOfYear.taxonomy # freq=3493581 freq=130807
-OrHighMedDayTaxoFacets: had stories +facets:DayOfYear.taxonomy # freq=1246743 freq=110223
-OrHighMedDayTaxoFacets: this established +facets:DayOfYear.taxonomy # freq=2224932 freq=282471
-OrHighMedDayTaxoFacets: other source +facets:DayOfYear.taxonomy # freq=1269961 freq=231838
-OrHighMedDayTaxoFacets: 1 alone +facets:DayOfYear.taxonomy # freq=1641090 freq=93166
-OrHighMedDayTaxoFacets: and per +facets:DayOfYear.taxonomy # freq=7318061 freq=283568
-OrHighMedDayTaxoFacets: into larger +facets:DayOfYear.taxonomy # freq=888684 freq=87424
-OrHighMedDayTaxoFacets: to book +facets:DayOfYear.taxonomy # freq=6155577 freq=617297
-OrHighMedDayTaxoFacets: at london +facets:DayOfYear.taxonomy # freq=2857534 freq=348918
-OrHighMedDayTaxoFacets: at km +facets:DayOfYear.taxonomy # freq=2857534 freq=233831
-OrHighMedDayTaxoFacets: in convert +facets:DayOfYear.taxonomy # freq=7320987 freq=267974
-OrHighMedDayTaxoFacets: s yet +facets:DayOfYear.taxonomy # freq=1581243 freq=100857
-OrHighMedDayTaxoFacets: 1 1973 +facets:DayOfYear.taxonomy # freq=1641090 freq=125985
-OrHighMedDayTaxoFacets: 1 yet +facets:DayOfYear.taxonomy # freq=1641090 freq=100857
-OrHighMedDayTaxoFacets: 3 preserved +facets:DayOfYear.taxonomy # freq=1148799 freq=111088
-OrHighMedDayTaxoFacets: when various +facets:DayOfYear.taxonomy # freq=1027487 freq=224593
-OrHighMedDayTaxoFacets: his result +facets:DayOfYear.taxonomy # freq=1777780 freq=276803
-OrHighMedDayTaxoFacets: into film +facets:DayOfYear.taxonomy # freq=888684 freq=432758
-OrHighMedDayTaxoFacets: was leader +facets:DayOfYear.taxonomy # freq=3763623 freq=127591
-OrHighMedDayTaxoFacets: see list +facets:DayOfYear.taxonomy # freq=1044180 freq=585922
-OrHighMedDayTaxoFacets: first institute +facets:DayOfYear.taxonomy # freq=1933372 freq=136311
-OrHighMedDayTaxoFacets: work got +facets:DayOfYear.taxonomy # freq=853422 freq=92640
-OrHighMedDayTaxoFacets: had rule +facets:DayOfYear.taxonomy # freq=1246743 freq=86729
-OrHighMedDayTaxoFacets: 1 thought +facets:DayOfYear.taxonomy # freq=1641090 freq=108963
-OrHighMedDayTaxoFacets: an hard +facets:DayOfYear.taxonomy # freq=2628056 freq=90149
-OrHighMedDayTaxoFacets: only 1972 +facets:DayOfYear.taxonomy # freq=875561 freq=130791
-OrHighMedDayTaxoFacets: was american +facets:DayOfYear.taxonomy # freq=3763623 freq=758337
-OrHighMedDayTaxoFacets: 2009 lines +facets:DayOfYear.taxonomy # freq=887702 freq=96969
-OrHighMedDayTaxoFacets: no followed +facets:DayOfYear.taxonomy # freq=1045000 freq=121848
-OrHighMedDayTaxoFacets: had five +facets:DayOfYear.taxonomy # freq=1246743 freq=262923
-OrHighMedDayTaxoFacets: was q +facets:DayOfYear.taxonomy # freq=3763623 freq=149271
-OrHighMedDayTaxoFacets: cite wikipedia +facets:DayOfYear.taxonomy # freq=1741194 freq=149673
-OrHighMedDayTaxoFacets: other already +facets:DayOfYear.taxonomy # freq=1269961 freq=126694
-OrHighMedDayTaxoFacets: it keep +facets:DayOfYear.taxonomy # freq=2675552 freq=177996
-OrHighMedDayTaxoFacets: states t +facets:DayOfYear.taxonomy # freq=1034872 freq=262832
-OrHighMedDayTaxoFacets: 1 listed +facets:DayOfYear.taxonomy # freq=1641090 freq=94990
-OrHighMedDayTaxoFacets: there modify +facets:DayOfYear.taxonomy # freq=956153 freq=109819
-OrHighMedDayTaxoFacets: url win +facets:DayOfYear.taxonomy # freq=1513595 freq=121070
-OrHighMedDayTaxoFacets: may 39 +facets:DayOfYear.taxonomy # freq=1071932 freq=132689
-OrHighMedDayTaxoFacets: two charles +facets:DayOfYear.taxonomy # freq=1104053 freq=204987
-OrHighMedDayTaxoFacets: also appears +facets:DayOfYear.taxonomy # freq=1959419 freq=104511
-OrHighMedDayTaxoFacets: more rowspan +facets:DayOfYear.taxonomy # freq=963533 freq=124637
-OrHighMedDayTaxoFacets: web north +facets:DayOfYear.taxonomy # freq=1118334 freq=564195
-OrHighMedDayTaxoFacets: 1 smith +facets:DayOfYear.taxonomy # freq=1641090 freq=126344
-OrHighMedDayTaxoFacets: 2010 2000 +facets:DayOfYear.taxonomy # freq=950573 freq=499639
-OrHighMedDayTaxoFacets: they features +facets:DayOfYear.taxonomy # freq=1021945 freq=156867
-OrHighMedDayTaxoFacets: 2 project +facets:DayOfYear.taxonomy # freq=1549245 freq=180139
-OrHighMedDayTaxoFacets: http instead +facets:DayOfYear.taxonomy # freq=3493581 freq=149345
-OrHighMedDayTaxoFacets: by am +facets:DayOfYear.taxonomy # freq=3826691 freq=127152
-OrHighMedDayTaxoFacets: it pacific +facets:DayOfYear.taxonomy # freq=2675552 freq=107648
-OrHighMedDayTaxoFacets: states times +facets:DayOfYear.taxonomy # freq=1034872 freq=407155
-OrHighMedDayTaxoFacets: name middle +facets:DayOfYear.taxonomy # freq=2827713 freq=156728
-OrHighMedDayTaxoFacets: is 1988 +facets:DayOfYear.taxonomy # freq=4074455 freq=181327
-OrHighMedDayTaxoFacets: 5 c +facets:DayOfYear.taxonomy # freq=891361 freq=444247
-OrHighMedDayTaxoFacets: their court +facets:DayOfYear.taxonomy # freq=1158682 freq=169309
-OrHighMedDayTaxoFacets: they double +facets:DayOfYear.taxonomy # freq=1021945 freq=87304
-OrHighMedDayTaxoFacets: in george +facets:DayOfYear.taxonomy # freq=7320987 freq=256196
-OrHighMedDayTaxoFacets: after appears +facets:DayOfYear.taxonomy # freq=1247398 freq=104511
-OrHighMedDayTaxoFacets: is thomas +facets:DayOfYear.taxonomy # freq=4074455 freq=191625
-OrHighMedDayTaxoFacets: about specific +facets:DayOfYear.taxonomy # freq=850283 freq=93622
-OrHighMedDayTaxoFacets: be captain +facets:DayOfYear.taxonomy # freq=2051702 freq=91635
-OrHighMedDayTaxoFacets: be journal +facets:DayOfYear.taxonomy # freq=2051702 freq=348162
-OrHighMedDayTaxoFacets: this month +facets:DayOfYear.taxonomy # freq=2224932 freq=162128
-OrHighMedDayTaxoFacets: last given +facets:DayOfYear.taxonomy # freq=958437 freq=235719
-OrHighMedDayTaxoFacets: from running +facets:DayOfYear.taxonomy # freq=3224339 freq=101764
-OrHighMedDayTaxoFacets: 2008 liberal +facets:DayOfYear.taxonomy # freq=831253 freq=93070
-OrHighMedDayTaxoFacets: i island +facets:DayOfYear.taxonomy # freq=956148 freq=203023
-OrHighMedDayTaxoFacets: or pp +facets:DayOfYear.taxonomy # freq=1858841 freq=204742
-OrHighMedDayTaxoFacets: which earth +facets:DayOfYear.taxonomy # freq=1963428 freq=110512
-OrHighMedDayTaxoFacets: united school +facets:DayOfYear.taxonomy # freq=1196944 freq=462166
-OrHighMedDayTaxoFacets: at fall +facets:DayOfYear.taxonomy # freq=2857534 freq=103379
-OrHighMedDayTaxoFacets: by talk +facets:DayOfYear.taxonomy # freq=3826691 freq=364194
-OrHighMedDayTaxoFacets: title appropriate +facets:DayOfYear.taxonomy # freq=2397378 freq=135343
-OrHighMedDayTaxoFacets: first data +facets:DayOfYear.taxonomy # freq=1933372 freq=159657
-OrHighMedDayTaxoFacets: by community +facets:DayOfYear.taxonomy # freq=3826691 freq=225571
-OrHighMedDayTaxoFacets: it anti +facets:DayOfYear.taxonomy # freq=2675552 freq=99993
-OrHighMedDayTaxoFacets: 2005 would +facets:DayOfYear.taxonomy # freq=835460 freq=690480
-OrHighMedDayTaxoFacets: no archive +facets:DayOfYear.taxonomy # freq=1045000 freq=215381
-OrHighMedDayTaxoFacets: had 11 +facets:DayOfYear.taxonomy # freq=1246743 freq=730505
-OrHighMedDayTaxoFacets: which 978 +facets:DayOfYear.taxonomy # freq=1963428 freq=101276
-OrHighMedDayTaxoFacets: accessdate seems +facets:DayOfYear.taxonomy # freq=1228887 freq=83963
-OrHighMedDayTaxoFacets: 2011 commission +facets:DayOfYear.taxonomy # freq=871410 freq=91476
-OrHighMedDayTaxoFacets: that county +facets:DayOfYear.taxonomy # freq=2931020 freq=521126
-OrHighMedDayTaxoFacets: they hard +facets:DayOfYear.taxonomy # freq=1021945 freq=90149
-OrHighMedDayTaxoFacets: first historic +facets:DayOfYear.taxonomy # freq=1933372 freq=112292
-OrHighMedDayTaxoFacets: this category +facets:DayOfYear.taxonomy # freq=2224932 freq=595446
-OrHighMedDayTaxoFacets: its counties +facets:DayOfYear.taxonomy # freq=1173450 freq=87574
-OrHighMedDayTaxoFacets: year 1963 +facets:DayOfYear.taxonomy # freq=1235231 freq=96439
-OrHighMedDayTaxoFacets: this include +facets:DayOfYear.taxonomy # freq=2224932 freq=276466
-OrHighMedDayTaxoFacets: one british +facets:DayOfYear.taxonomy # freq=1527689 freq=417307
-OrHighMedDayTaxoFacets: was world +facets:DayOfYear.taxonomy # freq=3763623 freq=808563
-OrHighMedDayTaxoFacets: the references +facets:DayOfYear.taxonomy # freq=8217362 freq=760306
-OrHighMedDayTaxoFacets: its 56 +facets:DayOfYear.taxonomy # freq=1173450 freq=96215
-OrHighMedDayTaxoFacets: their son +facets:DayOfYear.taxonomy # freq=1158682 freq=202340
-OrHighMedDayTaxoFacets: the federal +facets:DayOfYear.taxonomy # freq=8217362 freq=166274
-OrHighMedDayTaxoFacets: with jpg +facets:DayOfYear.taxonomy # freq=3709421 freq=322278
-OrHighMedDayTaxoFacets: on training +facets:DayOfYear.taxonomy # freq=4074624 freq=107271
-OrHighMedDayTaxoFacets: for famous +facets:DayOfYear.taxonomy # freq=4380011 freq=139092
-OrHighMedDayTaxoFacets: work run +facets:DayOfYear.taxonomy # freq=853422 freq=183609
-OrHighMedDayTaxoFacets: which start +facets:DayOfYear.taxonomy # freq=1963428 freq=233925
-OrHighMedDayTaxoFacets: and author +facets:DayOfYear.taxonomy # freq=7318061 freq=567768
-OrHighMedDayTaxoFacets: name mother +facets:DayOfYear.taxonomy # freq=2827713 freq=122930
-OrHighMedDayTaxoFacets: who current +facets:DayOfYear.taxonomy # freq=1196171 freq=217174
-OrHighMedDayTaxoFacets: s vote +facets:DayOfYear.taxonomy # freq=1581243 freq=96871
-OrHighMedDayTaxoFacets: 4 51 +facets:DayOfYear.taxonomy # freq=986452 freq=108800
-OrHighMedDayTaxoFacets: 2011 special +facets:DayOfYear.taxonomy # freq=871410 freq=198917
-OrHighMedDayTaxoFacets: accessdate st +facets:DayOfYear.taxonomy # freq=1228887 freq=309092
-OrHighMedDayTaxoFacets: about must +facets:DayOfYear.taxonomy # freq=850283 freq=228491
-OrHighMedDayTaxoFacets: had census +facets:DayOfYear.taxonomy # freq=1246743 freq=205166
-OrHighMedDayTaxoFacets: publisher 56 +facets:DayOfYear.taxonomy # freq=1289029 freq=96215
-OrHighMedDayTaxoFacets: other 12 +facets:DayOfYear.taxonomy # freq=1269961 freq=774572
-OrHighMedDayTaxoFacets: or 22 +facets:DayOfYear.taxonomy # freq=1858841 freq=502778
-OrHighMedDayTaxoFacets: of deletion +facets:DayOfYear.taxonomy # freq=8184358 freq=166633
-OrHighMedDayTaxoFacets: as married +facets:DayOfYear.taxonomy # freq=3925535 freq=156752
-OrHighMedDayTaxoFacets: also do +facets:DayOfYear.taxonomy # freq=1959419 freq=511178
-OrHighMedDayTaxoFacets: of larger +facets:DayOfYear.taxonomy # freq=8184358 freq=87424
-OrHighMedDayTaxoFacets: the wikipedia:persondata +facets:DayOfYear.taxonomy # freq=8217362 freq=222385
-OrHighMedDayTaxoFacets: be books +facets:DayOfYear.taxonomy # freq=2051702 freq=341376
-OrHighMedDayTaxoFacets: url george +facets:DayOfYear.taxonomy # freq=1513595 freq=256196
-OrHighMedDayTaxoFacets: accessdate del +facets:DayOfYear.taxonomy # freq=1228887 freq=82614
-OrHighMedDayTaxoFacets: about command +facets:DayOfYear.taxonomy # freq=850283 freq=87496
-OrHighMedDayTaxoFacets: there soon +facets:DayOfYear.taxonomy # freq=956153 freq=123657
-OrHighMedDayTaxoFacets: url special +facets:DayOfYear.taxonomy # freq=1513595 freq=198917
-OrHighMedDayTaxoFacets: may authority +facets:DayOfYear.taxonomy # freq=1071932 freq=85540
-OrHighMedDayTaxoFacets: url ever +facets:DayOfYear.taxonomy # freq=1513595 freq=128732
-OrHighMedDayTaxoFacets: see 1987 +facets:DayOfYear.taxonomy # freq=1044180 freq=172453
-OrHighMedDayTaxoFacets: his ended +facets:DayOfYear.taxonomy # freq=1777780 freq=84664
-OrHighMedDayTaxoFacets: who prime +facets:DayOfYear.taxonomy # freq=1196171 freq=96945
-OrHighMedDayTaxoFacets: a success +facets:DayOfYear.taxonomy # freq=6560531 freq=112195
-OrHighMedDayTaxoFacets: cite elected +facets:DayOfYear.taxonomy # freq=1741194 freq=119941
-OrHighMedDayTaxoFacets: 2008 without +facets:DayOfYear.taxonomy # freq=831253 freq=249926
-OrHighMedDayTaxoFacets: after km +facets:DayOfYear.taxonomy # freq=1247398 freq=233831
-OrHighMedDayTaxoFacets: no fields +facets:DayOfYear.taxonomy # freq=1045000 freq=86938
-OrHighMedDayTaxoFacets: the financial +facets:DayOfYear.taxonomy # freq=8217362 freq=82536
-OrHighMedDayTaxoFacets: had features +facets:DayOfYear.taxonomy # freq=1246743 freq=156867
-OrHighMedDayTaxoFacets: into dead +facets:DayOfYear.taxonomy # freq=888684 freq=171386
-OrHighMedDayTaxoFacets: of caused +facets:DayOfYear.taxonomy # freq=8184358 freq=86397
-OrHighMedDayTaxoFacets: as changes +facets:DayOfYear.taxonomy # freq=3925535 freq=105677
-OrHighMedDayTaxoFacets: no president +facets:DayOfYear.taxonomy # freq=1045000 freq=263341
-OrHighMedDayTaxoFacets: one within +facets:DayOfYear.taxonomy # freq=1527689 freq=291049
-OrHighMedDayTaxoFacets: at mark +facets:DayOfYear.taxonomy # freq=2857534 freq=160033
-OrHighMedDayTaxoFacets: first down +facets:DayOfYear.taxonomy # freq=1933372 freq=280662
-OrHighMedDayTaxoFacets: be leader +facets:DayOfYear.taxonomy # freq=2051702 freq=127591
-OrHighMedDayTaxoFacets: were know +facets:DayOfYear.taxonomy # freq=1524630 freq=129655
-OrHighMedDayTaxoFacets: s england +facets:DayOfYear.taxonomy # freq=1581243 freq=317884
-OrHighMedDayTaxoFacets: one set +facets:DayOfYear.taxonomy # freq=1527689 freq=294255
-OrHighMedDayTaxoFacets: 5 flight +facets:DayOfYear.taxonomy # freq=891361 freq=84316
-OrHighMedDayTaxoFacets: i works +facets:DayOfYear.taxonomy # freq=956148 freq=199177
-OrHighMedDayTaxoFacets: was 1982 +facets:DayOfYear.taxonomy # freq=3763623 freq=153269
-OrHighMedDayTaxoFacets: but 57 +facets:DayOfYear.taxonomy # freq=1456553 freq=93708
-OrHighMedDayTaxoFacets: date coord +facets:DayOfYear.taxonomy # freq=2020626 freq=180590
-OrHighMedDayTaxoFacets: cite science +facets:DayOfYear.taxonomy # freq=1741194 freq=219988
-OrHighMedDayTaxoFacets: two past +facets:DayOfYear.taxonomy # freq=1104053 freq=126130
-OrHighMedDayTaxoFacets: first albums +facets:DayOfYear.taxonomy # freq=1933372 freq=118322
-OrHighMedDayTaxoFacets: its 14 +facets:DayOfYear.taxonomy # freq=1173450 freq=534005
-OrHighMedDayTaxoFacets: when rowspan +facets:DayOfYear.taxonomy # freq=1027487 freq=124637
-OrHighMedDayTaxoFacets: for league +facets:DayOfYear.taxonomy # freq=4380011 freq=270223
-OrHighMedDayTaxoFacets: to keep +facets:DayOfYear.taxonomy # freq=6155577 freq=177996
-OrHighMedDayTaxoFacets: a baseball +facets:DayOfYear.taxonomy # freq=6560531 freq=93326
-OrHighMedDayTaxoFacets: publisher colspan +facets:DayOfYear.taxonomy # freq=1289029 freq=134521
-OrHighMedDayTaxoFacets: when release +facets:DayOfYear.taxonomy # freq=1027487 freq=189375
-OrHighMedDayTaxoFacets: see down +facets:DayOfYear.taxonomy # freq=1044180 freq=280662
-OrHighMedDayTaxoFacets: date does +facets:DayOfYear.taxonomy # freq=2020626 freq=232202
-OrHighMedDayTaxoFacets: s boston +facets:DayOfYear.taxonomy # freq=1581243 freq=85235
-OrHighMedDayTaxoFacets: but center +facets:DayOfYear.taxonomy # freq=1456553 freq=489673
-OrHighMedDayTaxoFacets: some originally +facets:DayOfYear.taxonomy # freq=839919 freq=168282
-OrHighMedDayTaxoFacets: all movement +facets:DayOfYear.taxonomy # freq=1203572 freq=131692
-OrHighMedDayTaxoFacets: an human +facets:DayOfYear.taxonomy # freq=2628056 freq=182617
-OrHighMedDayTaxoFacets: time life +facets:DayOfYear.taxonomy # freq=1032071 freq=477007
-OrHighMedDayTaxoFacets: first bridge +facets:DayOfYear.taxonomy # freq=1933372 freq=92398
-OrHighMedDayTaxoFacets: one comments +facets:DayOfYear.taxonomy # freq=1527689 freq=185637
-OrHighMedDayTaxoFacets: he background +facets:DayOfYear.taxonomy # freq=1659434 freq=314229
-OrHighMedDayTaxoFacets: 2006 1988 +facets:DayOfYear.taxonomy # freq=889954 freq=181327
-OrHighMedDayTaxoFacets: http fiction +facets:DayOfYear.taxonomy # freq=3493581 freq=87227
-OrHighMedDayTaxoFacets: 4 case +facets:DayOfYear.taxonomy # freq=986452 freq=207307
-OrHighMedDayTaxoFacets: there mike +facets:DayOfYear.taxonomy # freq=956153 freq=91795
-OrHighMedDayTaxoFacets: there 29 +facets:DayOfYear.taxonomy # freq=956153 freq=372091
-OrHighMedDayTaxoFacets: 2010 near +facets:DayOfYear.taxonomy # freq=950573 freq=254492
-OrHighMedDayTaxoFacets: url channel +facets:DayOfYear.taxonomy # freq=1513595 freq=101401
-OrHighMedDayTaxoFacets: two robert +facets:DayOfYear.taxonomy # freq=1104053 freq=246405
-OrHighMedDayTaxoFacets: or public +facets:DayOfYear.taxonomy # freq=1858841 freq=368868
-OrHighMedDayTaxoFacets: other robert +facets:DayOfYear.taxonomy # freq=1269961 freq=246405
-OrHighMedDayTaxoFacets: ref germany +facets:DayOfYear.taxonomy # freq=3793973 freq=190478
-OrHighMedDayTaxoFacets: one english +facets:DayOfYear.taxonomy # freq=1527689 freq=412061
-OrHighMedDayTaxoFacets: no cd +facets:DayOfYear.taxonomy # freq=1045000 freq=87105
-OrHighMedDayTaxoFacets: publisher what +facets:DayOfYear.taxonomy # freq=1289029 freq=394675
-OrHighMedDayTaxoFacets: their win +facets:DayOfYear.taxonomy # freq=1158682 freq=121070
-OrHighMedDayTaxoFacets: an 1959 +facets:DayOfYear.taxonomy # freq=2628056 freq=87097
-OrHighMedDayTaxoFacets: but digital +facets:DayOfYear.taxonomy # freq=1456553 freq=82650
-OrHighMedDayTaxoFacets: but 30 +facets:DayOfYear.taxonomy # freq=1456553 freq=488930
-OrHighMedDayTaxoFacets: work information +facets:DayOfYear.taxonomy # freq=853422 freq=353153
-OrHighMedDayTaxoFacets: by population +facets:DayOfYear.taxonomy # freq=3826691 freq=374481
-OrHighMedDayTaxoFacets: in post +facets:DayOfYear.taxonomy # freq=7320987 freq=218570
-OrHighMedDayTaxoFacets: who birth +facets:DayOfYear.taxonomy # freq=1196171 freq=425138
-OrHighMedDayTaxoFacets: who multiple +facets:DayOfYear.taxonomy # freq=1196171 freq=89684
-OrHighMedDayTaxoFacets: ref trade +facets:DayOfYear.taxonomy # freq=3793973 freq=106384
-OrHighMedDayTaxoFacets: after lord +facets:DayOfYear.taxonomy # freq=1247398 freq=106633
-OrHighMedDayTaxoFacets: to significant +facets:DayOfYear.taxonomy # freq=6155577 freq=111574
-OrHighMedDayTaxoFacets: also 1976 +facets:DayOfYear.taxonomy # freq=1959419 freq=134555
-OrHighMedDayTaxoFacets: which awards +facets:DayOfYear.taxonomy # freq=1963428 freq=159679
-OrHighMedDayTaxoFacets: by blue +facets:DayOfYear.taxonomy # freq=3826691 freq=156658
-OrHighMedDayTaxoFacets: that cause +facets:DayOfYear.taxonomy # freq=2931020 freq=83898
-OrHighMedDayTaxoFacets: about began +facets:DayOfYear.taxonomy # freq=850283 freq=276036
-OrHighMedDayTaxoFacets: other entire +facets:DayOfYear.taxonomy # freq=1269961 freq=97485
-OrHighMedDayTaxoFacets: has internet +facets:DayOfYear.taxonomy # freq=1502961 freq=85510
-OrHighMedDayTaxoFacets: url highest +facets:DayOfYear.taxonomy # freq=1513595 freq=91072
-OrHighMedDayTaxoFacets: an stage +facets:DayOfYear.taxonomy # freq=2628056 freq=113041
-OrHighMedDayTaxoFacets: title imagesize +facets:DayOfYear.taxonomy # freq=2397378 freq=82746
-OrHighMedDayTaxoFacets: see span +facets:DayOfYear.taxonomy # freq=1044180 freq=146676
-OrHighMedDayTaxoFacets: states 2007 +facets:DayOfYear.taxonomy # freq=1034872 freq=801586
-OrHighMedDayTaxoFacets: in clear +facets:DayOfYear.taxonomy # freq=7320987 freq=109812
-OrHighMedDayTaxoFacets: with jean +facets:DayOfYear.taxonomy # freq=3709421 freq=84299
-OrHighMedDayTaxoFacets: other dq +facets:DayOfYear.taxonomy # freq=1269961 freq=88557
-OrHighMedDayTaxoFacets: from chris +facets:DayOfYear.taxonomy # freq=3224339 freq=85523
-OrHighMedDayTaxoFacets: no next +facets:DayOfYear.taxonomy # freq=1045000 freq=259039
-OrHighMedDayTaxoFacets: for musical +facets:DayOfYear.taxonomy # freq=4380011 freq=132600
-OrHighMedDayTaxoFacets: see came +facets:DayOfYear.taxonomy # freq=1044180 freq=197126
-OrHighMedDayTaxoFacets: two wales +facets:DayOfYear.taxonomy # freq=1104053 freq=103595
-OrHighMedDayTaxoFacets: new eastern +facets:DayOfYear.taxonomy # freq=1657293 freq=176853
-OrHighMedDayTaxoFacets: 2 marriage +facets:DayOfYear.taxonomy # freq=1549245 freq=97658
-OrHighMedDayTaxoFacets: 2009 forces +facets:DayOfYear.taxonomy # freq=887702 freq=152939
-OrHighMedDayTaxoFacets: at any +facets:DayOfYear.taxonomy # freq=2857534 freq=483514
-OrHighMedDayTaxoFacets: as live +facets:DayOfYear.taxonomy # freq=3925535 freq=242147
-OrHighMedDayTaxoFacets: see academy +facets:DayOfYear.taxonomy # freq=1044180 freq=119055
-OrHighMedDayTaxoFacets: their get +facets:DayOfYear.taxonomy # freq=1158682 freq=187847
-OrHighMedDayTaxoFacets: about via +facets:DayOfYear.taxonomy # freq=850283 freq=109090
-OrHighMedDayTaxoFacets: only fields +facets:DayOfYear.taxonomy # freq=875561 freq=86938
-OrHighMedDayTaxoFacets: time central +facets:DayOfYear.taxonomy # freq=1032071 freq=272531
-OrHighMedDayTaxoFacets: two my +facets:DayOfYear.taxonomy # freq=1104053 freq=274256
-OrHighMedDayTaxoFacets: with land +facets:DayOfYear.taxonomy # freq=3709421 freq=230284
-OrHighMedDayTaxoFacets: two financial +facets:DayOfYear.taxonomy # freq=1104053 freq=82536
-OrHighMedDayTaxoFacets: was convert +facets:DayOfYear.taxonomy # freq=3763623 freq=267974
-OrHighMedDayTaxoFacets: not course +facets:DayOfYear.taxonomy # freq=1713264 freq=106126
-OrHighMedDayTaxoFacets: 10 producer +facets:DayOfYear.taxonomy # freq=918339 freq=137098
-OrHighMedDayTaxoFacets: 3 52 +facets:DayOfYear.taxonomy # freq=1148799 freq=108395
-OrHighMedDayTaxoFacets: 2008 final +facets:DayOfYear.taxonomy # freq=831253 freq=230006
-OrHighMedDayTaxoFacets: from sir +facets:DayOfYear.taxonomy # freq=3224339 freq=107709
-OrHighMedDayTaxoFacets: to majority +facets:DayOfYear.taxonomy # freq=6155577 freq=105058
-OrHighMedDayTaxoFacets: work published +facets:DayOfYear.taxonomy # freq=853422 freq=243548
-OrHighMedDayTaxoFacets: but might +facets:DayOfYear.taxonomy # freq=1456553 freq=114290
-OrHighMedDayTaxoFacets: has radio +facets:DayOfYear.taxonomy # freq=1502961 freq=183866
-OrHighMedDayTaxoFacets: of 45 +facets:DayOfYear.taxonomy # freq=8184358 freq=180879
-OrHighMedDayTaxoFacets: some africa +facets:DayOfYear.taxonomy # freq=839919 freq=124511
-OrHighMedDayTaxoFacets: title club +facets:DayOfYear.taxonomy # freq=2397378 freq=232173
-OrHighMedDayTaxoFacets: his bgcolor +facets:DayOfYear.taxonomy # freq=1777780 freq=124305
-OrHighMedDayTaxoFacets: that opened +facets:DayOfYear.taxonomy # freq=2931020 freq=140033
-OrHighMedDayTaxoFacets: new station +facets:DayOfYear.taxonomy # freq=1657293 freq=239572
-OrHighMedDayTaxoFacets: were value +facets:DayOfYear.taxonomy # freq=1524630 freq=86806
-OrHighMedDayTaxoFacets: time end +facets:DayOfYear.taxonomy # freq=1032071 freq=526636
-OrHighMedDayTaxoFacets: date start +facets:DayOfYear.taxonomy # freq=2020626 freq=233925
-OrHighMedDayTaxoFacets: 3 across +facets:DayOfYear.taxonomy # freq=1148799 freq=134478
-OrHighMedDayTaxoFacets: 1 j +facets:DayOfYear.taxonomy # freq=1641090 freq=327713
-OrHighMedDayTaxoFacets: the ever +facets:DayOfYear.taxonomy # freq=8217362 freq=128732
-OrHighMedDayTaxoFacets: s archive +facets:DayOfYear.taxonomy # freq=1581243 freq=215381
-OrHighMedDayTaxoFacets: date style +facets:DayOfYear.taxonomy # freq=2020626 freq=606000
-OrHighMedDayTaxoFacets: 2010 caused +facets:DayOfYear.taxonomy # freq=950573 freq=86397
-OrHighMedDayTaxoFacets: or past +facets:DayOfYear.taxonomy # freq=1858841 freq=126130
-OrHighMedDayTaxoFacets: also edits +facets:DayOfYear.taxonomy # freq=1959419 freq=134321
-OrHighMedDayTaxoFacets: http stated +facets:DayOfYear.taxonomy # freq=3493581 freq=89795
-OrHighMedDayTaxoFacets: publisher association +facets:DayOfYear.taxonomy # freq=1289029 freq=247156
-OrHighMedDayTaxoFacets: other europe +facets:DayOfYear.taxonomy # freq=1269961 freq=188671
-OrHighMedDayTaxoFacets: work japan +facets:DayOfYear.taxonomy # freq=853422 freq=163103
-OrHighMedDayTaxoFacets: been committee +facets:DayOfYear.taxonomy # freq=1041183 freq=108636
-OrHighMedDayTaxoFacets: about five +facets:DayOfYear.taxonomy # freq=850283 freq=262923
-OrHighMedDayTaxoFacets: the throughout +facets:DayOfYear.taxonomy # freq=8217362 freq=143603
-OrHighMedDayTaxoFacets: first studies +facets:DayOfYear.taxonomy # freq=1933372 freq=128020
-OrHighMedDayTaxoFacets: his university +facets:DayOfYear.taxonomy # freq=1777780 freq=636959
-OrHighMedDayTaxoFacets: there legal +facets:DayOfYear.taxonomy # freq=956153 freq=90645
-OrHighMedDayTaxoFacets: all italian +facets:DayOfYear.taxonomy # freq=1203572 freq=107082
-OrHighMedDayTaxoFacets: may buildings +facets:DayOfYear.taxonomy # freq=1071932 freq=89046
-OrHighMedDayTaxoFacets: with day +facets:DayOfYear.taxonomy # freq=3709421 freq=402096
-OrHighMedDayTaxoFacets: is code +facets:DayOfYear.taxonomy # freq=4074455 freq=170156
-OrHighMedDayTaxoFacets: date asia +facets:DayOfYear.taxonomy # freq=2020626 freq=90307
-OrHighMedDayTaxoFacets: and thumb +facets:DayOfYear.taxonomy # freq=7318061 freq=672667
-OrHighMedDayTaxoFacets: 10 1970 +facets:DayOfYear.taxonomy # freq=918339 freq=139043
-OrHighMedDayTaxoFacets: from generated +facets:DayOfYear.taxonomy # freq=3224339 freq=97908
-OrHighMedDayTaxoFacets: for light +facets:DayOfYear.taxonomy # freq=4380011 freq=161671
-OrHighMedDayTaxoFacets: about 1970 +facets:DayOfYear.taxonomy # freq=850283 freq=139043
-OrHighMedDayTaxoFacets: states start +facets:DayOfYear.taxonomy # freq=1034872 freq=233925
-OrHighMedDayTaxoFacets: 2 sir +facets:DayOfYear.taxonomy # freq=1549245 freq=107709
-OrHighMedDayTaxoFacets: from information +facets:DayOfYear.taxonomy # freq=3224339 freq=353153
-OrHighMedDayTaxoFacets: 3 reflist +facets:DayOfYear.taxonomy # freq=1148799 freq=561253
-OrHighMedDayTaxoFacets: year modern +facets:DayOfYear.taxonomy # freq=1235231 freq=218831
-OrHighMedDayTaxoFacets: states successful +facets:DayOfYear.taxonomy # freq=1034872 freq=106021
-OrHighMedDayTaxoFacets: on local +facets:DayOfYear.taxonomy # freq=4074624 freq=299012
-OrHighMedDayTaxoFacets: also production +facets:DayOfYear.taxonomy # freq=1959419 freq=191554
-OrHighMedDayTaxoFacets: ref white +facets:DayOfYear.taxonomy # freq=3793973 freq=299411
-OrHighMedDayTaxoFacets: that too +facets:DayOfYear.taxonomy # freq=2931020 freq=161626
-OrHighMedDayTaxoFacets: 2 20 +facets:DayOfYear.taxonomy # freq=1549245 freq=624967
-OrHighMedDayTaxoFacets: 2008 strong +facets:DayOfYear.taxonomy # freq=831253 freq=125611
-OrHighMedDayTaxoFacets: no list +facets:DayOfYear.taxonomy # freq=1045000 freq=585922
-OrHighMedDayTaxoFacets: first label +facets:DayOfYear.taxonomy # freq=1933372 freq=159161
-OrHighMedDayTaxoFacets: see metadata +facets:DayOfYear.taxonomy # freq=1044180 freq=298533
-OrHighMedDayTaxoFacets: they before +facets:DayOfYear.taxonomy # freq=1021945 freq=580481
-OrHighMedDayTaxoFacets: been volume +facets:DayOfYear.taxonomy # freq=1041183 freq=312846
-OrHighMedDayTaxoFacets: last division +facets:DayOfYear.taxonomy # freq=958437 freq=182624
-OrHighMedDayTaxoFacets: new 1988 +facets:DayOfYear.taxonomy # freq=1657293 freq=181327
-OrHighMedDayTaxoFacets: its single +facets:DayOfYear.taxonomy # freq=1173450 freq=283824
-OrHighMedDayTaxoFacets: accessdate awards +facets:DayOfYear.taxonomy # freq=1228887 freq=159679
-OrHighMedDayTaxoFacets: of 1974 +facets:DayOfYear.taxonomy # freq=8184358 freq=132835
-OrHighMedDayTaxoFacets: and st +facets:DayOfYear.taxonomy # freq=7318061 freq=309092
-OrHighMedDayTaxoFacets: which 2002 +facets:DayOfYear.taxonomy # freq=1963428 freq=406953
-OrHighMedDayTaxoFacets: 10 role +facets:DayOfYear.taxonomy # freq=918339 freq=208579
-OrHighMedDayTaxoFacets: 2008 infobox +facets:DayOfYear.taxonomy # freq=831253 freq=524810
-OrHighMedDayTaxoFacets: by units +facets:DayOfYear.taxonomy # freq=3826691 freq=118189
-OrHighMedDayTaxoFacets: see reported +facets:DayOfYear.taxonomy # freq=1044180 freq=91533
-OrHighMedDayTaxoFacets: were love +facets:DayOfYear.taxonomy # freq=1524630 freq=177242
-OrHighMedDayTaxoFacets: their london +facets:DayOfYear.taxonomy # freq=1158682 freq=348918
-OrHighMedDayTaxoFacets: who persondata +facets:DayOfYear.taxonomy # freq=1196171 freq=246119
-OrHighMedDayTaxoFacets: be uk +facets:DayOfYear.taxonomy # freq=2051702 freq=319211
-OrHighMedDayTaxoFacets: for f +facets:DayOfYear.taxonomy # freq=4380011 freq=278015
-OrHighMedDayTaxoFacets: only hold +facets:DayOfYear.taxonomy # freq=875561 freq=82579
-OrHighMedDayTaxoFacets: new way +facets:DayOfYear.taxonomy # freq=1657293 freq=318344
-OrHighMedDayTaxoFacets: which lines +facets:DayOfYear.taxonomy # freq=1963428 freq=96969
-OrHighMedDayTaxoFacets: has div +facets:DayOfYear.taxonomy # freq=1502961 freq=206057
-OrHighMedDayTaxoFacets: all francisco +facets:DayOfYear.taxonomy # freq=1203572 freq=83200
-OrHighMedDayTaxoFacets: from per +facets:DayOfYear.taxonomy # freq=3224339 freq=283568
-OrHighMedDayTaxoFacets: it marriage +facets:DayOfYear.taxonomy # freq=2675552 freq=97658
-OrHighMedDayTaxoFacets: states small +facets:DayOfYear.taxonomy # freq=1034872 freq=581643
-OrHighMedDayTaxoFacets: 2011 july +facets:DayOfYear.taxonomy # freq=871410 freq=529655
-OrHighMedDayTaxoFacets: and mid +facets:DayOfYear.taxonomy # freq=7318061 freq=126355
-OrHighMedDayTaxoFacets: year copy +facets:DayOfYear.taxonomy # freq=1235231 freq=95252
-OrHighMedDayTaxoFacets: not ft +facets:DayOfYear.taxonomy # freq=1713264 freq=88505
-OrHighMedDayTaxoFacets: this 1988 +facets:DayOfYear.taxonomy # freq=2224932 freq=181327
-OrHighMedDayTaxoFacets: accessdate father +facets:DayOfYear.taxonomy # freq=1228887 freq=175393
-OrHighMedDayTaxoFacets: this continued +facets:DayOfYear.taxonomy # freq=2224932 freq=151209
-OrHighMedDayTaxoFacets: with union +facets:DayOfYear.taxonomy # freq=3709421 freq=214164
-OrHighMedDayTaxoFacets: 2011 festival +facets:DayOfYear.taxonomy # freq=871410 freq=85717
-OrHighMedDayTaxoFacets: states hall +facets:DayOfYear.taxonomy # freq=1034872 freq=177247
-OrHighMedDayTaxoFacets: after thomas +facets:DayOfYear.taxonomy # freq=1247398 freq=191625
-OrHighMedDayTaxoFacets: 2 god +facets:DayOfYear.taxonomy # freq=1549245 freq=97443
-OrHighMedDayTaxoFacets: states owned +facets:DayOfYear.taxonomy # freq=1034872 freq=93981
-OrHighMedDayTaxoFacets: were european +facets:DayOfYear.taxonomy # freq=1524630 freq=193975
-OrHighMedDayTaxoFacets: have jack +facets:DayOfYear.taxonomy # freq=1297121 freq=91552
-OrHighMedDayTaxoFacets: time majority +facets:DayOfYear.taxonomy # freq=1032071 freq=105058
-OrHighMedDayTaxoFacets: were went +facets:DayOfYear.taxonomy # freq=1524630 freq=172677
-OrHighMedDayTaxoFacets: only game +facets:DayOfYear.taxonomy # freq=875561 freq=315157
-OrHighMedDayTaxoFacets: a review +facets:DayOfYear.taxonomy # freq=6560531 freq=240157
-OrHighMedDayTaxoFacets: united thomas +facets:DayOfYear.taxonomy # freq=1196944 freq=191625
-OrHighMedDayTaxoFacets: may off +facets:DayOfYear.taxonomy # freq=1071932 freq=315473
-OrHighMedDayTaxoFacets: url persondata +facets:DayOfYear.taxonomy # freq=1513595 freq=246119
-OrHighMedDayTaxoFacets: new hill +facets:DayOfYear.taxonomy # freq=1657293 freq=133714
-OrHighMedDayTaxoFacets: at ice +facets:DayOfYear.taxonomy # freq=2857534 freq=87086
-OrHighMedDayTaxoFacets: 2008 fourth +facets:DayOfYear.taxonomy # freq=831253 freq=102351
-OrHighMedDayTaxoFacets: for 3rd +facets:DayOfYear.taxonomy # freq=4380011 freq=90723
-OrHighMedDayTaxoFacets: more cross +facets:DayOfYear.taxonomy # freq=963533 freq=127216
-OrHighMedDayTaxoFacets: not index.php +facets:DayOfYear.taxonomy # freq=1713264 freq=126813
-OrHighMedDayTaxoFacets: but census +facets:DayOfYear.taxonomy # freq=1456553 freq=205166
-OrHighMedDayTaxoFacets: work replaced +facets:DayOfYear.taxonomy # freq=853422 freq=112506
-OrHighMedDayTaxoFacets: some groups +facets:DayOfYear.taxonomy # freq=839919 freq=146670
-OrHighMedDayTaxoFacets: 10 collection +facets:DayOfYear.taxonomy # freq=918339 freq=110483
-OrHighMedDayTaxoFacets: not opening +facets:DayOfYear.taxonomy # freq=1713264 freq=84576
-OrHighMedDayTaxoFacets: see september +facets:DayOfYear.taxonomy # freq=1044180 freq=553409
-OrHighMedDayTaxoFacets: 4 steve +facets:DayOfYear.taxonomy # freq=986452 freq=84364
-OrHighMedDayTaxoFacets: ref appears +facets:DayOfYear.taxonomy # freq=3793973 freq=104511
-OrHighMedDayTaxoFacets: a named +facets:DayOfYear.taxonomy # freq=6560531 freq=310150
-OrHighMedDayTaxoFacets: which pre +facets:DayOfYear.taxonomy # freq=1963428 freq=90549
-OrHighMedDayTaxoFacets: has stone +facets:DayOfYear.taxonomy # freq=1502961 freq=92132
-OrHighMedDayTaxoFacets: to energy +facets:DayOfYear.taxonomy # freq=6155577 freq=91150
-OrHighMedDayTaxoFacets: not should +facets:DayOfYear.taxonomy # freq=1713264 freq=401379
-OrHighMedDayTaxoFacets: 2010 media +facets:DayOfYear.taxonomy # freq=950573 freq=206574
-OrHighMedDayTaxoFacets: was behind +facets:DayOfYear.taxonomy # freq=3763623 freq=112070
-OrHighMedDayTaxoFacets: that black +facets:DayOfYear.taxonomy # freq=2931020 freq=256526
-OrHighMedDayTaxoFacets: are itself +facets:DayOfYear.taxonomy # freq=1877802 freq=138231
-OrHighMedDayTaxoFacets: only 90 +facets:DayOfYear.taxonomy # freq=875561 freq=116206
-OrHighMedDayTaxoFacets: 4 main +facets:DayOfYear.taxonomy # freq=986452 freq=470429
-OrHighMedDayTaxoFacets: with august +facets:DayOfYear.taxonomy # freq=3709421 freq=527806
-OrHighMedDayTaxoFacets: have age +facets:DayOfYear.taxonomy # freq=1297121 freq=395368
-OrHighMedDayTaxoFacets: time citation +facets:DayOfYear.taxonomy # freq=1032071 freq=291478
-OrHighMedDayTaxoFacets: his notes +facets:DayOfYear.taxonomy # freq=1777780 freq=210029
-OrHighMedDayTaxoFacets: year 17 +facets:DayOfYear.taxonomy # freq=1235231 freq=507396
-OrHighMedDayTaxoFacets: i bbc +facets:DayOfYear.taxonomy # freq=956148 freq=138548
-OrHighMedDayTaxoFacets: name 1984 +facets:DayOfYear.taxonomy # freq=2827713 freq=161404
-OrHighMedDayTaxoFacets: his greek +facets:DayOfYear.taxonomy # freq=1777780 freq=94348
-OrHighMedDayTaxoFacets: cite votes +facets:DayOfYear.taxonomy # freq=1741194 freq=93844
-OrHighMedDayTaxoFacets: be fire +facets:DayOfYear.taxonomy # freq=2051702 freq=133712
-OrHighMedDayTaxoFacets: in sometimes +facets:DayOfYear.taxonomy # freq=7320987 freq=144078
-OrHighMedDayTaxoFacets: last better +facets:DayOfYear.taxonomy # freq=958437 freq=125889
-OrHighMedDayTaxoFacets: by considered +facets:DayOfYear.taxonomy # freq=3826691 freq=186840
-OrHighMedDayTaxoFacets: no leading +facets:DayOfYear.taxonomy # freq=1045000 freq=120945
-OrHighMedDayTaxoFacets: name influence +facets:DayOfYear.taxonomy # freq=2827713 freq=83101
-OrHighMedDayTaxoFacets: 2009 power +facets:DayOfYear.taxonomy # freq=887702 freq=262586
-OrHighMedDayTaxoFacets: is institute +facets:DayOfYear.taxonomy # freq=4074455 freq=136311
-OrHighMedDayTaxoFacets: into doi +facets:DayOfYear.taxonomy # freq=888684 freq=170085
-OrHighMedDayTaxoFacets: into short +facets:DayOfYear.taxonomy # freq=888684 freq=465205
-OrHighMedDayTaxoFacets: were gr +facets:DayOfYear.taxonomy # freq=1524630 freq=83712
-OrHighMedDayTaxoFacets: has 16 +facets:DayOfYear.taxonomy # freq=1502961 freq=540539
-OrHighMedDayTaxoFacets: this towards +facets:DayOfYear.taxonomy # freq=2224932 freq=95574
-OrHighMedDayTaxoFacets: the div +facets:DayOfYear.taxonomy # freq=8217362 freq=206057
-OrHighMedDayTaxoFacets: its jean +facets:DayOfYear.taxonomy # freq=1173450 freq=84299
-OrHighMedDayTaxoFacets: their continued +facets:DayOfYear.taxonomy # freq=1158682 freq=151209
-OrHighMedDayTaxoFacets: publisher come +facets:DayOfYear.taxonomy # freq=1289029 freq=139047
-OrHighMedDayTaxoFacets: name yet +facets:DayOfYear.taxonomy # freq=2827713 freq=100857
-OrHighMedDayTaxoFacets: be before +facets:DayOfYear.taxonomy # freq=2051702 freq=580481
-OrHighMedDayTaxoFacets: ref britain +facets:DayOfYear.taxonomy # freq=3793973 freq=101080
-OrHighMedDayTaxoFacets: 10 returned +facets:DayOfYear.taxonomy # freq=918339 freq=141639
-OrHighMedDayTaxoFacets: 2006 02 +facets:DayOfYear.taxonomy # freq=889954 freq=319783
-OrHighMedDayTaxoFacets: 2011 daughter +facets:DayOfYear.taxonomy # freq=871410 freq=103883
-OrHighMedDayTaxoFacets: be independent +facets:DayOfYear.taxonomy # freq=2051702 freq=164766
-OrHighMedDayTaxoFacets: more self +facets:DayOfYear.taxonomy # freq=963533 freq=135012
-OrHighMedDayTaxoFacets: in particular +facets:DayOfYear.taxonomy # freq=7320987 freq=103643
-OrHighMedDayTaxoFacets: which non +facets:DayOfYear.taxonomy # freq=1963428 freq=348142
-OrHighMedDayTaxoFacets: his birth +facets:DayOfYear.taxonomy # freq=1777780 freq=425138
-OrHighMedDayTaxoFacets: ref stations +facets:DayOfYear.taxonomy # freq=3793973 freq=92011
-OrHighMedDayTaxoFacets: united include +facets:DayOfYear.taxonomy # freq=1196944 freq=276466
-OrHighMedDayTaxoFacets: http flight +facets:DayOfYear.taxonomy # freq=3493581 freq=84316
-OrHighMedDayTaxoFacets: http singles +facets:DayOfYear.taxonomy # freq=3493581 freq=89221
-OrHighMedDayTaxoFacets: year northern +facets:DayOfYear.taxonomy # freq=1235231 freq=194363
-OrHighMedDayTaxoFacets: been htm +facets:DayOfYear.taxonomy # freq=1041183 freq=191479
-OrHighMedDayTaxoFacets: one alone +facets:DayOfYear.taxonomy # freq=1527689 freq=93166
-OrHighMedDayTaxoFacets: their systems +facets:DayOfYear.taxonomy # freq=1158682 freq=134476
-OrHighMedDayTaxoFacets: to yet +facets:DayOfYear.taxonomy # freq=6155577 freq=100857
-OrHighMedDayTaxoFacets: see leader +facets:DayOfYear.taxonomy # freq=1044180 freq=127591
-OrHighMedDayTaxoFacets: on seen +facets:DayOfYear.taxonomy # freq=4074624 freq=173530
-OrHighMedDayTaxoFacets: has 200px +facets:DayOfYear.taxonomy # freq=1502961 freq=102661
-OrHighMedDayTaxoFacets: that 56 +facets:DayOfYear.taxonomy # freq=2931020 freq=96215
-OrHighMedDayTaxoFacets: about women +facets:DayOfYear.taxonomy # freq=850283 freq=128847
-OrHighMedDayTaxoFacets: only michael +facets:DayOfYear.taxonomy # freq=875561 freq=217311
-OrHighMedDayTaxoFacets: 2009 provided +facets:DayOfYear.taxonomy # freq=887702 freq=110088
-OrHighMedDayTaxoFacets: with show +facets:DayOfYear.taxonomy # freq=3709421 freq=293934
-OrHighMedDayTaxoFacets: 2011 utc +facets:DayOfYear.taxonomy # freq=871410 freq=450225
-OrHighMedDayTaxoFacets: which give +facets:DayOfYear.taxonomy # freq=1963428 freq=116375
-OrHighMedDayTaxoFacets: 2010 support +facets:DayOfYear.taxonomy # freq=950573 freq=236989
-OrHighMedDayTaxoFacets: 4 very +facets:DayOfYear.taxonomy # freq=986452 freq=354898
-OrHighMedDayTaxoFacets: 2 foreign +facets:DayOfYear.taxonomy # freq=1549245 freq=109174
-OrHighMedDayTaxoFacets: were 59 +facets:DayOfYear.taxonomy # freq=1524630 freq=93856
-OrHighMedDayTaxoFacets: 2010 take +facets:DayOfYear.taxonomy # freq=950573 freq=224260
-OrHighMedDayTaxoFacets: by york +facets:DayOfYear.taxonomy # freq=3826691 freq=521383
-OrHighMedDayTaxoFacets: http kingdom +facets:DayOfYear.taxonomy # freq=3493581 freq=299825
-OrHighMedDayTaxoFacets: only brother +facets:DayOfYear.taxonomy # freq=875561 freq=110146
-OrHighMedDayTaxoFacets: no died +facets:DayOfYear.taxonomy # freq=1045000 freq=202125
-OrHighMedDayTaxoFacets: other november +facets:DayOfYear.taxonomy # freq=1269961 freq=527131
-OrHighMedDayTaxoFacets: 2008 system +facets:DayOfYear.taxonomy # freq=831253 freq=412862
-OrHighMedDayTaxoFacets: 5 still +facets:DayOfYear.taxonomy # freq=891361 freq=332543
-OrHighMedDayTaxoFacets: by required +facets:DayOfYear.taxonomy # freq=3826691 freq=100578
-OrHighMedDayTaxoFacets: title era +facets:DayOfYear.taxonomy # freq=2397378 freq=95989
-OrHighMedDayTaxoFacets: 3 larger +facets:DayOfYear.taxonomy # freq=1148799 freq=87424
-OrHighMedDayTaxoFacets: into within +facets:DayOfYear.taxonomy # freq=888684 freq=291049
-OrHighMedDayTaxoFacets: http where +facets:DayOfYear.taxonomy # freq=3493581 freq=630647
-OrHighMedDayTaxoFacets: united say +facets:DayOfYear.taxonomy # freq=1196944 freq=110895
-OrHighMedDayTaxoFacets: no second +facets:DayOfYear.taxonomy # freq=1045000 freq=505575
-OrHighMedDayTaxoFacets: work 1998 +facets:DayOfYear.taxonomy # freq=853422 freq=300506
-OrHighMedDayTaxoFacets: 1 think +facets:DayOfYear.taxonomy # freq=1641090 freq=129332
-OrHighMedDayTaxoFacets: by b +facets:DayOfYear.taxonomy # freq=3826691 freq=369454
-OrHighMedDayTaxoFacets: 4 thumb +facets:DayOfYear.taxonomy # freq=986452 freq=672667
-OrHighMedDayTaxoFacets: be usa +facets:DayOfYear.taxonomy # freq=2051702 freq=191220
-OrHighMedDayTaxoFacets: not african +facets:DayOfYear.taxonomy # freq=1713264 freq=128682
-OrHighMedDayTaxoFacets: 1 president +facets:DayOfYear.taxonomy # freq=1641090 freq=263341
-OrHighMedDayTaxoFacets: 4 worked +facets:DayOfYear.taxonomy # freq=986452 freq=119896
-OrHighMedDayTaxoFacets: http added +facets:DayOfYear.taxonomy # freq=3493581 freq=138409
-OrHighMedDayTaxoFacets: s deletion +facets:DayOfYear.taxonomy # freq=1581243 freq=166633
-OrHighMedDayTaxoFacets: time nbsp +facets:DayOfYear.taxonomy # freq=1032071 freq=506054
-OrHighMedDayTaxoFacets: when 02 +facets:DayOfYear.taxonomy # freq=1027487 freq=319783
-OrHighMedDayTaxoFacets: may la +facets:DayOfYear.taxonomy # freq=1071932 freq=232610
-OrHighMedDayTaxoFacets: 2 royal +facets:DayOfYear.taxonomy # freq=1549245 freq=211710
-OrHighMedDayTaxoFacets: from office +facets:DayOfYear.taxonomy # freq=3224339 freq=225338
-OrHighMedDayTaxoFacets: and 22 +facets:DayOfYear.taxonomy # freq=7318061 freq=502778
-OrHighMedDayTaxoFacets: cite order +facets:DayOfYear.taxonomy # freq=1741194 freq=360915
-OrHighMedDayTaxoFacets: of upper +facets:DayOfYear.taxonomy # freq=8184358 freq=86379
-OrHighMedDayTaxoFacets: all htm +facets:DayOfYear.taxonomy # freq=1203572 freq=191479
-OrHighMedDayTaxoFacets: he towards +facets:DayOfYear.taxonomy # freq=1659434 freq=95574
-OrHighMedDayTaxoFacets: are traditional +facets:DayOfYear.taxonomy # freq=1877802 freq=110425
-OrHighMedDayTaxoFacets: a team +facets:DayOfYear.taxonomy # freq=6560531 freq=379028
-OrHighMedDayTaxoFacets: or imagesize +facets:DayOfYear.taxonomy # freq=1858841 freq=82746
-OrHighMedDayTaxoFacets: date regular +facets:DayOfYear.taxonomy # freq=2020626 freq=93809
-OrHighMedDayTaxoFacets: or birth_date +facets:DayOfYear.taxonomy # freq=1858841 freq=122665
-OrHighMedDayTaxoFacets: name each +facets:DayOfYear.taxonomy # freq=2827713 freq=354583
-OrHighMedDayTaxoFacets: but begin +facets:DayOfYear.taxonomy # freq=1456553 freq=104303
-OrHighMedDayTaxoFacets: 2 developed +facets:DayOfYear.taxonomy # freq=1549245 freq=151220
-OrHighMedDayTaxoFacets: ref note +facets:DayOfYear.taxonomy # freq=3793973 freq=194472
-OrHighMedDayTaxoFacets: united programs +facets:DayOfYear.taxonomy # freq=1196944 freq=83974
+BrowseDateTaxoFacets: *:* +facets:taxonomy:Date
+BrowseMonthTaxoFacets: *:* +facets:taxonomy:Month
+BrowseDayOfYearTaxoFacets: *:* +facets:taxonomy:DayOfYear
+BrowseRandomLabelTaxoFacets: *:* +facets:taxonomy:RandomLabel
+MedTermDayTaxoFacets: most +facets:taxonomy:DayOfYear # freq=819634
+MedTermDayTaxoFacets: up +facets:taxonomy:DayOfYear # freq=818546
+MedTermDayTaxoFacets: world +facets:taxonomy:DayOfYear # freq=808563
+MedTermDayTaxoFacets: 2007 +facets:taxonomy:DayOfYear # freq=801586
+MedTermDayTaxoFacets: during +facets:taxonomy:DayOfYear # freq=798114
+MedTermDayTaxoFacets: people +facets:taxonomy:DayOfYear # freq=790960
+MedTermDayTaxoFacets: years +facets:taxonomy:DayOfYear # freq=789628
+MedTermDayTaxoFacets: such +facets:taxonomy:DayOfYear # freq=787877
+MedTermDayTaxoFacets: 12 +facets:taxonomy:DayOfYear # freq=774572
+MedTermDayTaxoFacets: over +facets:taxonomy:DayOfYear # freq=774312
+MedTermDayTaxoFacets: can +facets:taxonomy:DayOfYear # freq=765163
+MedTermDayTaxoFacets: references +facets:taxonomy:DayOfYear # freq=760306
+MedTermDayTaxoFacets: city +facets:taxonomy:DayOfYear # freq=760272
+MedTermDayTaxoFacets: 6 +facets:taxonomy:DayOfYear # freq=759234
+MedTermDayTaxoFacets: american +facets:taxonomy:DayOfYear # freq=758337
+MedTermDayTaxoFacets: news +facets:taxonomy:DayOfYear # freq=756063
+MedTermDayTaxoFacets: history +facets:taxonomy:DayOfYear # freq=755471
+MedTermDayTaxoFacets: 0 +facets:taxonomy:DayOfYear # freq=754451
+MedTermDayTaxoFacets: made +facets:taxonomy:DayOfYear # freq=742313
+MedTermDayTaxoFacets: out +facets:taxonomy:DayOfYear # freq=733775
+MedTermDayTaxoFacets: 11 +facets:taxonomy:DayOfYear # freq=730505
+MedTermDayTaxoFacets: used +facets:taxonomy:DayOfYear # freq=708455
+MedTermDayTaxoFacets: links +facets:taxonomy:DayOfYear # freq=703350
+MedTermDayTaxoFacets: state +facets:taxonomy:DayOfYear # freq=702598
+MedTermDayTaxoFacets: many +facets:taxonomy:DayOfYear # freq=694439
+MedTermDayTaxoFacets: would +facets:taxonomy:DayOfYear # freq=690480
+MedTermDayTaxoFacets: page +facets:taxonomy:DayOfYear # freq=681036
+MedTermDayTaxoFacets: national +facets:taxonomy:DayOfYear # freq=677281
+MedTermDayTaxoFacets: than +facets:taxonomy:DayOfYear # freq=676864
+MedTermDayTaxoFacets: thumb +facets:taxonomy:DayOfYear # freq=672667
+MedTermDayTaxoFacets: 7 +facets:taxonomy:DayOfYear # freq=660220
+MedTermDayTaxoFacets: place +facets:taxonomy:DayOfYear # freq=654158
+MedTermDayTaxoFacets: de +facets:taxonomy:DayOfYear # freq=652242
+MedTermDayTaxoFacets: if +facets:taxonomy:DayOfYear # freq=640551
+MedTermDayTaxoFacets: university +facets:taxonomy:DayOfYear # freq=636959
+MedTermDayTaxoFacets: 8 +facets:taxonomy:DayOfYear # freq=635822
+MedTermDayTaxoFacets: external +facets:taxonomy:DayOfYear # freq=635450
+MedTermDayTaxoFacets: between +facets:taxonomy:DayOfYear # freq=630650
+MedTermDayTaxoFacets: where +facets:taxonomy:DayOfYear # freq=630647
+MedTermDayTaxoFacets: right +facets:taxonomy:DayOfYear # freq=630423
+MedTermDayTaxoFacets: 20 +facets:taxonomy:DayOfYear # freq=624967
+MedTermDayTaxoFacets: under +facets:taxonomy:DayOfYear # freq=623872
+MedTermDayTaxoFacets: these +facets:taxonomy:DayOfYear # freq=623267
+MedTermDayTaxoFacets: march +facets:taxonomy:DayOfYear # freq=620393
+MedTermDayTaxoFacets: br +facets:taxonomy:DayOfYear # freq=617824
+MedTermDayTaxoFacets: book +facets:taxonomy:DayOfYear # freq=617297
+MedTermDayTaxoFacets: p +facets:taxonomy:DayOfYear # freq=616159
+MedTermDayTaxoFacets: article +facets:taxonomy:DayOfYear # freq=610650
+MedTermDayTaxoFacets: known +facets:taxonomy:DayOfYear # freq=607158
+MedTermDayTaxoFacets: then +facets:taxonomy:DayOfYear # freq=606159
+MedTermDayTaxoFacets: style +facets:taxonomy:DayOfYear # freq=606000
+MedTermDayTaxoFacets: later +facets:taxonomy:DayOfYear # freq=604921
+MedTermDayTaxoFacets: three +facets:taxonomy:DayOfYear # freq=598349
+MedTermDayTaxoFacets: use +facets:taxonomy:DayOfYear # freq=597053
+MedTermDayTaxoFacets: category +facets:taxonomy:DayOfYear # freq=595446
+MedTermDayTaxoFacets: john +facets:taxonomy:DayOfYear # freq=594461
+MedTermDayTaxoFacets: part +facets:taxonomy:DayOfYear # freq=594224
+MedTermDayTaxoFacets: left +facets:taxonomy:DayOfYear # freq=593967
+MedTermDayTaxoFacets: 2004 +facets:taxonomy:DayOfYear # freq=593934
+MedTermDayTaxoFacets: 15 +facets:taxonomy:DayOfYear # freq=592407
+MedTermDayTaxoFacets: december +facets:taxonomy:DayOfYear # freq=590171
+MedTermDayTaxoFacets: april +facets:taxonomy:DayOfYear # freq=587542
+MedTermDayTaxoFacets: list +facets:taxonomy:DayOfYear # freq=585922
+MedTermDayTaxoFacets: 18 +facets:taxonomy:DayOfYear # freq=585631
+MedTermDayTaxoFacets: small +facets:taxonomy:DayOfYear # freq=581643
+MedTermDayTaxoFacets: january +facets:taxonomy:DayOfYear # freq=581309
+MedTermDayTaxoFacets: before +facets:taxonomy:DayOfYear # freq=580481
+MedTermDayTaxoFacets: being +facets:taxonomy:DayOfYear # freq=580185
+MedTermDayTaxoFacets: well +facets:taxonomy:DayOfYear # freq=580011
+MedTermDayTaxoFacets: id +facets:taxonomy:DayOfYear # freq=579566
+MedTermDayTaxoFacets: while +facets:taxonomy:DayOfYear # freq=579117
+MedTermDayTaxoFacets: 9 +facets:taxonomy:DayOfYear # freq=574434
+MedTermDayTaxoFacets: death +facets:taxonomy:DayOfYear # freq=568895
+MedTermDayTaxoFacets: author +facets:taxonomy:DayOfYear # freq=567768
+MedTermDayTaxoFacets: however +facets:taxonomy:DayOfYear # freq=566494
+MedTermDayTaxoFacets: october +facets:taxonomy:DayOfYear # freq=566229
+MedTermDayTaxoFacets: north +facets:taxonomy:DayOfYear # freq=564195
+MedTermDayTaxoFacets: so +facets:taxonomy:DayOfYear # freq=562598
+MedTermDayTaxoFacets: reflist +facets:taxonomy:DayOfYear # freq=561253
+MedTermDayTaxoFacets: south +facets:taxonomy:DayOfYear # freq=560468
+MedTermDayTaxoFacets: area +facets:taxonomy:DayOfYear # freq=559023
+MedTermDayTaxoFacets: class +facets:taxonomy:DayOfYear # freq=556838
+MedTermDayTaxoFacets: september +facets:taxonomy:DayOfYear # freq=553409
+MedTermDayTaxoFacets: war +facets:taxonomy:DayOfYear # freq=547417
+MedTermDayTaxoFacets: image +facets:taxonomy:DayOfYear # freq=541747
+MedTermDayTaxoFacets: 16 +facets:taxonomy:DayOfYear # freq=540539
+MedTermDayTaxoFacets: both +facets:taxonomy:DayOfYear # freq=534900
+MedTermDayTaxoFacets: 14 +facets:taxonomy:DayOfYear # freq=534005
+MedTermDayTaxoFacets: 13 +facets:taxonomy:DayOfYear # freq=530419
+MedTermDayTaxoFacets: july +facets:taxonomy:DayOfYear # freq=529655
+MedTermDayTaxoFacets: august +facets:taxonomy:DayOfYear # freq=527806
+MedTermDayTaxoFacets: november +facets:taxonomy:DayOfYear # freq=527131
+MedTermDayTaxoFacets: end +facets:taxonomy:DayOfYear # freq=526636
+MedTermDayTaxoFacets: february +facets:taxonomy:DayOfYear # freq=524886
+MedTermDayTaxoFacets: infobox +facets:taxonomy:DayOfYear # freq=524810
+MedTermDayTaxoFacets: june +facets:taxonomy:DayOfYear # freq=522519
+MedTermDayTaxoFacets: series +facets:taxonomy:DayOfYear # freq=521861
+MedTermDayTaxoFacets: york +facets:taxonomy:DayOfYear # freq=521383
+MedTermDayTaxoFacets: including +facets:taxonomy:DayOfYear # freq=521324
+MedTermDayTaxoFacets: county +facets:taxonomy:DayOfYear # freq=521126
+MedTermDayTaxoFacets: them +facets:taxonomy:DayOfYear # freq=520298
+MedTermDayTaxoFacets: her +facets:taxonomy:DayOfYear # freq=518717
+MedTermDayTaxoFacets: through +facets:taxonomy:DayOfYear # freq=514966
+MedTermDayTaxoFacets: do +facets:taxonomy:DayOfYear # freq=511178
+MedTermDayTaxoFacets: 17 +facets:taxonomy:DayOfYear # freq=507396
+MedTermDayTaxoFacets: him +facets:taxonomy:DayOfYear # freq=507350
+MedTermDayTaxoFacets: nbsp +facets:taxonomy:DayOfYear # freq=506054
+MedTermDayTaxoFacets: second +facets:taxonomy:DayOfYear # freq=505575
+MedTermDayTaxoFacets: 22 +facets:taxonomy:DayOfYear # freq=502778
+MedTermDayTaxoFacets: html +facets:taxonomy:DayOfYear # freq=500198
+MedTermDayTaxoFacets: 2000 +facets:taxonomy:DayOfYear # freq=499639
+MedTermDayTaxoFacets: 25 +facets:taxonomy:DayOfYear # freq=491957
+MedTermDayTaxoFacets: location +facets:taxonomy:DayOfYear # freq=489791
+MedTermDayTaxoFacets: will +facets:taxonomy:DayOfYear # freq=489711
+MedTermDayTaxoFacets: center +facets:taxonomy:DayOfYear # freq=489673
+MedTermDayTaxoFacets: 30 +facets:taxonomy:DayOfYear # freq=488930
+MedTermDayTaxoFacets: since +facets:taxonomy:DayOfYear # freq=485325
+MedTermDayTaxoFacets: 19 +facets:taxonomy:DayOfYear # freq=484187
+MedTermDayTaxoFacets: now +facets:taxonomy:DayOfYear # freq=484114
+MedTermDayTaxoFacets: any +facets:taxonomy:DayOfYear # freq=483514
+MedTermDayTaxoFacets: early +facets:taxonomy:DayOfYear # freq=482793
+MedTermDayTaxoFacets: 21 +facets:taxonomy:DayOfYear # freq=482314
+MedTermDayTaxoFacets: high +facets:taxonomy:DayOfYear # freq=482152
+MedTermDayTaxoFacets: like +facets:taxonomy:DayOfYear # freq=479390
+MedTermDayTaxoFacets: life +facets:taxonomy:DayOfYear # freq=477007
+MedTermDayTaxoFacets: general +facets:taxonomy:DayOfYear # freq=476690
+MedTermDayTaxoFacets: music +facets:taxonomy:DayOfYear # freq=473240
+MedTermDayTaxoFacets: number +facets:taxonomy:DayOfYear # freq=473154
+MedTermDayTaxoFacets: 24 +facets:taxonomy:DayOfYear # freq=470708
+MedTermDayTaxoFacets: main +facets:taxonomy:DayOfYear # freq=470429
+MedTermDayTaxoFacets: isbn +facets:taxonomy:DayOfYear # freq=467574
+MedTermDayTaxoFacets: pages +facets:taxonomy:DayOfYear # freq=466290
+MedTermDayTaxoFacets: became +facets:taxonomy:DayOfYear # freq=465594
+MedTermDayTaxoFacets: short +facets:taxonomy:DayOfYear # freq=465205
+MedTermDayTaxoFacets: school +facets:taxonomy:DayOfYear # freq=462166
+MedTermDayTaxoFacets: you +facets:taxonomy:DayOfYear # freq=461587
+MedTermDayTaxoFacets: 23 +facets:taxonomy:DayOfYear # freq=457097
+MedTermDayTaxoFacets: 2003 +facets:taxonomy:DayOfYear # freq=456990
+MedTermDayTaxoFacets: called +facets:taxonomy:DayOfYear # freq=454580
+MedTermDayTaxoFacets: utc +facets:taxonomy:DayOfYear # freq=450225
+MedTermDayTaxoFacets: n +facets:taxonomy:DayOfYear # freq=449994
+MedTermDayTaxoFacets: c +facets:taxonomy:DayOfYear # freq=444247
+MedTermDayTaxoFacets: group +facets:taxonomy:DayOfYear # freq=442503
+MedTermDayTaxoFacets: m +facets:taxonomy:DayOfYear # freq=441232
+MedTermDayTaxoFacets: several +facets:taxonomy:DayOfYear # freq=436129
+MedTermDayTaxoFacets: website +facets:taxonomy:DayOfYear # freq=435941
+MedTermDayTaxoFacets: film +facets:taxonomy:DayOfYear # freq=432758
+MedTermDayTaxoFacets: west +facets:taxonomy:DayOfYear # freq=431006
+MedTermDayTaxoFacets: u.s +facets:taxonomy:DayOfYear # freq=428534
+MedTermDayTaxoFacets: she +facets:taxonomy:DayOfYear # freq=426267
+MedTermDayTaxoFacets: until +facets:taxonomy:DayOfYear # freq=425389
+MedTermDayTaxoFacets: birth +facets:taxonomy:DayOfYear # freq=425138
+MedTermDayTaxoFacets: us +facets:taxonomy:DayOfYear # freq=421210
+MedTermDayTaxoFacets: same +facets:taxonomy:DayOfYear # freq=420741
+MedTermDayTaxoFacets: country +facets:taxonomy:DayOfYear # freq=420052
+MedTermDayTaxoFacets: international +facets:taxonomy:DayOfYear # freq=418261
+MedTermDayTaxoFacets: british +facets:taxonomy:DayOfYear # freq=417307
+MedTermDayTaxoFacets: language +facets:taxonomy:DayOfYear # freq=416771
+MedTermDayTaxoFacets: following +facets:taxonomy:DayOfYear # freq=416515
+MedTermDayTaxoFacets: because +facets:taxonomy:DayOfYear # freq=413003
+MedTermDayTaxoFacets: system +facets:taxonomy:DayOfYear # freq=412862
+MedTermDayTaxoFacets: english +facets:taxonomy:DayOfYear # freq=412061
+MedTermDayTaxoFacets: 2001 +facets:taxonomy:DayOfYear # freq=410364
+MedTermDayTaxoFacets: e +facets:taxonomy:DayOfYear # freq=408741
+MedTermDayTaxoFacets: times +facets:taxonomy:DayOfYear # freq=407155
+MedTermDayTaxoFacets: 2002 +facets:taxonomy:DayOfYear # freq=406953
+MedTermDayTaxoFacets: names +facets:taxonomy:DayOfYear # freq=404796
+MedTermDayTaxoFacets: w +facets:taxonomy:DayOfYear # freq=404764
+MedTermDayTaxoFacets: day +facets:taxonomy:DayOfYear # freq=402096
+MedTermDayTaxoFacets: should +facets:taxonomy:DayOfYear # freq=401379
+MedTermDayTaxoFacets: against +facets:taxonomy:DayOfYear # freq=399228
+MedTermDayTaxoFacets: press +facets:taxonomy:DayOfYear # freq=398988
+MedTermDayTaxoFacets: based +facets:taxonomy:DayOfYear # freq=398415
+MedTermDayTaxoFacets: age +facets:taxonomy:DayOfYear # freq=395368
+MedTermDayTaxoFacets: what +facets:taxonomy:DayOfYear # freq=394675
+MedTermDayTaxoFacets: party +facets:taxonomy:DayOfYear # freq=394410
+MedTermDayTaxoFacets: company +facets:taxonomy:DayOfYear # freq=391520
+MedTermDayTaxoFacets: four +facets:taxonomy:DayOfYear # freq=389818
+MedTermDayTaxoFacets: 28 +facets:taxonomy:DayOfYear # freq=389552
+MedTermDayTaxoFacets: 26 +facets:taxonomy:DayOfYear # freq=389026
+MedTermDayTaxoFacets: family +facets:taxonomy:DayOfYear # freq=387175
+MedTermDayTaxoFacets: long +facets:taxonomy:DayOfYear # freq=385787
+MedTermDayTaxoFacets: century +facets:taxonomy:DayOfYear # freq=385541
+MedTermDayTaxoFacets: government +facets:taxonomy:DayOfYear # freq=384004
+MedTermDayTaxoFacets: 27 +facets:taxonomy:DayOfYear # freq=383042
+MedTermDayTaxoFacets: old +facets:taxonomy:DayOfYear # freq=381809
+MedTermDayTaxoFacets: team +facets:taxonomy:DayOfYear # freq=379028
+MedTermDayTaxoFacets: house +facets:taxonomy:DayOfYear # freq=377336
+MedTermDayTaxoFacets: population +facets:taxonomy:DayOfYear # freq=374481
+MedTermDayTaxoFacets: 29 +facets:taxonomy:DayOfYear # freq=372091
+MedTermDayTaxoFacets: b +facets:taxonomy:DayOfYear # freq=369454
+MedTermDayTaxoFacets: public +facets:taxonomy:DayOfYear # freq=368868
+MedTermDayTaxoFacets: home +facets:taxonomy:DayOfYear # freq=367819
+MedTermDayTaxoFacets: top +facets:taxonomy:DayOfYear # freq=364628
+MedTermDayTaxoFacets: east +facets:taxonomy:DayOfYear # freq=364582
+MedTermDayTaxoFacets: talk +facets:taxonomy:DayOfYear # freq=364194
+MedTermDayTaxoFacets: order +facets:taxonomy:DayOfYear # freq=360915
+MedTermDayTaxoFacets: line +facets:taxonomy:DayOfYear # freq=360442
+MedTermDayTaxoFacets: could +facets:taxonomy:DayOfYear # freq=356679
+MedTermDayTaxoFacets: 2012 +facets:taxonomy:DayOfYear # freq=355641
+MedTermDayTaxoFacets: description +facets:taxonomy:DayOfYear # freq=355070
+MedTermDayTaxoFacets: very +facets:taxonomy:DayOfYear # freq=354898
+MedTermDayTaxoFacets: each +facets:taxonomy:DayOfYear # freq=354583
+MedTermDayTaxoFacets: information +facets:taxonomy:DayOfYear # freq=353153
+MedTermDayTaxoFacets: another +facets:taxonomy:DayOfYear # freq=352496
+MedTermDayTaxoFacets: born +facets:taxonomy:DayOfYear # freq=352196
+MedTermDayTaxoFacets: back +facets:taxonomy:DayOfYear # freq=349276
+MedTermDayTaxoFacets: london +facets:taxonomy:DayOfYear # freq=348918
+MedTermDayTaxoFacets: just +facets:taxonomy:DayOfYear # freq=348911
+MedTermDayTaxoFacets: town +facets:taxonomy:DayOfYear # freq=348598
+MedTermDayTaxoFacets: journal +facets:taxonomy:DayOfYear # freq=348162
+MedTermDayTaxoFacets: non +facets:taxonomy:DayOfYear # freq=348142
+MedTermDayTaxoFacets: color +facets:taxonomy:DayOfYear # freq=347941
+MedTermDayTaxoFacets: 01 +facets:taxonomy:DayOfYear # freq=347922
+MedTermDayTaxoFacets: great +facets:taxonomy:DayOfYear # freq=347499
+MedTermDayTaxoFacets: although +facets:taxonomy:DayOfYear # freq=341432
+MedTermDayTaxoFacets: books +facets:taxonomy:DayOfYear # freq=341376
+MedTermDayTaxoFacets: ii +facets:taxonomy:DayOfYear # freq=340800
+MedTermDayTaxoFacets: major +facets:taxonomy:DayOfYear # freq=340345
+MedTermDayTaxoFacets: further +facets:taxonomy:DayOfYear # freq=339350
+MedTermDayTaxoFacets: 1999 +facets:taxonomy:DayOfYear # freq=334887
+MedTermDayTaxoFacets: around +facets:taxonomy:DayOfYear # freq=334840
+MedTermDayTaxoFacets: best +facets:taxonomy:DayOfYear # freq=334550
+MedTermDayTaxoFacets: former +facets:taxonomy:DayOfYear # freq=332750
+MedTermDayTaxoFacets: still +facets:taxonomy:DayOfYear # freq=332543
+MedTermDayTaxoFacets: album +facets:taxonomy:DayOfYear # freq=331360
+MedTermDayTaxoFacets: stub +facets:taxonomy:DayOfYear # freq=329768
+MedTermDayTaxoFacets: did +facets:taxonomy:DayOfYear # freq=328303
+MedTermDayTaxoFacets: j +facets:taxonomy:DayOfYear # freq=327713
+MedTermDayTaxoFacets: even +facets:taxonomy:DayOfYear # freq=326231
+MedTermDayTaxoFacets: official +facets:taxonomy:DayOfYear # freq=326177
+MedTermDayTaxoFacets: original +facets:taxonomy:DayOfYear # freq=323521
+MedTermDayTaxoFacets: user +facets:taxonomy:DayOfYear # freq=323242
+MedTermDayTaxoFacets: alternative +facets:taxonomy:DayOfYear # freq=322536
+MedTermDayTaxoFacets: released +facets:taxonomy:DayOfYear # freq=322473
+MedTermDayTaxoFacets: jpg +facets:taxonomy:DayOfYear # freq=322278
+MedTermDayTaxoFacets: issue +facets:taxonomy:DayOfYear # freq=322106
+MedTermDayTaxoFacets: own +facets:taxonomy:DayOfYear # freq=321703
+MedTermDayTaxoFacets: season +facets:taxonomy:DayOfYear # freq=320228
+MedTermDayTaxoFacets: those +facets:taxonomy:DayOfYear # freq=320013
+MedTermDayTaxoFacets: 02 +facets:taxonomy:DayOfYear # freq=319783
+MedTermDayTaxoFacets: uk +facets:taxonomy:DayOfYear # freq=319211
+MedTermDayTaxoFacets: way +facets:taxonomy:DayOfYear # freq=318344
+MedTermDayTaxoFacets: type +facets:taxonomy:DayOfYear # freq=318210
+MedTermDayTaxoFacets: 03 +facets:taxonomy:DayOfYear # freq=318112
+MedTermDayTaxoFacets: england +facets:taxonomy:DayOfYear # freq=317884
+MedTermDayTaxoFacets: much +facets:taxonomy:DayOfYear # freq=317670
+MedTermDayTaxoFacets: off +facets:taxonomy:DayOfYear # freq=315473
+MedTermDayTaxoFacets: game +facets:taxonomy:DayOfYear # freq=315157
+MedTermDayTaxoFacets: background +facets:taxonomy:DayOfYear # freq=314229
+MedTermDayTaxoFacets: 04 +facets:taxonomy:DayOfYear # freq=313827
+MedTermDayTaxoFacets: found +facets:taxonomy:DayOfYear # freq=313247
+MedTermDayTaxoFacets: volume +facets:taxonomy:DayOfYear # freq=312846
+MedTermDayTaxoFacets: named +facets:taxonomy:DayOfYear # freq=310150
+MedTermDayTaxoFacets: service +facets:taxonomy:DayOfYear # freq=309976
+MedTermDayTaxoFacets: d +facets:taxonomy:DayOfYear # freq=309729
+MedTermDayTaxoFacets: st +facets:taxonomy:DayOfYear # freq=309092
+MedTermDayTaxoFacets: large +facets:taxonomy:DayOfYear # freq=308888
+MedTermDayTaxoFacets: often +facets:taxonomy:DayOfYear # freq=307684
+MedTermDayTaxoFacets: 06 +facets:taxonomy:DayOfYear # freq=305698
+MedTermDayTaxoFacets: 05 +facets:taxonomy:DayOfYear # freq=302860
+MedTermDayTaxoFacets: 1998 +facets:taxonomy:DayOfYear # freq=300506
+MedTermDayTaxoFacets: align +facets:taxonomy:DayOfYear # freq=300455
+MedTermDayTaxoFacets: kingdom +facets:taxonomy:DayOfYear # freq=299825
+MedTermDayTaxoFacets: using +facets:taxonomy:DayOfYear # freq=299474
+MedTermDayTaxoFacets: white +facets:taxonomy:DayOfYear # freq=299411
+MedTermDayTaxoFacets: 07 +facets:taxonomy:DayOfYear # freq=299351
+MedTermDayTaxoFacets: district +facets:taxonomy:DayOfYear # freq=299108
+MedTermDayTaxoFacets: local +facets:taxonomy:DayOfYear # freq=299012
+MedTermDayTaxoFacets: metadata +facets:taxonomy:DayOfYear # freq=298533
+MedTermDayTaxoFacets: 31 +facets:taxonomy:DayOfYear # freq=298349
+MedTermDayTaxoFacets: 08 +facets:taxonomy:DayOfYear # freq=297258
+MedTermDayTaxoFacets: 09 +facets:taxonomy:DayOfYear # freq=296300
+MedTermDayTaxoFacets: r +facets:taxonomy:DayOfYear # freq=296283
+MedTermDayTaxoFacets: set +facets:taxonomy:DayOfYear # freq=294255
+MedTermDayTaxoFacets: show +facets:taxonomy:DayOfYear # freq=293934
+MedTermDayTaxoFacets: david +facets:taxonomy:DayOfYear # freq=292847
+MedTermDayTaxoFacets: make +facets:taxonomy:DayOfYear # freq=292607
+MedTermDayTaxoFacets: story +facets:taxonomy:DayOfYear # freq=292404
+MedTermDayTaxoFacets: citation +facets:taxonomy:DayOfYear # freq=291478
+MedTermDayTaxoFacets: within +facets:taxonomy:DayOfYear # freq=291049
+MedTermDayTaxoFacets: due +facets:taxonomy:DayOfYear # freq=290531
+MedTermDayTaxoFacets: link +facets:taxonomy:DayOfYear # freq=287552
+MedTermDayTaxoFacets: 1997 +facets:taxonomy:DayOfYear # freq=286789
+MedTermDayTaxoFacets: members +facets:taxonomy:DayOfYear # freq=286028
+MedTermDayTaxoFacets: william +facets:taxonomy:DayOfYear # freq=284592
+MedTermDayTaxoFacets: along +facets:taxonomy:DayOfYear # freq=284442
+MedTermDayTaxoFacets: v +facets:taxonomy:DayOfYear # freq=284318
+MedTermDayTaxoFacets: located +facets:taxonomy:DayOfYear # freq=283899
+MedTermDayTaxoFacets: single +facets:taxonomy:DayOfYear # freq=283824
+MedTermDayTaxoFacets: per +facets:taxonomy:DayOfYear # freq=283568
+MedTermDayTaxoFacets: established +facets:taxonomy:DayOfYear # freq=282471
+MedTermDayTaxoFacets: james +facets:taxonomy:DayOfYear # freq=281597
+MedTermDayTaxoFacets: needed +facets:taxonomy:DayOfYear # freq=281051
+MedTermDayTaxoFacets: down +facets:taxonomy:DayOfYear # freq=280662
+MedTermDayTaxoFacets: present +facets:taxonomy:DayOfYear # freq=278449
+MedTermDayTaxoFacets: man +facets:taxonomy:DayOfYear # freq=278112
+MedTermDayTaxoFacets: college +facets:taxonomy:DayOfYear # freq=278094
+MedTermDayTaxoFacets: f +facets:taxonomy:DayOfYear # freq=278015
+MedTermDayTaxoFacets: site +facets:taxonomy:DayOfYear # freq=277788
+MedTermDayTaxoFacets: football +facets:taxonomy:DayOfYear # freq=277738
+MedTermDayTaxoFacets: en +facets:taxonomy:DayOfYear # freq=277463
+MedTermDayTaxoFacets: result +facets:taxonomy:DayOfYear # freq=276803
+MedTermDayTaxoFacets: include +facets:taxonomy:DayOfYear # freq=276466
+MedTermDayTaxoFacets: began +facets:taxonomy:DayOfYear # freq=276036
+MedTermDayTaxoFacets: my +facets:taxonomy:DayOfYear # freq=274256
+MedTermDayTaxoFacets: x +facets:taxonomy:DayOfYear # freq=272695
+MedTermDayTaxoFacets: central +facets:taxonomy:DayOfYear # freq=272531
+MedTermDayTaxoFacets: band +facets:taxonomy:DayOfYear # freq=272207
+MedTermDayTaxoFacets: 1996 +facets:taxonomy:DayOfYear # freq=271980
+MedTermDayTaxoFacets: form +facets:taxonomy:DayOfYear # freq=271966
+MedTermDayTaxoFacets: member +facets:taxonomy:DayOfYear # freq=271607
+MedTermDayTaxoFacets: television +facets:taxonomy:DayOfYear # freq=271426
+MedTermDayTaxoFacets: league +facets:taxonomy:DayOfYear # freq=270223
+MedTermDayTaxoFacets: free +facets:taxonomy:DayOfYear # freq=270199
+MedTermDayTaxoFacets: political +facets:taxonomy:DayOfYear # freq=269665
+MedTermDayTaxoFacets: font +facets:taxonomy:DayOfYear # freq=269439
+MedTermDayTaxoFacets: 100 +facets:taxonomy:DayOfYear # freq=268978
+MedTermDayTaxoFacets: convert +facets:taxonomy:DayOfYear # freq=267974
+MedTermDayTaxoFacets: red +facets:taxonomy:DayOfYear # freq=266177
+MedTermDayTaxoFacets: president +facets:taxonomy:DayOfYear # freq=263341
+MedTermDayTaxoFacets: five +facets:taxonomy:DayOfYear # freq=262923
+MedTermDayTaxoFacets: t +facets:taxonomy:DayOfYear # freq=262832
+MedTermDayTaxoFacets: power +facets:taxonomy:DayOfYear # freq=262586
+MedTermDayTaxoFacets: river +facets:taxonomy:DayOfYear # freq=262231
+MedTermDayTaxoFacets: we +facets:taxonomy:DayOfYear # freq=261001
+MedTermDayTaxoFacets: song +facets:taxonomy:DayOfYear # freq=260741
+MedTermDayTaxoFacets: next +facets:taxonomy:DayOfYear # freq=259039
+MedTermDayTaxoFacets: articles +facets:taxonomy:DayOfYear # freq=258949
+MedTermDayTaxoFacets: point +facets:taxonomy:DayOfYear # freq=258471
+MedTermDayTaxoFacets: text +facets:taxonomy:DayOfYear # freq=257803
+MedTermDayTaxoFacets: according +facets:taxonomy:DayOfYear # freq=256949
+MedTermDayTaxoFacets: black +facets:taxonomy:DayOfYear # freq=256526
+MedTermDayTaxoFacets: george +facets:taxonomy:DayOfYear # freq=256196
+MedTermDayTaxoFacets: different +facets:taxonomy:DayOfYear # freq=255951
+MedTermDayTaxoFacets: ndash +facets:taxonomy:DayOfYear # freq=255747
+MedTermDayTaxoFacets: third +facets:taxonomy:DayOfYear # freq=255690
+MedTermDayTaxoFacets: tv +facets:taxonomy:DayOfYear # freq=255429
+MedTermDayTaxoFacets: law +facets:taxonomy:DayOfYear # freq=255248
+MedTermDayTaxoFacets: canada +facets:taxonomy:DayOfYear # freq=254867
+MedTermDayTaxoFacets: near +facets:taxonomy:DayOfYear # freq=254492
+MedTermDayTaxoFacets: built +facets:taxonomy:DayOfYear # freq=254491
+MedTermDayTaxoFacets: 1995 +facets:taxonomy:DayOfYear # freq=252837
+MedTermDayTaxoFacets: how +facets:taxonomy:DayOfYear # freq=252284
+MedTermDayTaxoFacets: record +facets:taxonomy:DayOfYear # freq=250484
+MedTermDayTaxoFacets: french +facets:taxonomy:DayOfYear # freq=250453
+MedTermDayTaxoFacets: air +facets:taxonomy:DayOfYear # freq=250411
+MedTermDayTaxoFacets: king +facets:taxonomy:DayOfYear # freq=250321
+MedTermDayTaxoFacets: without +facets:taxonomy:DayOfYear # freq=249926
+MedTermDayTaxoFacets: though +facets:taxonomy:DayOfYear # freq=248968
+MedTermDayTaxoFacets: played +facets:taxonomy:DayOfYear # freq=248191
+MedTermDayTaxoFacets: park +facets:taxonomy:DayOfYear # freq=247801
+MedTermDayTaxoFacets: took +facets:taxonomy:DayOfYear # freq=247388
+MedTermDayTaxoFacets: association +facets:taxonomy:DayOfYear # freq=247156
+MedTermDayTaxoFacets: military +facets:taxonomy:DayOfYear # freq=246727
+MedTermDayTaxoFacets: robert +facets:taxonomy:DayOfYear # freq=246405
+MedTermDayTaxoFacets: above +facets:taxonomy:DayOfYear # freq=246135
+MedTermDayTaxoFacets: persondata +facets:taxonomy:DayOfYear # freq=246119
+MedTermDayTaxoFacets: career +facets:taxonomy:DayOfYear # freq=245439
+MedTermDayTaxoFacets: version +facets:taxonomy:DayOfYear # freq=244541
+MedTermDayTaxoFacets: again +facets:taxonomy:DayOfYear # freq=244255
+MedTermDayTaxoFacets: late +facets:taxonomy:DayOfYear # freq=243636
+MedTermDayTaxoFacets: published +facets:taxonomy:DayOfYear # freq=243548
+MedTermDayTaxoFacets: live +facets:taxonomy:DayOfYear # freq=242147
+MedTermDayTaxoFacets: h +facets:taxonomy:DayOfYear # freq=241946
+MedTermDayTaxoFacets: good +facets:taxonomy:DayOfYear # freq=241649
+MedTermDayTaxoFacets: player +facets:taxonomy:DayOfYear # freq=241451
+MedTermDayTaxoFacets: others +facets:taxonomy:DayOfYear # freq=240487
+MedTermDayTaxoFacets: america +facets:taxonomy:DayOfYear # freq=240374
+MedTermDayTaxoFacets: review +facets:taxonomy:DayOfYear # freq=240157
+MedTermDayTaxoFacets: station +facets:taxonomy:DayOfYear # freq=239572
+MedTermDayTaxoFacets: among +facets:taxonomy:DayOfYear # freq=238986
+MedTermDayTaxoFacets: section +facets:taxonomy:DayOfYear # freq=238874
+MedTermDayTaxoFacets: border +facets:taxonomy:DayOfYear # freq=238540
+MedTermDayTaxoFacets: your +facets:taxonomy:DayOfYear # freq=237723
+MedTermDayTaxoFacets: size +facets:taxonomy:DayOfYear # freq=237662
+MedTermDayTaxoFacets: births +facets:taxonomy:DayOfYear # freq=237033
+MedTermDayTaxoFacets: support +facets:taxonomy:DayOfYear # freq=236989
+MedTermDayTaxoFacets: german +facets:taxonomy:DayOfYear # freq=236721
+MedTermDayTaxoFacets: california +facets:taxonomy:DayOfYear # freq=236086
+MedTermDayTaxoFacets: given +facets:taxonomy:DayOfYear # freq=235719
+MedTermDayTaxoFacets: commons +facets:taxonomy:DayOfYear # freq=235235
+MedTermDayTaxoFacets: 1994 +facets:taxonomy:DayOfYear # freq=235100
+MedTermDayTaxoFacets: start +facets:taxonomy:DayOfYear # freq=233925
+MedTermDayTaxoFacets: km +facets:taxonomy:DayOfYear # freq=233831
+MedTermDayTaxoFacets: said +facets:taxonomy:DayOfYear # freq=233066
+MedTermDayTaxoFacets: western +facets:taxonomy:DayOfYear # freq=232781
+MedTermDayTaxoFacets: won +facets:taxonomy:DayOfYear # freq=232751
+MedTermDayTaxoFacets: la +facets:taxonomy:DayOfYear # freq=232610
+MedTermDayTaxoFacets: held +facets:taxonomy:DayOfYear # freq=232354
+MedTermDayTaxoFacets: children +facets:taxonomy:DayOfYear # freq=232342
+MedTermDayTaxoFacets: does +facets:taxonomy:DayOfYear # freq=232202
+MedTermDayTaxoFacets: club +facets:taxonomy:DayOfYear # freq=232173
+MedTermDayTaxoFacets: source +facets:taxonomy:DayOfYear # freq=231838
+MedTermDayTaxoFacets: church +facets:taxonomy:DayOfYear # freq=231667
+MedTermDayTaxoFacets: format +facets:taxonomy:DayOfYear # freq=231300
+MedTermDayTaxoFacets: example +facets:taxonomy:DayOfYear # freq=230457
+MedTermDayTaxoFacets: development +facets:taxonomy:DayOfYear # freq=230286
+MedTermDayTaxoFacets: land +facets:taxonomy:DayOfYear # freq=230284
+MedTermDayTaxoFacets: total +facets:taxonomy:DayOfYear # freq=230013
+MedTermDayTaxoFacets: final +facets:taxonomy:DayOfYear # freq=230006
+MedTermDayTaxoFacets: 50 +facets:taxonomy:DayOfYear # freq=229614
+MedTermDayTaxoFacets: please +facets:taxonomy:DayOfYear # freq=229602
+MedTermDayTaxoFacets: region +facets:taxonomy:DayOfYear # freq=229561
+MedTermDayTaxoFacets: here +facets:taxonomy:DayOfYear # freq=229505
+MedTermDayTaxoFacets: me +facets:taxonomy:DayOfYear # freq=229204
+MedTermDayTaxoFacets: caption +facets:taxonomy:DayOfYear # freq=229172
+MedTermDayTaxoFacets: must +facets:taxonomy:DayOfYear # freq=228491
+MedTermDayTaxoFacets: army +facets:taxonomy:DayOfYear # freq=228105
+MedTermDayTaxoFacets: l +facets:taxonomy:DayOfYear # freq=227974
+MedTermDayTaxoFacets: side +facets:taxonomy:DayOfYear # freq=227747
+MedTermDayTaxoFacets: society +facets:taxonomy:DayOfYear # freq=226742
+MedTermDayTaxoFacets: full +facets:taxonomy:DayOfYear # freq=226457
+MedTermDayTaxoFacets: few +facets:taxonomy:DayOfYear # freq=226422
+MedTermDayTaxoFacets: records +facets:taxonomy:DayOfYear # freq=225886
+MedTermDayTaxoFacets: below +facets:taxonomy:DayOfYear # freq=225843
+MedTermDayTaxoFacets: community +facets:taxonomy:DayOfYear # freq=225571
+MedTermDayTaxoFacets: office +facets:taxonomy:DayOfYear # freq=225338
+MedTermDayTaxoFacets: 1992 +facets:taxonomy:DayOfYear # freq=225200
+MedTermDayTaxoFacets: road +facets:taxonomy:DayOfYear # freq=225050
+MedTermDayTaxoFacets: research +facets:taxonomy:DayOfYear # freq=224925
+MedTermDayTaxoFacets: various +facets:taxonomy:DayOfYear # freq=224593
+MedTermDayTaxoFacets: take +facets:taxonomy:DayOfYear # freq=224260
+MedTermDayTaxoFacets: wikipedia:persondata +facets:taxonomy:DayOfYear # freq=222385
+MedTermDayTaxoFacets: 1990 +facets:taxonomy:DayOfYear # freq=222154
+MedTermDayTaxoFacets: 40 +facets:taxonomy:DayOfYear # freq=221687
+MedTermDayTaxoFacets: created +facets:taxonomy:DayOfYear # freq=220831
+MedTermDayTaxoFacets: 1993 +facets:taxonomy:DayOfYear # freq=220776
+MedTermDayTaxoFacets: france +facets:taxonomy:DayOfYear # freq=220058
+MedTermDayTaxoFacets: science +facets:taxonomy:DayOfYear # freq=219988
+MedTermDayTaxoFacets: every +facets:taxonomy:DayOfYear # freq=219884
+MedTermDayTaxoFacets: become +facets:taxonomy:DayOfYear # freq=219753
+MedTermDayTaxoFacets: modern +facets:taxonomy:DayOfYear # freq=218831
+MedTermDayTaxoFacets: post +facets:taxonomy:DayOfYear # freq=218570
+MedTermDayTaxoFacets: games +facets:taxonomy:DayOfYear # freq=218434
+MedTermDayTaxoFacets: michael +facets:taxonomy:DayOfYear # freq=217311
+MedTermDayTaxoFacets: current +facets:taxonomy:DayOfYear # freq=217174
+MedTermDayTaxoFacets: included +facets:taxonomy:DayOfYear # freq=216978
+MedTermDayTaxoFacets: ja +facets:taxonomy:DayOfYear # freq=216549
+MedTermDayTaxoFacets: magazine +facets:taxonomy:DayOfYear # freq=215725
+MedTermDayTaxoFacets: position +facets:taxonomy:DayOfYear # freq=215493
+MedTermDayTaxoFacets: australia +facets:taxonomy:DayOfYear # freq=215391
+MedTermDayTaxoFacets: archive +facets:taxonomy:DayOfYear # freq=215381
+MedTermDayTaxoFacets: union +facets:taxonomy:DayOfYear # freq=214164
+MedTermDayTaxoFacets: having +facets:taxonomy:DayOfYear # freq=213416
+MedTermDayTaxoFacets: g +facets:taxonomy:DayOfYear # freq=212936
+MedTermDayTaxoFacets: popular +facets:taxonomy:DayOfYear # freq=212493
+MedTermDayTaxoFacets: royal +facets:taxonomy:DayOfYear # freq=211710
+MedTermDayTaxoFacets: period +facets:taxonomy:DayOfYear # freq=211690
+MedTermDayTaxoFacets: little +facets:taxonomy:DayOfYear # freq=211124
+MedTermDayTaxoFacets: wikitable +facets:taxonomy:DayOfYear # freq=210990
+MedTermDayTaxoFacets: rock +facets:taxonomy:DayOfYear # freq=210815
+MedTermDayTaxoFacets: artist +facets:taxonomy:DayOfYear # freq=210591
+MedTermDayTaxoFacets: play +facets:taxonomy:DayOfYear # freq=210199
+MedTermDayTaxoFacets: led +facets:taxonomy:DayOfYear # freq=210033
+MedTermDayTaxoFacets: notes +facets:taxonomy:DayOfYear # freq=210029
+MedTermDayTaxoFacets: water +facets:taxonomy:DayOfYear # freq=209444
+MedTermDayTaxoFacets: business +facets:taxonomy:DayOfYear # freq=209353
+MedTermDayTaxoFacets: art +facets:taxonomy:DayOfYear # freq=209322
+MedTermDayTaxoFacets: common +facets:taxonomy:DayOfYear # freq=209310
+MedTermDayTaxoFacets: co +facets:taxonomy:DayOfYear # freq=209086
+MedTermDayTaxoFacets: education +facets:taxonomy:DayOfYear # freq=208909
+MedTermDayTaxoFacets: role +facets:taxonomy:DayOfYear # freq=208579
+MedTermDayTaxoFacets: 1991 +facets:taxonomy:DayOfYear # freq=207589
+MedTermDayTaxoFacets: case +facets:taxonomy:DayOfYear # freq=207307
+MedTermDayTaxoFacets: paul +facets:taxonomy:DayOfYear # freq=207229
+MedTermDayTaxoFacets: media +facets:taxonomy:DayOfYear # freq=206574
+MedTermDayTaxoFacets: div +facets:taxonomy:DayOfYear # freq=206057
+MedTermDayTaxoFacets: census +facets:taxonomy:DayOfYear # freq=205166
+MedTermDayTaxoFacets: charles +facets:taxonomy:DayOfYear # freq=204987
+MedTermDayTaxoFacets: written +facets:taxonomy:DayOfYear # freq=204891
+MedTermDayTaxoFacets: pp +facets:taxonomy:DayOfYear # freq=204742
+MedTermDayTaxoFacets: green +facets:taxonomy:DayOfYear # freq=203371
+MedTermDayTaxoFacets: island +facets:taxonomy:DayOfYear # freq=203023
+MedTermDayTaxoFacets: never +facets:taxonomy:DayOfYear # freq=203017
+MedTermDayTaxoFacets: making +facets:taxonomy:DayOfYear # freq=203003
+MedTermDayTaxoFacets: term +facets:taxonomy:DayOfYear # freq=202691
+MedTermDayTaxoFacets: video +facets:taxonomy:DayOfYear # freq=202380
+MedTermDayTaxoFacets: son +facets:taxonomy:DayOfYear # freq=202340
+MedTermDayTaxoFacets: discussion +facets:taxonomy:DayOfYear # freq=202145
+MedTermDayTaxoFacets: died +facets:taxonomy:DayOfYear # freq=202125
+MedTermDayTaxoFacets: view +facets:taxonomy:DayOfYear # freq=201593
+MedTermDayTaxoFacets: street +facets:taxonomy:DayOfYear # freq=200985
+MedTermDayTaxoFacets: council +facets:taxonomy:DayOfYear # freq=200706
+MedTermDayTaxoFacets: re +facets:taxonomy:DayOfYear # freq=199632
+MedTermDayTaxoFacets: award +facets:taxonomy:DayOfYear # freq=199318
+MedTermDayTaxoFacets: works +facets:taxonomy:DayOfYear # freq=199177
+MedTermDayTaxoFacets: special +facets:taxonomy:DayOfYear # freq=198917
+MedTermDayTaxoFacets: force +facets:taxonomy:DayOfYear # freq=198556
+MedTermDayTaxoFacets: six +facets:taxonomy:DayOfYear # freq=197970
+MedTermDayTaxoFacets: came +facets:taxonomy:DayOfYear # freq=197126
+MedTermDayTaxoFacets: building +facets:taxonomy:DayOfYear # freq=196508
+MedTermDayTaxoFacets: young +facets:taxonomy:DayOfYear # freq=196428
+MedTermDayTaxoFacets: together +facets:taxonomy:DayOfYear # freq=195949
+MedTermDayTaxoFacets: important +facets:taxonomy:DayOfYear # freq=195851
+MedTermDayTaxoFacets: star +facets:taxonomy:DayOfYear # freq=195768
+MedTermDayTaxoFacets: similar +facets:taxonomy:DayOfYear # freq=195171
+MedTermDayTaxoFacets: received +facets:taxonomy:DayOfYear # freq=194983
+MedTermDayTaxoFacets: sup +facets:taxonomy:DayOfYear # freq=194723
+MedTermDayTaxoFacets: head +facets:taxonomy:DayOfYear # freq=194682
+AndHighHighDayTaxoFacets: +of +s +facets:taxonomy:DayOfYear # freq=8184358 freq=1581243
+AndHighHighDayTaxoFacets: +date +he +facets:taxonomy:DayOfYear # freq=2020626 freq=1659434
+AndHighHighDayTaxoFacets: +cite +2005 +facets:taxonomy:DayOfYear # freq=1741194 freq=835460
+AndHighHighDayTaxoFacets: +i +10 +facets:taxonomy:DayOfYear # freq=956148 freq=918339
+AndHighHighDayTaxoFacets: +date +2009 +facets:taxonomy:DayOfYear # freq=2020626 freq=887702
+AndHighHighDayTaxoFacets: +for +cite +facets:taxonomy:DayOfYear # freq=4380011 freq=1741194
+AndHighHighDayTaxoFacets: +as +its +facets:taxonomy:DayOfYear # freq=3925535 freq=1173450
+AndHighHighDayTaxoFacets: +which +2011 +facets:taxonomy:DayOfYear # freq=1963428 freq=871410
+AndHighHighDayTaxoFacets: +have +see +facets:taxonomy:DayOfYear # freq=1297121 freq=1044180
+AndHighHighDayTaxoFacets: +first +accessdate +facets:taxonomy:DayOfYear # freq=1933372 freq=1228887
+AndHighHighDayTaxoFacets: +also +no +facets:taxonomy:DayOfYear # freq=1959419 freq=1045000
+AndHighHighDayTaxoFacets: +first +new +facets:taxonomy:DayOfYear # freq=1933372 freq=1657293
+AndHighHighDayTaxoFacets: +publisher +web +facets:taxonomy:DayOfYear # freq=1289029 freq=1118334
+AndHighHighDayTaxoFacets: +states +work +facets:taxonomy:DayOfYear # freq=1034872 freq=853422
+AndHighHighDayTaxoFacets: +more +work +facets:taxonomy:DayOfYear # freq=963533 freq=853422
+AndHighHighDayTaxoFacets: +1 +their +facets:taxonomy:DayOfYear # freq=1641090 freq=1158682
+AndHighHighDayTaxoFacets: +http +an +facets:taxonomy:DayOfYear # freq=3493581 freq=2628056
+AndHighHighDayTaxoFacets: +year +5 +facets:taxonomy:DayOfYear # freq=1235231 freq=891361
+AndHighHighDayTaxoFacets: +4 +there +facets:taxonomy:DayOfYear # freq=986452 freq=956153
+AndHighHighDayTaxoFacets: +s +who +facets:taxonomy:DayOfYear # freq=1581243 freq=1196171
+AndHighHighDayTaxoFacets: +who +may +facets:taxonomy:DayOfYear # freq=1196171 freq=1071932
+AndHighHighDayTaxoFacets: +united +time +facets:taxonomy:DayOfYear # freq=1196944 freq=1032071
+AndHighHighDayTaxoFacets: +other +no +facets:taxonomy:DayOfYear # freq=1269961 freq=1045000
+AndHighHighDayTaxoFacets: +time +when +facets:taxonomy:DayOfYear # freq=1032071 freq=1027487
+AndHighHighDayTaxoFacets: +that +cite +facets:taxonomy:DayOfYear # freq=2931020 freq=1741194
+AndHighHighDayTaxoFacets: +to +its +facets:taxonomy:DayOfYear # freq=6155577 freq=1173450
+AndHighHighDayTaxoFacets: +2011 +2008 +facets:taxonomy:DayOfYear # freq=871410 freq=831253
+AndHighHighDayTaxoFacets: +been +2005 +facets:taxonomy:DayOfYear # freq=1041183 freq=835460
+AndHighHighDayTaxoFacets: +1 +year +facets:taxonomy:DayOfYear # freq=1641090 freq=1235231
+AndHighHighDayTaxoFacets: +was +more +facets:taxonomy:DayOfYear # freq=3763623 freq=963533
+AndHighHighDayTaxoFacets: +3 +2005 +facets:taxonomy:DayOfYear # freq=1148799 freq=835460
+AndHighHighDayTaxoFacets: +a +they +facets:taxonomy:DayOfYear # freq=6560531 freq=1021945
+AndHighHighDayTaxoFacets: +s +time +facets:taxonomy:DayOfYear # freq=1581243 freq=1032071
+AndHighHighDayTaxoFacets: +in +2011 +facets:taxonomy:DayOfYear # freq=7320987 freq=871410
+AndHighHighDayTaxoFacets: +a +work +facets:taxonomy:DayOfYear # freq=6560531 freq=853422
+AndHighHighDayTaxoFacets: +they +4 +facets:taxonomy:DayOfYear # freq=1021945 freq=986452
+AndHighHighDayTaxoFacets: +and +2 +facets:taxonomy:DayOfYear # freq=7318061 freq=1549245
+AndHighHighDayTaxoFacets: +to +an +facets:taxonomy:DayOfYear # freq=6155577 freq=2628056
+AndHighHighDayTaxoFacets: +an +which +facets:taxonomy:DayOfYear # freq=2628056 freq=1963428
+AndHighHighDayTaxoFacets: +was +also +facets:taxonomy:DayOfYear # freq=3763623 freq=1959419
+AndHighHighDayTaxoFacets: +this +see +facets:taxonomy:DayOfYear # freq=2224932 freq=1044180
+AndHighHighDayTaxoFacets: +all +2010 +facets:taxonomy:DayOfYear # freq=1203572 freq=950573
+AndHighHighDayTaxoFacets: +2 +2010 +facets:taxonomy:DayOfYear # freq=1549245 freq=950573
+AndHighHighDayTaxoFacets: +first +work +facets:taxonomy:DayOfYear # freq=1933372 freq=853422
+AndHighHighDayTaxoFacets: +he +10 +facets:taxonomy:DayOfYear # freq=1659434 freq=918339
+AndHighHighDayTaxoFacets: +http +that +facets:taxonomy:DayOfYear # freq=3493581 freq=2931020
+AndHighHighDayTaxoFacets: +new +2011 +facets:taxonomy:DayOfYear # freq=1657293 freq=871410
+AndHighHighDayTaxoFacets: +as +by +facets:taxonomy:DayOfYear # freq=3925535 freq=3826691
+AndHighHighDayTaxoFacets: +there +2008 +facets:taxonomy:DayOfYear # freq=956153 freq=831253
+AndHighHighDayTaxoFacets: +is +they +facets:taxonomy:DayOfYear # freq=4074455 freq=1021945
+AndHighHighDayTaxoFacets: +2010 +2011 +facets:taxonomy:DayOfYear # freq=950573 freq=871410
+AndHighHighDayTaxoFacets: +accessdate +2005 +facets:taxonomy:DayOfYear # freq=1228887 freq=835460
+AndHighHighDayTaxoFacets: +at +this +facets:taxonomy:DayOfYear # freq=2857534 freq=2224932
+AndHighHighDayTaxoFacets: +as +some +facets:taxonomy:DayOfYear # freq=3925535 freq=839919
+AndHighHighDayTaxoFacets: +after +all +facets:taxonomy:DayOfYear # freq=1247398 freq=1203572
+AndHighHighDayTaxoFacets: +year +they +facets:taxonomy:DayOfYear # freq=1235231 freq=1021945
+AndHighHighDayTaxoFacets: +1 +accessdate +facets:taxonomy:DayOfYear # freq=1641090 freq=1228887
+AndHighHighDayTaxoFacets: +on +web +facets:taxonomy:DayOfYear # freq=4074624 freq=1118334
+AndHighHighDayTaxoFacets: +first +5 +facets:taxonomy:DayOfYear # freq=1933372 freq=891361
+AndHighHighDayTaxoFacets: +he +but +facets:taxonomy:DayOfYear # freq=1659434 freq=1456553
+AndHighHighDayTaxoFacets: +title +when +facets:taxonomy:DayOfYear # freq=2397378 freq=1027487
+AndHighHighDayTaxoFacets: +who +two +facets:taxonomy:DayOfYear # freq=1196171 freq=1104053
+AndHighHighDayTaxoFacets: +last +2006 +facets:taxonomy:DayOfYear # freq=958437 freq=889954
+AndHighHighDayTaxoFacets: +from +name +facets:taxonomy:DayOfYear # freq=3224339 freq=2827713
+AndHighHighDayTaxoFacets: +new +i +facets:taxonomy:DayOfYear # freq=1657293 freq=956148
+AndHighHighDayTaxoFacets: +was +publisher +facets:taxonomy:DayOfYear # freq=3763623 freq=1289029
+AndHighHighDayTaxoFacets: +and +not +facets:taxonomy:DayOfYear # freq=7318061 freq=1713264
+AndHighHighDayTaxoFacets: +is +their +facets:taxonomy:DayOfYear # freq=4074455 freq=1158682
+AndHighHighDayTaxoFacets: +ref +that +facets:taxonomy:DayOfYear # freq=3793973 freq=2931020
+AndHighHighDayTaxoFacets: +of +for +facets:taxonomy:DayOfYear # freq=8184358 freq=4380011
+AndHighHighDayTaxoFacets: +name +which +facets:taxonomy:DayOfYear # freq=2827713 freq=1963428
+AndHighHighDayTaxoFacets: +after +2008 +facets:taxonomy:DayOfYear # freq=1247398 freq=831253
+AndHighHighDayTaxoFacets: +that +an +facets:taxonomy:DayOfYear # freq=2931020 freq=2628056
+AndHighHighDayTaxoFacets: +by +2006 +facets:taxonomy:DayOfYear # freq=3826691 freq=889954
+AndHighHighDayTaxoFacets: +that +or +facets:taxonomy:DayOfYear # freq=2931020 freq=1858841
+AndHighHighDayTaxoFacets: +be +which +facets:taxonomy:DayOfYear # freq=2051702 freq=1963428
+AndHighHighDayTaxoFacets: +with +2010 +facets:taxonomy:DayOfYear # freq=3709421 freq=950573
+AndHighHighDayTaxoFacets: +by +with +facets:taxonomy:DayOfYear # freq=3826691 freq=3709421
+AndHighHighDayTaxoFacets: +by +4 +facets:taxonomy:DayOfYear # freq=3826691 freq=986452
+AndHighHighDayTaxoFacets: +was +cite +facets:taxonomy:DayOfYear # freq=3763623 freq=1741194
+AndHighHighDayTaxoFacets: +was +they +facets:taxonomy:DayOfYear # freq=3763623 freq=1021945
+AndHighHighDayTaxoFacets: +on +was +facets:taxonomy:DayOfYear # freq=4074624 freq=3763623
+AndHighHighDayTaxoFacets: +is +time +facets:taxonomy:DayOfYear # freq=4074455 freq=1032071
+AndHighHighDayTaxoFacets: +the +be +facets:taxonomy:DayOfYear # freq=8217362 freq=2051702
+AndHighHighDayTaxoFacets: +were +2010 +facets:taxonomy:DayOfYear # freq=1524630 freq=950573
+AndHighHighDayTaxoFacets: +they +2006 +facets:taxonomy:DayOfYear # freq=1021945 freq=889954
+AndHighHighDayTaxoFacets: +he +may +facets:taxonomy:DayOfYear # freq=1659434 freq=1071932
+AndHighHighDayTaxoFacets: +an +title +facets:taxonomy:DayOfYear # freq=2628056 freq=2397378
+AndHighHighDayTaxoFacets: +into +some +facets:taxonomy:DayOfYear # freq=888684 freq=839919
+AndHighHighDayTaxoFacets: +first +some +facets:taxonomy:DayOfYear # freq=1933372 freq=839919
+AndHighHighDayTaxoFacets: +name +new +facets:taxonomy:DayOfYear # freq=2827713 freq=1657293
+AndHighHighDayTaxoFacets: +cite +3 +facets:taxonomy:DayOfYear # freq=1741194 freq=1148799
+AndHighHighDayTaxoFacets: +to +web +facets:taxonomy:DayOfYear # freq=6155577 freq=1118334
+AndHighHighDayTaxoFacets: +for +it +facets:taxonomy:DayOfYear # freq=4380011 freq=2675552
+AndHighHighDayTaxoFacets: +year +there +facets:taxonomy:DayOfYear # freq=1235231 freq=956153
+AndHighHighDayTaxoFacets: +but +been +facets:taxonomy:DayOfYear # freq=1456553 freq=1041183
+AndHighHighDayTaxoFacets: +this +who +facets:taxonomy:DayOfYear # freq=2224932 freq=1196171
+AndHighHighDayTaxoFacets: +ref +web +facets:taxonomy:DayOfYear # freq=3793973 freq=1118334
+AndHighHighDayTaxoFacets: +cite +2011 +facets:taxonomy:DayOfYear # freq=1741194 freq=871410
+AndHighHighDayTaxoFacets: +by +he +facets:taxonomy:DayOfYear # freq=3826691 freq=1659434
+AndHighHighDayTaxoFacets: +name +first +facets:taxonomy:DayOfYear # freq=2827713 freq=1933372
+AndHighHighDayTaxoFacets: +has +about +facets:taxonomy:DayOfYear # freq=1502961 freq=850283
+AndHighHighDayTaxoFacets: +were +two +facets:taxonomy:DayOfYear # freq=1524630 freq=1104053
+AndHighHighDayTaxoFacets: +two +work +facets:taxonomy:DayOfYear # freq=1104053 freq=853422
+AndHighHighDayTaxoFacets: +he +been +facets:taxonomy:DayOfYear # freq=1659434 freq=1041183
+AndHighHighDayTaxoFacets: +from +2 +facets:taxonomy:DayOfYear # freq=3224339 freq=1549245
+AndHighHighDayTaxoFacets: +all +some +facets:taxonomy:DayOfYear # freq=1203572 freq=839919
+AndHighHighDayTaxoFacets: +on +only +facets:taxonomy:DayOfYear # freq=4074624 freq=875561
+AndHighHighDayTaxoFacets: +was +no +facets:taxonomy:DayOfYear # freq=3763623 freq=1045000
+AndHighHighDayTaxoFacets: +name +see +facets:taxonomy:DayOfYear # freq=2827713 freq=1044180
+AndHighHighDayTaxoFacets: +of +as +facets:taxonomy:DayOfYear # freq=8184358 freq=3925535
+AndHighHighDayTaxoFacets: +be +has +facets:taxonomy:DayOfYear # freq=2051702 freq=1502961
+AndHighHighDayTaxoFacets: +url +into +facets:taxonomy:DayOfYear # freq=1513595 freq=888684
+AndHighHighDayTaxoFacets: +of +2006 +facets:taxonomy:DayOfYear # freq=8184358 freq=889954
+AndHighHighDayTaxoFacets: +ref +or +facets:taxonomy:DayOfYear # freq=3793973 freq=1858841
+AndHighHighDayTaxoFacets: +by +url +facets:taxonomy:DayOfYear # freq=3826691 freq=1513595
+AndHighHighDayTaxoFacets: +3 +into +facets:taxonomy:DayOfYear # freq=1148799 freq=888684
+AndHighHighDayTaxoFacets: +which +year +facets:taxonomy:DayOfYear # freq=1963428 freq=1235231
+AndHighHighDayTaxoFacets: +at +only +facets:taxonomy:DayOfYear # freq=2857534 freq=875561
+AndHighHighDayTaxoFacets: +http +publisher +facets:taxonomy:DayOfYear # freq=3493581 freq=1289029
+AndHighHighDayTaxoFacets: +with +accessdate +facets:taxonomy:DayOfYear # freq=3709421 freq=1228887
+AndHighHighDayTaxoFacets: +had +work +facets:taxonomy:DayOfYear # freq=1246743 freq=853422
+AndHighHighDayTaxoFacets: +as +they +facets:taxonomy:DayOfYear # freq=3925535 freq=1021945
+AndHighHighDayTaxoFacets: +the +2009 +facets:taxonomy:DayOfYear # freq=8217362 freq=887702
+AndHighHighDayTaxoFacets: +are +but +facets:taxonomy:DayOfYear # freq=1877802 freq=1456553
+AndHighHighDayTaxoFacets: +other +10 +facets:taxonomy:DayOfYear # freq=1269961 freq=918339
+AndHighHighDayTaxoFacets: +two +they +facets:taxonomy:DayOfYear # freq=1104053 freq=1021945
+AndHighHighDayTaxoFacets: +all +they +facets:taxonomy:DayOfYear # freq=1203572 freq=1021945
+AndHighHighDayTaxoFacets: +2011 +about +facets:taxonomy:DayOfYear # freq=871410 freq=850283
+AndHighHighDayTaxoFacets: +name +states +facets:taxonomy:DayOfYear # freq=2827713 freq=1034872
+AndHighHighDayTaxoFacets: +were +may +facets:taxonomy:DayOfYear # freq=1524630 freq=1071932
+AndHighHighDayTaxoFacets: +the +into +facets:taxonomy:DayOfYear # freq=8217362 freq=888684
+AndHighHighDayTaxoFacets: +new +united +facets:taxonomy:DayOfYear # freq=1657293 freq=1196944
+AndHighHighDayTaxoFacets: +their +only +facets:taxonomy:DayOfYear # freq=1158682 freq=875561
+AndHighHighDayTaxoFacets: +be +10 +facets:taxonomy:DayOfYear # freq=2051702 freq=918339
+AndHighHighDayTaxoFacets: +that +not +facets:taxonomy:DayOfYear # freq=2931020 freq=1713264
+AndHighHighDayTaxoFacets: +title +all +facets:taxonomy:DayOfYear # freq=2397378 freq=1203572
+AndHighHighDayTaxoFacets: +with +have +facets:taxonomy:DayOfYear # freq=3709421 freq=1297121
+AndHighHighDayTaxoFacets: +as +been +facets:taxonomy:DayOfYear # freq=3925535 freq=1041183
+AndHighHighDayTaxoFacets: +it +more +facets:taxonomy:DayOfYear # freq=2675552 freq=963533
+AndHighHighDayTaxoFacets: +all +united +facets:taxonomy:DayOfYear # freq=1203572 freq=1196944
+AndHighHighDayTaxoFacets: +other +two +facets:taxonomy:DayOfYear # freq=1269961 freq=1104053
+AndHighHighDayTaxoFacets: +he +url +facets:taxonomy:DayOfYear # freq=1659434 freq=1513595
+AndHighHighDayTaxoFacets: +to +3 +facets:taxonomy:DayOfYear # freq=6155577 freq=1148799
+AndHighHighDayTaxoFacets: +in +from +facets:taxonomy:DayOfYear # freq=7320987 freq=3224339
+AndHighHighDayTaxoFacets: +not +there +facets:taxonomy:DayOfYear # freq=1713264 freq=956153
+AndHighHighDayTaxoFacets: +other +see +facets:taxonomy:DayOfYear # freq=1269961 freq=1044180
+AndHighHighDayTaxoFacets: +its +i +facets:taxonomy:DayOfYear # freq=1173450 freq=956148
+AndHighHighDayTaxoFacets: +as +2008 +facets:taxonomy:DayOfYear # freq=3925535 freq=831253
+AndHighHighDayTaxoFacets: +http +s +facets:taxonomy:DayOfYear # freq=3493581 freq=1581243
+AndHighHighDayTaxoFacets: +or +web +facets:taxonomy:DayOfYear # freq=1858841 freq=1118334
+AndHighHighDayTaxoFacets: +new +publisher +facets:taxonomy:DayOfYear # freq=1657293 freq=1289029
+AndHighHighDayTaxoFacets: +of +who +facets:taxonomy:DayOfYear # freq=8184358 freq=1196171
+AndHighHighDayTaxoFacets: +10 +2009 +facets:taxonomy:DayOfYear # freq=918339 freq=887702
+AndHighHighDayTaxoFacets: +that +he +facets:taxonomy:DayOfYear # freq=2931020 freq=1659434
+AndHighHighDayTaxoFacets: +url +2005 +facets:taxonomy:DayOfYear # freq=1513595 freq=835460
+AndHighHighDayTaxoFacets: +the +a +facets:taxonomy:DayOfYear # freq=8217362 freq=6560531
+AndHighHighDayTaxoFacets: +more +there +facets:taxonomy:DayOfYear # freq=963533 freq=956153
+AndHighHighDayTaxoFacets: +and +an +facets:taxonomy:DayOfYear # freq=7318061 freq=2628056
+AndHighHighDayTaxoFacets: +with +they +facets:taxonomy:DayOfYear # freq=3709421 freq=1021945
+AndHighHighDayTaxoFacets: +title +time +facets:taxonomy:DayOfYear # freq=2397378 freq=1032071
+AndHighHighDayTaxoFacets: +states +4 +facets:taxonomy:DayOfYear # freq=1034872 freq=986452
+AndHighHighDayTaxoFacets: +united +when +facets:taxonomy:DayOfYear # freq=1196944 freq=1027487
+AndHighHighDayTaxoFacets: +is +title +facets:taxonomy:DayOfYear # freq=4074455 freq=2397378
+AndHighHighDayTaxoFacets: +from +who +facets:taxonomy:DayOfYear # freq=3224339 freq=1196171
+AndHighHighDayTaxoFacets: +more +some +facets:taxonomy:DayOfYear # freq=963533 freq=839919
+AndHighHighDayTaxoFacets: +title +year +facets:taxonomy:DayOfYear # freq=2397378 freq=1235231
+AndHighHighDayTaxoFacets: +one +after +facets:taxonomy:DayOfYear # freq=1527689 freq=1247398
+AndHighHighDayTaxoFacets: +with +title +facets:taxonomy:DayOfYear # freq=3709421 freq=2397378
+AndHighHighDayTaxoFacets: +in +first +facets:taxonomy:DayOfYear # freq=7320987 freq=1933372
+AndHighHighDayTaxoFacets: +are +i +facets:taxonomy:DayOfYear # freq=1877802 freq=956148
+AndHighHighDayTaxoFacets: +the +two +facets:taxonomy:DayOfYear # freq=8217362 freq=1104053
+AndHighHighDayTaxoFacets: +but +there +facets:taxonomy:DayOfYear # freq=1456553 freq=956153
+AndHighHighDayTaxoFacets: +from +all +facets:taxonomy:DayOfYear # freq=3224339 freq=1203572
+AndHighHighDayTaxoFacets: +2 +more +facets:taxonomy:DayOfYear # freq=1549245 freq=963533
+AndHighHighDayTaxoFacets: +had +its +facets:taxonomy:DayOfYear # freq=1246743 freq=1173450
+AndHighHighDayTaxoFacets: +in +no +facets:taxonomy:DayOfYear # freq=7320987 freq=1045000
+AndHighHighDayTaxoFacets: +other +more +facets:taxonomy:DayOfYear # freq=1269961 freq=963533
+AndHighHighDayTaxoFacets: +his +united +facets:taxonomy:DayOfYear # freq=1777780 freq=1196944
+AndHighHighDayTaxoFacets: +more +last +facets:taxonomy:DayOfYear # freq=963533 freq=958437
+AndHighHighDayTaxoFacets: +ref +more +facets:taxonomy:DayOfYear # freq=3793973 freq=963533
+AndHighHighDayTaxoFacets: +ref +been +facets:taxonomy:DayOfYear # freq=3793973 freq=1041183
+AndHighHighDayTaxoFacets: +cite +time +facets:taxonomy:DayOfYear # freq=1741194 freq=1032071
+AndHighHighDayTaxoFacets: +http +3 +facets:taxonomy:DayOfYear # freq=3493581 freq=1148799
+AndHighHighDayTaxoFacets: +has +they +facets:taxonomy:DayOfYear # freq=1502961 freq=1021945
+AndHighHighDayTaxoFacets: +and +2011 +facets:taxonomy:DayOfYear # freq=7318061 freq=871410
+AndHighHighDayTaxoFacets: +be +accessdate +facets:taxonomy:DayOfYear # freq=2051702 freq=1228887
+AndHighHighDayTaxoFacets: +are +2010 +facets:taxonomy:DayOfYear # freq=1877802 freq=950573
+AndHighHighDayTaxoFacets: +at +2009 +facets:taxonomy:DayOfYear # freq=2857534 freq=887702
+AndHighHighDayTaxoFacets: +also +united +facets:taxonomy:DayOfYear # freq=1959419 freq=1196944
+AndHighHighDayTaxoFacets: +united +been +facets:taxonomy:DayOfYear # freq=1196944 freq=1041183
+AndHighHighDayTaxoFacets: +also +1 +facets:taxonomy:DayOfYear # freq=1959419 freq=1641090
+AndHighHighDayTaxoFacets: +he +last +facets:taxonomy:DayOfYear # freq=1659434 freq=958437
+AndHighHighDayTaxoFacets: +was +from +facets:taxonomy:DayOfYear # freq=3763623 freq=3224339
+AndHighHighDayTaxoFacets: +ref +when +facets:taxonomy:DayOfYear # freq=3793973 freq=1027487
+AndHighHighDayTaxoFacets: +not +they +facets:taxonomy:DayOfYear # freq=1713264 freq=1021945
+AndHighHighDayTaxoFacets: +the +other +facets:taxonomy:DayOfYear # freq=8217362 freq=1269961
+AndHighHighDayTaxoFacets: +cite +work +facets:taxonomy:DayOfYear # freq=1741194 freq=853422
+AndHighHighDayTaxoFacets: +was +were +facets:taxonomy:DayOfYear # freq=3763623 freq=1524630
+AndHighHighDayTaxoFacets: +in +after +facets:taxonomy:DayOfYear # freq=7320987 freq=1247398
+AndHighHighDayTaxoFacets: +and +first +facets:taxonomy:DayOfYear # freq=7318061 freq=1933372
+AndHighHighDayTaxoFacets: +have +their +facets:taxonomy:DayOfYear # freq=1297121 freq=1158682
+AndHighHighDayTaxoFacets: +also +4 +facets:taxonomy:DayOfYear # freq=1959419 freq=986452
+AndHighHighDayTaxoFacets: +he +2006 +facets:taxonomy:DayOfYear # freq=1659434 freq=889954
+AndHighHighDayTaxoFacets: +may +time +facets:taxonomy:DayOfYear # freq=1071932 freq=1032071
+AndHighHighDayTaxoFacets: +is +url +facets:taxonomy:DayOfYear # freq=4074455 freq=1513595
+AndHighHighDayTaxoFacets: +for +has +facets:taxonomy:DayOfYear # freq=4380011 freq=1502961
+AndHighHighDayTaxoFacets: +and +be +facets:taxonomy:DayOfYear # freq=7318061 freq=2051702
+AndHighHighDayTaxoFacets: +url +had +facets:taxonomy:DayOfYear # freq=1513595 freq=1246743
+AndHighHighDayTaxoFacets: +his +5 +facets:taxonomy:DayOfYear # freq=1777780 freq=891361
+AndHighHighDayTaxoFacets: +on +he +facets:taxonomy:DayOfYear # freq=4074624 freq=1659434
+AndHighHighDayTaxoFacets: +this +first +facets:taxonomy:DayOfYear # freq=2224932 freq=1933372
+AndHighHighDayTaxoFacets: +new +its +facets:taxonomy:DayOfYear # freq=1657293 freq=1173450
+AndHighHighDayTaxoFacets: +s +2009 +facets:taxonomy:DayOfYear # freq=1581243 freq=887702
+AndHighHighDayTaxoFacets: +see +2010 +facets:taxonomy:DayOfYear # freq=1044180 freq=950573
+AndHighHighDayTaxoFacets: +or +but +facets:taxonomy:DayOfYear # freq=1858841 freq=1456553
+AndHighHighDayTaxoFacets: +its +into +facets:taxonomy:DayOfYear # freq=1173450 freq=888684
+AndHighHighDayTaxoFacets: +on +accessdate +facets:taxonomy:DayOfYear # freq=4074624 freq=1228887
+AndHighHighDayTaxoFacets: +are +accessdate +facets:taxonomy:DayOfYear # freq=1877802 freq=1228887
+AndHighHighDayTaxoFacets: +2 +there +facets:taxonomy:DayOfYear # freq=1549245 freq=956153
+AndHighHighDayTaxoFacets: +united +3 +facets:taxonomy:DayOfYear # freq=1196944 freq=1148799
+AndHighHighDayTaxoFacets: +which +no +facets:taxonomy:DayOfYear # freq=1963428 freq=1045000
+AndHighHighDayTaxoFacets: +s +2006 +facets:taxonomy:DayOfYear # freq=1581243 freq=889954
+AndHighHighDayTaxoFacets: +ref +there +facets:taxonomy:DayOfYear # freq=3793973 freq=956153
+AndHighHighDayTaxoFacets: +he +more +facets:taxonomy:DayOfYear # freq=1659434 freq=963533
+AndHighHighDayTaxoFacets: +had +two +facets:taxonomy:DayOfYear # freq=1246743 freq=1104053
+AndHighHighDayTaxoFacets: +the +only +facets:taxonomy:DayOfYear # freq=8217362 freq=875561
+AndHighHighDayTaxoFacets: +be +about +facets:taxonomy:DayOfYear # freq=2051702 freq=850283
+AndHighHighDayTaxoFacets: +in +has +facets:taxonomy:DayOfYear # freq=7320987 freq=1502961
+AndHighHighDayTaxoFacets: +2009 +work +facets:taxonomy:DayOfYear # freq=887702 freq=853422
+AndHighHighDayTaxoFacets: +on +10 +facets:taxonomy:DayOfYear # freq=4074624 freq=918339
+AndHighHighDayTaxoFacets: +ref +2010 +facets:taxonomy:DayOfYear # freq=3793973 freq=950573
+AndHighHighDayTaxoFacets: +other +2006 +facets:taxonomy:DayOfYear # freq=1269961 freq=889954
+AndHighHighDayTaxoFacets: +with +all +facets:taxonomy:DayOfYear # freq=3709421 freq=1203572
+AndHighHighDayTaxoFacets: +in +work +facets:taxonomy:DayOfYear # freq=7320987 freq=853422
+AndHighHighDayTaxoFacets: +url +about +facets:taxonomy:DayOfYear # freq=1513595 freq=850283
+AndHighHighDayTaxoFacets: +after +some +facets:taxonomy:DayOfYear # freq=1247398 freq=839919
+AndHighHighDayTaxoFacets: +this +when +facets:taxonomy:DayOfYear # freq=2224932 freq=1027487
+AndHighHighDayTaxoFacets: +not +1 +facets:taxonomy:DayOfYear # freq=1713264 freq=1641090
+AndHighHighDayTaxoFacets: +1 +more +facets:taxonomy:DayOfYear # freq=1641090 freq=963533
+AndHighHighDayTaxoFacets: +not +2 +facets:taxonomy:DayOfYear # freq=1713264 freq=1549245
+AndHighHighDayTaxoFacets: +publisher +2005 +facets:taxonomy:DayOfYear # freq=1289029 freq=835460
+AndHighHighDayTaxoFacets: +in +at +facets:taxonomy:DayOfYear # freq=7320987 freq=2857534
+AndHighHighDayTaxoFacets: +1 +some +facets:taxonomy:DayOfYear # freq=1641090 freq=839919
+AndHighHighDayTaxoFacets: +s +its +facets:taxonomy:DayOfYear # freq=1581243 freq=1173450
+AndHighHighDayTaxoFacets: +date +more +facets:taxonomy:DayOfYear # freq=2020626 freq=963533
+AndHighHighDayTaxoFacets: +from +his +facets:taxonomy:DayOfYear # freq=3224339 freq=1777780
+AndHighHighDayTaxoFacets: +was +when +facets:taxonomy:DayOfYear # freq=3763623 freq=1027487
+AndHighHighDayTaxoFacets: +time +2010 +facets:taxonomy:DayOfYear # freq=1032071 freq=950573
+AndHighHighDayTaxoFacets: +it +2 +facets:taxonomy:DayOfYear # freq=2675552 freq=1549245
+AndHighHighDayTaxoFacets: +of +http +facets:taxonomy:DayOfYear # freq=8184358 freq=3493581
+AndHighHighDayTaxoFacets: +2 +2011 +facets:taxonomy:DayOfYear # freq=1549245 freq=871410
+AndHighHighDayTaxoFacets: +who +2009 +facets:taxonomy:DayOfYear # freq=1196171 freq=887702
+AndHighHighDayTaxoFacets: +in +2009 +facets:taxonomy:DayOfYear # freq=7320987 freq=887702
+AndHighHighDayTaxoFacets: +by +3 +facets:taxonomy:DayOfYear # freq=3826691 freq=1148799
+AndHighHighDayTaxoFacets: +when +2011 +facets:taxonomy:DayOfYear # freq=1027487 freq=871410
+AndHighHighDayTaxoFacets: +not +have +facets:taxonomy:DayOfYear # freq=1713264 freq=1297121
+AndHighHighDayTaxoFacets: +all +their +facets:taxonomy:DayOfYear # freq=1203572 freq=1158682
+AndHighHighDayTaxoFacets: +an +2005 +facets:taxonomy:DayOfYear # freq=2628056 freq=835460
+AndHighHighDayTaxoFacets: +of +is +facets:taxonomy:DayOfYear # freq=8184358 freq=4074455
+AndHighHighDayTaxoFacets: +of +url +facets:taxonomy:DayOfYear # freq=8184358 freq=1513595
+AndHighHighDayTaxoFacets: +also +year +facets:taxonomy:DayOfYear # freq=1959419 freq=1235231
+AndHighHighDayTaxoFacets: +is +new +facets:taxonomy:DayOfYear # freq=4074455 freq=1657293
+AndHighHighDayTaxoFacets: +http +name +facets:taxonomy:DayOfYear # freq=3493581 freq=2827713
+AndHighHighDayTaxoFacets: +i +into +facets:taxonomy:DayOfYear # freq=956148 freq=888684
+AndHighHighDayTaxoFacets: +are +united +facets:taxonomy:DayOfYear # freq=1877802 freq=1196944
+AndHighHighDayTaxoFacets: +or +only +facets:taxonomy:DayOfYear # freq=1858841 freq=875561
+AndHighHighDayTaxoFacets: +who +their +facets:taxonomy:DayOfYear # freq=1196171 freq=1158682
+AndHighHighDayTaxoFacets: +name +been +facets:taxonomy:DayOfYear # freq=2827713 freq=1041183
+AndHighHighDayTaxoFacets: +last +2009 +facets:taxonomy:DayOfYear # freq=958437 freq=887702
+AndHighHighDayTaxoFacets: +they +2005 +facets:taxonomy:DayOfYear # freq=1021945 freq=835460
+AndHighHighDayTaxoFacets: +new +1 +facets:taxonomy:DayOfYear # freq=1657293 freq=1641090
+AndHighHighDayTaxoFacets: +title +some +facets:taxonomy:DayOfYear # freq=2397378 freq=839919
+AndHighHighDayTaxoFacets: +name +5 +facets:taxonomy:DayOfYear # freq=2827713 freq=891361
+AndHighHighDayTaxoFacets: +and +or +facets:taxonomy:DayOfYear # freq=7318061 freq=1858841
+AndHighHighDayTaxoFacets: +3 +2006 +facets:taxonomy:DayOfYear # freq=1148799 freq=889954
+AndHighHighDayTaxoFacets: +of +has +facets:taxonomy:DayOfYear # freq=8184358 freq=1502961
+AndHighHighDayTaxoFacets: +which +i +facets:taxonomy:DayOfYear # freq=1963428 freq=956148
+AndHighHighDayTaxoFacets: +see +5 +facets:taxonomy:DayOfYear # freq=1044180 freq=891361
+AndHighHighDayTaxoFacets: +has +2011 +facets:taxonomy:DayOfYear # freq=1502961 freq=871410
+AndHighHighDayTaxoFacets: +new +accessdate +facets:taxonomy:DayOfYear # freq=1657293 freq=1228887
+AndHighHighDayTaxoFacets: +united +i +facets:taxonomy:DayOfYear # freq=1196944 freq=956148
+AndHighHighDayTaxoFacets: +are +10 +facets:taxonomy:DayOfYear # freq=1877802 freq=918339
+AndHighHighDayTaxoFacets: +the +is +facets:taxonomy:DayOfYear # freq=8217362 freq=4074455
+AndHighHighDayTaxoFacets: +other +web +facets:taxonomy:DayOfYear # freq=1269961 freq=1118334
+AndHighHighDayTaxoFacets: +i +2006 +facets:taxonomy:DayOfYear # freq=956148 freq=889954
+AndHighHighDayTaxoFacets: +were +publisher +facets:taxonomy:DayOfYear # freq=1524630 freq=1289029
+AndHighHighDayTaxoFacets: +be +when +facets:taxonomy:DayOfYear # freq=2051702 freq=1027487
+AndHighHighDayTaxoFacets: +to +date +facets:taxonomy:DayOfYear # freq=6155577 freq=2020626
+AndHighHighDayTaxoFacets: +for +2006 +facets:taxonomy:DayOfYear # freq=4380011 freq=889954
+AndHighHighDayTaxoFacets: +for +at +facets:taxonomy:DayOfYear # freq=4380011 freq=2857534
+AndHighHighDayTaxoFacets: +his +s +facets:taxonomy:DayOfYear # freq=1777780 freq=1581243
+AndHighHighDayTaxoFacets: +from +or +facets:taxonomy:DayOfYear # freq=3224339 freq=1858841
+AndHighHighDayTaxoFacets: +ref +an +facets:taxonomy:DayOfYear # freq=3793973 freq=2628056
+AndHighHighDayTaxoFacets: +which +had +facets:taxonomy:DayOfYear # freq=1963428 freq=1246743
+AndHighHighDayTaxoFacets: +an +were +facets:taxonomy:DayOfYear # freq=2628056 freq=1524630
+AndHighHighDayTaxoFacets: +web +only +facets:taxonomy:DayOfYear # freq=1118334 freq=875561
+AndHighHighDayTaxoFacets: +ref +one +facets:taxonomy:DayOfYear # freq=3793973 freq=1527689
+AndHighHighDayTaxoFacets: +a +one +facets:taxonomy:DayOfYear # freq=6560531 freq=1527689
+AndHighHighDayTaxoFacets: +they +into +facets:taxonomy:DayOfYear # freq=1021945 freq=888684
+AndHighHighDayTaxoFacets: +of +2008 +facets:taxonomy:DayOfYear # freq=8184358 freq=831253
+AndHighHighDayTaxoFacets: +in +which +facets:taxonomy:DayOfYear # freq=7320987 freq=1963428
+AndHighHighDayTaxoFacets: +united +2010 +facets:taxonomy:DayOfYear # freq=1196944 freq=950573
+AndHighHighDayTaxoFacets: +after +i +facets:taxonomy:DayOfYear # freq=1247398 freq=956148
+AndHighHighDayTaxoFacets: +he +web +facets:taxonomy:DayOfYear # freq=1659434 freq=1118334
+AndHighHighDayTaxoFacets: +are +states +facets:taxonomy:DayOfYear # freq=1877802 freq=1034872
+AndHighHighDayTaxoFacets: +after +time +facets:taxonomy:DayOfYear # freq=1247398 freq=1032071
+AndHighHighDayTaxoFacets: +its +web +facets:taxonomy:DayOfYear # freq=1173450 freq=1118334
+AndHighHighDayTaxoFacets: +for +when +facets:taxonomy:DayOfYear # freq=4380011 freq=1027487
+AndHighHighDayTaxoFacets: +has +states +facets:taxonomy:DayOfYear # freq=1502961 freq=1034872
+AndHighHighDayTaxoFacets: +the +no +facets:taxonomy:DayOfYear # freq=8217362 freq=1045000
+AndHighHighDayTaxoFacets: +title +one +facets:taxonomy:DayOfYear # freq=2397378 freq=1527689
+AndHighHighDayTaxoFacets: +i +2009 +facets:taxonomy:DayOfYear # freq=956148 freq=887702
+AndHighHighDayTaxoFacets: +1 +states +facets:taxonomy:DayOfYear # freq=1641090 freq=1034872
+AndHighHighDayTaxoFacets: +other +only +facets:taxonomy:DayOfYear # freq=1269961 freq=875561
+AndHighHighDayTaxoFacets: +by +they +facets:taxonomy:DayOfYear # freq=3826691 freq=1021945
+AndHighHighDayTaxoFacets: +http +its +facets:taxonomy:DayOfYear # freq=3493581 freq=1173450
+AndHighHighDayTaxoFacets: +for +two +facets:taxonomy:DayOfYear # freq=4380011 freq=1104053
+AndHighHighDayTaxoFacets: +all +may +facets:taxonomy:DayOfYear # freq=1203572 freq=1071932
+AndHighHighDayTaxoFacets: +after +last +facets:taxonomy:DayOfYear # freq=1247398 freq=958437
+AndHighHighDayTaxoFacets: +there +only +facets:taxonomy:DayOfYear # freq=956153 freq=875561
+AndHighHighDayTaxoFacets: +2 +no +facets:taxonomy:DayOfYear # freq=1549245 freq=1045000
+AndHighHighDayTaxoFacets: +an +he +facets:taxonomy:DayOfYear # freq=2628056 freq=1659434
+AndHighHighDayTaxoFacets: +his +i +facets:taxonomy:DayOfYear # freq=1777780 freq=956148
+AndHighHighDayTaxoFacets: +first +not +facets:taxonomy:DayOfYear # freq=1933372 freq=1713264
+AndHighHighDayTaxoFacets: +a +5 +facets:taxonomy:DayOfYear # freq=6560531 freq=891361
+AndHighHighDayTaxoFacets: +from +2005 +facets:taxonomy:DayOfYear # freq=3224339 freq=835460
+AndHighHighDayTaxoFacets: +after +web +facets:taxonomy:DayOfYear # freq=1247398 freq=1118334
+AndHighHighDayTaxoFacets: +to +which +facets:taxonomy:DayOfYear # freq=6155577 freq=1963428
+AndHighHighDayTaxoFacets: +this +into +facets:taxonomy:DayOfYear # freq=2224932 freq=888684
+AndHighHighDayTaxoFacets: +its +last +facets:taxonomy:DayOfYear # freq=1173450 freq=958437
+AndHighHighDayTaxoFacets: +it +there +facets:taxonomy:DayOfYear # freq=2675552 freq=956153
+AndHighHighDayTaxoFacets: +name +are +facets:taxonomy:DayOfYear # freq=2827713 freq=1877802
+AndHighHighDayTaxoFacets: +are +4 +facets:taxonomy:DayOfYear # freq=1877802 freq=986452
+AndHighHighDayTaxoFacets: +name +cite +facets:taxonomy:DayOfYear # freq=2827713 freq=1741194
+AndHighHighDayTaxoFacets: +more +2008 +facets:taxonomy:DayOfYear # freq=963533 freq=831253
+AndHighHighDayTaxoFacets: +of +that +facets:taxonomy:DayOfYear # freq=8184358 freq=2931020
+AndHighHighDayTaxoFacets: +ref +at +facets:taxonomy:DayOfYear # freq=3793973 freq=2857534
+AndHighHighDayTaxoFacets: +new +web +facets:taxonomy:DayOfYear # freq=1657293 freq=1118334
+AndHighHighDayTaxoFacets: +the +2 +facets:taxonomy:DayOfYear # freq=8217362 freq=1549245
+AndHighHighDayTaxoFacets: +for +1 +facets:taxonomy:DayOfYear # freq=4380011 freq=1641090
+AndHighHighDayTaxoFacets: +by +no +facets:taxonomy:DayOfYear # freq=3826691 freq=1045000
+AndHighHighDayTaxoFacets: +all +i +facets:taxonomy:DayOfYear # freq=1203572 freq=956148
+AndHighHighDayTaxoFacets: +5 +2006 +facets:taxonomy:DayOfYear # freq=891361 freq=889954
+AndHighHighDayTaxoFacets: +4 +work +facets:taxonomy:DayOfYear # freq=986452 freq=853422
+AndHighHighDayTaxoFacets: +was +new +facets:taxonomy:DayOfYear # freq=3763623 freq=1657293
+AndHighHighDayTaxoFacets: +year +see +facets:taxonomy:DayOfYear # freq=1235231 freq=1044180
+AndHighHighDayTaxoFacets: +s +had +facets:taxonomy:DayOfYear # freq=1581243 freq=1246743
+AndHighHighDayTaxoFacets: +an +last +facets:taxonomy:DayOfYear # freq=2628056 freq=958437
+AndHighHighDayTaxoFacets: +had +4 +facets:taxonomy:DayOfYear # freq=1246743 freq=986452
+AndHighHighDayTaxoFacets: +from +publisher +facets:taxonomy:DayOfYear # freq=3224339 freq=1289029
+AndHighHighDayTaxoFacets: +new +url +facets:taxonomy:DayOfYear # freq=1657293 freq=1513595
+AndHighHighDayTaxoFacets: +4 +5 +facets:taxonomy:DayOfYear # freq=986452 freq=891361
+AndHighHighDayTaxoFacets: +by +cite +facets:taxonomy:DayOfYear # freq=3826691 freq=1741194
+AndHighHighDayTaxoFacets: +2010 +2009 +facets:taxonomy:DayOfYear # freq=950573 freq=887702
+AndHighHighDayTaxoFacets: +their +4 +facets:taxonomy:DayOfYear # freq=1158682 freq=986452
+AndHighHighDayTaxoFacets: +publisher +who +facets:taxonomy:DayOfYear # freq=1289029 freq=1196171
+AndHighHighDayTaxoFacets: +that +more +facets:taxonomy:DayOfYear # freq=2931020 freq=963533
+AndHighHighDayTaxoFacets: +ref +see +facets:taxonomy:DayOfYear # freq=3793973 freq=1044180
+AndHighHighDayTaxoFacets: +publisher +last +facets:taxonomy:DayOfYear # freq=1289029 freq=958437
+AndHighHighDayTaxoFacets: +but +their +facets:taxonomy:DayOfYear # freq=1456553 freq=1158682
+AndHighHighDayTaxoFacets: +is +1 +facets:taxonomy:DayOfYear # freq=4074455 freq=1641090
+AndHighHighDayTaxoFacets: +new +have +facets:taxonomy:DayOfYear # freq=1657293 freq=1297121
+AndHighHighDayTaxoFacets: +title +also +facets:taxonomy:DayOfYear # freq=2397378 freq=1959419
+AndHighHighDayTaxoFacets: +also +i +facets:taxonomy:DayOfYear # freq=1959419 freq=956148
+AndHighHighDayTaxoFacets: +had +into +facets:taxonomy:DayOfYear # freq=1246743 freq=888684
+AndHighHighDayTaxoFacets: +first +when +facets:taxonomy:DayOfYear # freq=1933372 freq=1027487
+AndHighHighDayTaxoFacets: +in +be +facets:taxonomy:DayOfYear # freq=7320987 freq=2051702
+AndHighHighDayTaxoFacets: +are +2008 +facets:taxonomy:DayOfYear # freq=1877802 freq=831253
+AndHighHighDayTaxoFacets: +two +2006 +facets:taxonomy:DayOfYear # freq=1104053 freq=889954
+AndHighHighDayTaxoFacets: +date +about +facets:taxonomy:DayOfYear # freq=2020626 freq=850283
+AndHighHighDayTaxoFacets: +its +only +facets:taxonomy:DayOfYear # freq=1173450 freq=875561
+AndHighHighDayTaxoFacets: +title +new +facets:taxonomy:DayOfYear # freq=2397378 freq=1657293
+AndHighHighDayTaxoFacets: +2 +10 +facets:taxonomy:DayOfYear # freq=1549245 freq=918339
+AndHighHighDayTaxoFacets: +2 +one +facets:taxonomy:DayOfYear # freq=1549245 freq=1527689
+AndHighHighDayTaxoFacets: +is +an +facets:taxonomy:DayOfYear # freq=4074455 freq=2628056
+AndHighHighDayTaxoFacets: +at +no +facets:taxonomy:DayOfYear # freq=2857534 freq=1045000
+AndHighHighDayTaxoFacets: +has +its +facets:taxonomy:DayOfYear # freq=1502961 freq=1173450
+AndHighHighDayTaxoFacets: +were +there +facets:taxonomy:DayOfYear # freq=1524630 freq=956153
+AndHighHighDayTaxoFacets: +with +were +facets:taxonomy:DayOfYear # freq=3709421 freq=1524630
+AndHighHighDayTaxoFacets: +on +i +facets:taxonomy:DayOfYear # freq=4074624 freq=956148
+AndHighHighDayTaxoFacets: +as +was +facets:taxonomy:DayOfYear # freq=3925535 freq=3763623
+AndHighHighDayTaxoFacets: +date +cite +facets:taxonomy:DayOfYear # freq=2020626 freq=1741194
+AndHighHighDayTaxoFacets: +or +united +facets:taxonomy:DayOfYear # freq=1858841 freq=1196944
+AndHighHighDayTaxoFacets: +to +http +facets:taxonomy:DayOfYear # freq=6155577 freq=3493581
+AndHighHighDayTaxoFacets: +he +have +facets:taxonomy:DayOfYear # freq=1659434 freq=1297121
+AndHighHighDayTaxoFacets: +s +about +facets:taxonomy:DayOfYear # freq=1581243 freq=850283
+AndHighHighDayTaxoFacets: +this +s +facets:taxonomy:DayOfYear # freq=2224932 freq=1581243
+AndHighHighDayTaxoFacets: +is +but +facets:taxonomy:DayOfYear # freq=4074455 freq=1456553
+AndHighHighDayTaxoFacets: +web +2010 +facets:taxonomy:DayOfYear # freq=1118334 freq=950573
+AndHighHighDayTaxoFacets: +first +are +facets:taxonomy:DayOfYear # freq=1933372 freq=1877802
+AndHighHighDayTaxoFacets: +have +2008 +facets:taxonomy:DayOfYear # freq=1297121 freq=831253
+AndHighHighDayTaxoFacets: +to +no +facets:taxonomy:DayOfYear # freq=6155577 freq=1045000
+AndHighHighDayTaxoFacets: +or +2 +facets:taxonomy:DayOfYear # freq=1858841 freq=1549245
+AndHighHighDayTaxoFacets: +was +about +facets:taxonomy:DayOfYear # freq=3763623 freq=850283
+AndHighHighDayTaxoFacets: +cite +more +facets:taxonomy:DayOfYear # freq=1741194 freq=963533
+AndHighHighDayTaxoFacets: +date +their +facets:taxonomy:DayOfYear # freq=2020626 freq=1158682
+AndHighHighDayTaxoFacets: +from +work +facets:taxonomy:DayOfYear # freq=3224339 freq=853422
+AndHighHighDayTaxoFacets: +at +2010 +facets:taxonomy:DayOfYear # freq=2857534 freq=950573
+AndHighHighDayTaxoFacets: +other +last +facets:taxonomy:DayOfYear # freq=1269961 freq=958437
+AndHighHighDayTaxoFacets: +date +into +facets:taxonomy:DayOfYear # freq=2020626 freq=888684
+AndHighHighDayTaxoFacets: +they +more +facets:taxonomy:DayOfYear # freq=1021945 freq=963533
+AndHighHighDayTaxoFacets: +to +ref +facets:taxonomy:DayOfYear # freq=6155577 freq=3793973
+AndHighHighDayTaxoFacets: +be +but +facets:taxonomy:DayOfYear # freq=2051702 freq=1456553
+AndHighHighDayTaxoFacets: +or +into +facets:taxonomy:DayOfYear # freq=1858841 freq=888684
+AndHighHighDayTaxoFacets: +has +last +facets:taxonomy:DayOfYear # freq=1502961 freq=958437
+AndHighHighDayTaxoFacets: +to +time +facets:taxonomy:DayOfYear # freq=6155577 freq=1032071
+AndHighHighDayTaxoFacets: +the +some +facets:taxonomy:DayOfYear # freq=8217362 freq=839919
+AndHighHighDayTaxoFacets: +ref +united +facets:taxonomy:DayOfYear # freq=3793973 freq=1196944
+AndHighHighDayTaxoFacets: +all +last +facets:taxonomy:DayOfYear # freq=1203572 freq=958437
+AndHighHighDayTaxoFacets: +url +all +facets:taxonomy:DayOfYear # freq=1513595 freq=1203572
+AndHighHighDayTaxoFacets: +other +some +facets:taxonomy:DayOfYear # freq=1269961 freq=839919
+AndHighHighDayTaxoFacets: +cite +new +facets:taxonomy:DayOfYear # freq=1741194 freq=1657293
+AndHighHighDayTaxoFacets: +and +by +facets:taxonomy:DayOfYear # freq=7318061 freq=3826691
+AndHighHighDayTaxoFacets: +publisher +i +facets:taxonomy:DayOfYear # freq=1289029 freq=956148
+AndHighHighDayTaxoFacets: +to +publisher +facets:taxonomy:DayOfYear # freq=6155577 freq=1289029
+AndHighHighDayTaxoFacets: +the +about +facets:taxonomy:DayOfYear # freq=8217362 freq=850283
+AndHighHighDayTaxoFacets: +as +are +facets:taxonomy:DayOfYear # freq=3925535 freq=1877802
+AndHighHighDayTaxoFacets: +it +title +facets:taxonomy:DayOfYear # freq=2675552 freq=2397378
+AndHighHighDayTaxoFacets: +by +are +facets:taxonomy:DayOfYear # freq=3826691 freq=1877802
+AndHighHighDayTaxoFacets: +has +have +facets:taxonomy:DayOfYear # freq=1502961 freq=1297121
+AndHighHighDayTaxoFacets: +one +2011 +facets:taxonomy:DayOfYear # freq=1527689 freq=871410
+AndHighHighDayTaxoFacets: +are +2005 +facets:taxonomy:DayOfYear # freq=1877802 freq=835460
+AndHighHighDayTaxoFacets: +had +some +facets:taxonomy:DayOfYear # freq=1246743 freq=839919
+AndHighHighDayTaxoFacets: +by +when +facets:taxonomy:DayOfYear # freq=3826691 freq=1027487
+AndHighHighDayTaxoFacets: +it +2011 +facets:taxonomy:DayOfYear # freq=2675552 freq=871410
+AndHighHighDayTaxoFacets: +1 +they +facets:taxonomy:DayOfYear # freq=1641090 freq=1021945
+AndHighHighDayTaxoFacets: +on +their +facets:taxonomy:DayOfYear # freq=4074624 freq=1158682
+AndHighHighDayTaxoFacets: +been +10 +facets:taxonomy:DayOfYear # freq=1041183 freq=918339
+AndHighHighDayTaxoFacets: +was +only +facets:taxonomy:DayOfYear # freq=3763623 freq=875561
+AndHighHighDayTaxoFacets: +also +other +facets:taxonomy:DayOfYear # freq=1959419 freq=1269961
+AndHighHighDayTaxoFacets: +who +its +facets:taxonomy:DayOfYear # freq=1196171 freq=1173450
+AndHighHighDayTaxoFacets: +3 +may +facets:taxonomy:DayOfYear # freq=1148799 freq=1071932
+AndHighHighDayTaxoFacets: +with +2006 +facets:taxonomy:DayOfYear # freq=3709421 freq=889954
+AndHighHighDayTaxoFacets: +from +but +facets:taxonomy:DayOfYear # freq=3224339 freq=1456553
+AndHighHighDayTaxoFacets: +was +work +facets:taxonomy:DayOfYear # freq=3763623 freq=853422
+AndHighHighDayTaxoFacets: +as +also +facets:taxonomy:DayOfYear # freq=3925535 freq=1959419
+AndHighHighDayTaxoFacets: +which +into +facets:taxonomy:DayOfYear # freq=1963428 freq=888684
+AndHighHighDayTaxoFacets: +see +i +facets:taxonomy:DayOfYear # freq=1044180 freq=956148
+AndHighHighDayTaxoFacets: +have +more +facets:taxonomy:DayOfYear # freq=1297121 freq=963533
+AndHighHighDayTaxoFacets: +were +after +facets:taxonomy:DayOfYear # freq=1524630 freq=1247398
+AndHighHighDayTaxoFacets: +on +2010 +facets:taxonomy:DayOfYear # freq=4074624 freq=950573
+AndHighHighDayTaxoFacets: +is +had +facets:taxonomy:DayOfYear # freq=4074455 freq=1246743
+AndHighHighDayTaxoFacets: +he +5 +facets:taxonomy:DayOfYear # freq=1659434 freq=891361
+AndHighHighDayTaxoFacets: +first +year +facets:taxonomy:DayOfYear # freq=1933372 freq=1235231
+AndHighHighDayTaxoFacets: +not +url +facets:taxonomy:DayOfYear # freq=1713264 freq=1513595
+AndHighHighDayTaxoFacets: +first +his +facets:taxonomy:DayOfYear # freq=1933372 freq=1777780
+AndHighHighDayTaxoFacets: +date +10 +facets:taxonomy:DayOfYear # freq=2020626 freq=918339
+AndHighHighDayTaxoFacets: +was +not +facets:taxonomy:DayOfYear # freq=3763623 freq=1713264
+AndHighHighDayTaxoFacets: +and +may +facets:taxonomy:DayOfYear # freq=7318061 freq=1071932
+AndHighHighDayTaxoFacets: +no +more +facets:taxonomy:DayOfYear # freq=1045000 freq=963533
+AndHighHighDayTaxoFacets: +it +url +facets:taxonomy:DayOfYear # freq=2675552 freq=1513595
+AndHighHighDayTaxoFacets: +as +no +facets:taxonomy:DayOfYear # freq=3925535 freq=1045000
+AndHighHighDayTaxoFacets: +other +all +facets:taxonomy:DayOfYear # freq=1269961 freq=1203572
+AndHighHighDayTaxoFacets: +as +2 +facets:taxonomy:DayOfYear # freq=3925535 freq=1549245
+AndHighHighDayTaxoFacets: +for +as +facets:taxonomy:DayOfYear # freq=4380011 freq=3925535
+AndHighHighDayTaxoFacets: +for +there +facets:taxonomy:DayOfYear # freq=4380011 freq=956153
+AndHighHighDayTaxoFacets: +the +new +facets:taxonomy:DayOfYear # freq=8217362 freq=1657293
+AndHighHighDayTaxoFacets: +is +no +facets:taxonomy:DayOfYear # freq=4074455 freq=1045000
+AndHighHighDayTaxoFacets: +also +their +facets:taxonomy:DayOfYear # freq=1959419 freq=1158682
+AndHighHighDayTaxoFacets: +that +2010 +facets:taxonomy:DayOfYear # freq=2931020 freq=950573
+AndHighHighDayTaxoFacets: +s +2008 +facets:taxonomy:DayOfYear # freq=1581243 freq=831253
+AndHighHighDayTaxoFacets: +were +2009 +facets:taxonomy:DayOfYear # freq=1524630 freq=887702
+AndHighHighDayTaxoFacets: +of +after +facets:taxonomy:DayOfYear # freq=8184358 freq=1247398
+AndHighHighDayTaxoFacets: +of +an +facets:taxonomy:DayOfYear # freq=8184358 freq=2628056
+AndHighHighDayTaxoFacets: +the +10 +facets:taxonomy:DayOfYear # freq=8217362 freq=918339
+AndHighHighDayTaxoFacets: +title +web +facets:taxonomy:DayOfYear # freq=2397378 freq=1118334
+AndHighHighDayTaxoFacets: +on +they +facets:taxonomy:DayOfYear # freq=4074624 freq=1021945
+AndHighHighDayTaxoFacets: +to +have +facets:taxonomy:DayOfYear # freq=6155577 freq=1297121
+AndHighHighDayTaxoFacets: +was +its +facets:taxonomy:DayOfYear # freq=3763623 freq=1173450
+AndHighHighDayTaxoFacets: +at +time +facets:taxonomy:DayOfYear # freq=2857534 freq=1032071
+AndHighHighDayTaxoFacets: +2 +accessdate +facets:taxonomy:DayOfYear # freq=1549245 freq=1228887
+AndHighHighDayTaxoFacets: +with +united +facets:taxonomy:DayOfYear # freq=3709421 freq=1196944
+AndHighHighDayTaxoFacets: +in +about +facets:taxonomy:DayOfYear # freq=7320987 freq=850283
+AndHighHighDayTaxoFacets: +in +2005 +facets:taxonomy:DayOfYear # freq=7320987 freq=835460
+AndHighHighDayTaxoFacets: +for +last +facets:taxonomy:DayOfYear # freq=4380011 freq=958437
+AndHighHighDayTaxoFacets: +and +when +facets:taxonomy:DayOfYear # freq=7318061 freq=1027487
+AndHighHighDayTaxoFacets: +an +their +facets:taxonomy:DayOfYear # freq=2628056 freq=1158682
+AndHighHighDayTaxoFacets: +2010 +into +facets:taxonomy:DayOfYear # freq=950573 freq=888684
+AndHighHighDayTaxoFacets: +web +two +facets:taxonomy:DayOfYear # freq=1118334 freq=1104053
+AndHighHighDayTaxoFacets: +two +4 +facets:taxonomy:DayOfYear # freq=1104053 freq=986452
+AndHighHighDayTaxoFacets: +1 +there +facets:taxonomy:DayOfYear # freq=1641090 freq=956153
+AndHighHighDayTaxoFacets: +name +url +facets:taxonomy:DayOfYear # freq=2827713 freq=1513595
+AndHighHighDayTaxoFacets: +united +who +facets:taxonomy:DayOfYear # freq=1196944 freq=1196171
+AndHighHighDayTaxoFacets: +they +there +facets:taxonomy:DayOfYear # freq=1021945 freq=956153
+AndHighHighDayTaxoFacets: +http +5 +facets:taxonomy:DayOfYear # freq=3493581 freq=891361
+AndHighHighDayTaxoFacets: +not +2008 +facets:taxonomy:DayOfYear # freq=1713264 freq=831253
+AndHighHighDayTaxoFacets: +are +2009 +facets:taxonomy:DayOfYear # freq=1877802 freq=887702
+AndHighHighDayTaxoFacets: +on +may +facets:taxonomy:DayOfYear # freq=4074624 freq=1071932
+AndHighHighDayTaxoFacets: +is +are +facets:taxonomy:DayOfYear # freq=4074455 freq=1877802
+AndHighHighDayTaxoFacets: +been +there +facets:taxonomy:DayOfYear # freq=1041183 freq=956153
+AndHighHighDayTaxoFacets: +other +into +facets:taxonomy:DayOfYear # freq=1269961 freq=888684
+AndHighHighDayTaxoFacets: +be +their +facets:taxonomy:DayOfYear # freq=2051702 freq=1158682
+AndHighHighDayTaxoFacets: +new +other +facets:taxonomy:DayOfYear # freq=1657293 freq=1269961
+AndHighHighDayTaxoFacets: +its +2011 +facets:taxonomy:DayOfYear # freq=1173450 freq=871410
+AndHighHighDayTaxoFacets: +ref +3 +facets:taxonomy:DayOfYear # freq=3793973 freq=1148799
+AndHighHighDayTaxoFacets: +name +be +facets:taxonomy:DayOfYear # freq=2827713 freq=2051702
+AndHighHighDayTaxoFacets: +had +see +facets:taxonomy:DayOfYear # freq=1246743 freq=1044180
+AndHighHighDayTaxoFacets: +also +or +facets:taxonomy:DayOfYear # freq=1959419 freq=1858841
+AndHighHighDayTaxoFacets: +but +4 +facets:taxonomy:DayOfYear # freq=1456553 freq=986452
+AndHighMedDayTaxoFacets: +has +please +facets:taxonomy:DayOfYear # freq=1502961 freq=229602
+AndHighMedDayTaxoFacets: +he +battle +facets:taxonomy:DayOfYear # freq=1659434 freq=192357
+AndHighMedDayTaxoFacets: +be +century +facets:taxonomy:DayOfYear # freq=2051702 freq=385541
+AndHighMedDayTaxoFacets: +may +studio +facets:taxonomy:DayOfYear # freq=1071932 freq=101979
+AndHighMedDayTaxoFacets: +have +level +facets:taxonomy:DayOfYear # freq=1297121 freq=175382
+AndHighMedDayTaxoFacets: +web +place +facets:taxonomy:DayOfYear # freq=1118334 freq=654158
+AndHighMedDayTaxoFacets: +all +close +facets:taxonomy:DayOfYear # freq=1203572 freq=136706
+AndHighMedDayTaxoFacets: +as +chart +facets:taxonomy:DayOfYear # freq=3925535 freq=84194
+AndHighMedDayTaxoFacets: +ref +appropriate +facets:taxonomy:DayOfYear # freq=3793973 freq=135343
+AndHighMedDayTaxoFacets: +be +put +facets:taxonomy:DayOfYear # freq=2051702 freq=139882
+AndHighMedDayTaxoFacets: +and +called +facets:taxonomy:DayOfYear # freq=7318061 freq=454580
+AndHighMedDayTaxoFacets: +been +four +facets:taxonomy:DayOfYear # freq=1041183 freq=389818
+AndHighMedDayTaxoFacets: +url +whether +facets:taxonomy:DayOfYear # freq=1513595 freq=93965
+AndHighMedDayTaxoFacets: +with +day +facets:taxonomy:DayOfYear # freq=3709421 freq=402096
+AndHighMedDayTaxoFacets: +a +famous +facets:taxonomy:DayOfYear # freq=6560531 freq=139092
+AndHighMedDayTaxoFacets: +it +nature +facets:taxonomy:DayOfYear # freq=2675552 freq=107428
+AndHighMedDayTaxoFacets: +his +although +facets:taxonomy:DayOfYear # freq=1777780 freq=341432
+AndHighMedDayTaxoFacets: +1 +artists +facets:taxonomy:DayOfYear # freq=1641090 freq=107145
+AndHighMedDayTaxoFacets: +title +digital +facets:taxonomy:DayOfYear # freq=2397378 freq=82650
+AndHighMedDayTaxoFacets: +that +37 +facets:taxonomy:DayOfYear # freq=2931020 freq=126429
+AndHighMedDayTaxoFacets: +was +free +facets:taxonomy:DayOfYear # freq=3763623 freq=270199
+AndHighMedDayTaxoFacets: +5 +west +facets:taxonomy:DayOfYear # freq=891361 freq=431006
+AndHighMedDayTaxoFacets: +had +reference +facets:taxonomy:DayOfYear # freq=1246743 freq=111493
+AndHighMedDayTaxoFacets: +in +sports +facets:taxonomy:DayOfYear # freq=7320987 freq=178542
+AndHighMedDayTaxoFacets: +its +interview +facets:taxonomy:DayOfYear # freq=1173450 freq=98846
+AndHighMedDayTaxoFacets: +url +took +facets:taxonomy:DayOfYear # freq=1513595 freq=247388
+AndHighMedDayTaxoFacets: +and +los +facets:taxonomy:DayOfYear # freq=7318061 freq=145404
+AndHighMedDayTaxoFacets: +last +english +facets:taxonomy:DayOfYear # freq=958437 freq=412061
+AndHighMedDayTaxoFacets: +not +lee +facets:taxonomy:DayOfYear # freq=1713264 freq=90461
+AndHighMedDayTaxoFacets: +their +few +facets:taxonomy:DayOfYear # freq=1158682 freq=226422
+AndHighMedDayTaxoFacets: +they +round +facets:taxonomy:DayOfYear # freq=1021945 freq=122499
+AndHighMedDayTaxoFacets: +cite +area +facets:taxonomy:DayOfYear # freq=1741194 freq=559023
+AndHighMedDayTaxoFacets: +two +lake +facets:taxonomy:DayOfYear # freq=1104053 freq=131603
+AndHighMedDayTaxoFacets: +time +8 +facets:taxonomy:DayOfYear # freq=1032071 freq=635822
+AndHighMedDayTaxoFacets: +this +winning +facets:taxonomy:DayOfYear # freq=2224932 freq=95704
+AndHighMedDayTaxoFacets: +only +performed +facets:taxonomy:DayOfYear # freq=875561 freq=104044
+AndHighMedDayTaxoFacets: +when +books.google.com +facets:taxonomy:DayOfYear # freq=1027487 freq=119391
+AndHighMedDayTaxoFacets: +who +legal +facets:taxonomy:DayOfYear # freq=1196171 freq=90645
+AndHighMedDayTaxoFacets: +2009 +keep +facets:taxonomy:DayOfYear # freq=887702 freq=177996
+AndHighMedDayTaxoFacets: +http +running +facets:taxonomy:DayOfYear # freq=3493581 freq=101764
+AndHighMedDayTaxoFacets: +5 +grand +facets:taxonomy:DayOfYear # freq=891361 freq=139202
+AndHighMedDayTaxoFacets: +it +man +facets:taxonomy:DayOfYear # freq=2675552 freq=278112
+AndHighMedDayTaxoFacets: +had +entertainment +facets:taxonomy:DayOfYear # freq=1246743 freq=117931
+AndHighMedDayTaxoFacets: +with +200px +facets:taxonomy:DayOfYear # freq=3709421 freq=102661
+AndHighMedDayTaxoFacets: +had +van +facets:taxonomy:DayOfYear # freq=1246743 freq=116920
+AndHighMedDayTaxoFacets: +was +track +facets:taxonomy:DayOfYear # freq=3763623 freq=148840
+AndHighMedDayTaxoFacets: +10 +corporation +facets:taxonomy:DayOfYear # freq=918339 freq=107425
+AndHighMedDayTaxoFacets: +other +make +facets:taxonomy:DayOfYear # freq=1269961 freq=292607
+AndHighMedDayTaxoFacets: +first +results +facets:taxonomy:DayOfYear # freq=1933372 freq=137248
+AndHighMedDayTaxoFacets: +2010 +unreferenced +facets:taxonomy:DayOfYear # freq=950573 freq=107803
+AndHighMedDayTaxoFacets: +first +top +facets:taxonomy:DayOfYear # freq=1933372 freq=364628
+AndHighMedDayTaxoFacets: +his +en +facets:taxonomy:DayOfYear # freq=1777780 freq=277463
+AndHighMedDayTaxoFacets: +other +airport +facets:taxonomy:DayOfYear # freq=1269961 freq=88205
+AndHighMedDayTaxoFacets: +10 +march +facets:taxonomy:DayOfYear # freq=918339 freq=620393
+AndHighMedDayTaxoFacets: +all +recently +facets:taxonomy:DayOfYear # freq=1203572 freq=90249
+AndHighMedDayTaxoFacets: +were +genre +facets:taxonomy:DayOfYear # freq=1524630 freq=121233
+AndHighMedDayTaxoFacets: +and +program +facets:taxonomy:DayOfYear # freq=7318061 freq=173553
+AndHighMedDayTaxoFacets: +i +09 +facets:taxonomy:DayOfYear # freq=956148 freq=296300
+AndHighMedDayTaxoFacets: +to +ended +facets:taxonomy:DayOfYear # freq=6155577 freq=84664
+AndHighMedDayTaxoFacets: +not +playing +facets:taxonomy:DayOfYear # freq=1713264 freq=133330
+AndHighMedDayTaxoFacets: +time +companies +facets:taxonomy:DayOfYear # freq=1032071 freq=98905
+AndHighMedDayTaxoFacets: +to +living +facets:taxonomy:DayOfYear # freq=6155577 freq=181427
+AndHighMedDayTaxoFacets: +of +silver +facets:taxonomy:DayOfYear # freq=8184358 freq=85967
+AndHighMedDayTaxoFacets: +in +images +facets:taxonomy:DayOfYear # freq=7320987 freq=125154
+AndHighMedDayTaxoFacets: +2008 +debate +facets:taxonomy:DayOfYear # freq=831253 freq=177827
+AndHighMedDayTaxoFacets: +some +los +facets:taxonomy:DayOfYear # freq=839919 freq=145404
+AndHighMedDayTaxoFacets: +2008 +simply +facets:taxonomy:DayOfYear # freq=831253 freq=84090
+AndHighMedDayTaxoFacets: +first +producer +facets:taxonomy:DayOfYear # freq=1933372 freq=137098
+AndHighMedDayTaxoFacets: +last +seven +facets:taxonomy:DayOfYear # freq=958437 freq=134402
+AndHighMedDayTaxoFacets: +more +soon +facets:taxonomy:DayOfYear # freq=963533 freq=123657
+AndHighMedDayTaxoFacets: +date +talk +facets:taxonomy:DayOfYear # freq=2020626 freq=364194
+AndHighMedDayTaxoFacets: +its +49 +facets:taxonomy:DayOfYear # freq=1173450 freq=103612
+AndHighMedDayTaxoFacets: +publisher +car +facets:taxonomy:DayOfYear # freq=1289029 freq=121250
+AndHighMedDayTaxoFacets: +were +v +facets:taxonomy:DayOfYear # freq=1524630 freq=284318
+AndHighMedDayTaxoFacets: +more +says +facets:taxonomy:DayOfYear # freq=963533 freq=84589
+AndHighMedDayTaxoFacets: +3 +man +facets:taxonomy:DayOfYear # freq=1148799 freq=278112
+AndHighMedDayTaxoFacets: +but +1974 +facets:taxonomy:DayOfYear # freq=1456553 freq=132835
+AndHighMedDayTaxoFacets: +but +02 +facets:taxonomy:DayOfYear # freq=1456553 freq=319783
+AndHighMedDayTaxoFacets: +see +historic +facets:taxonomy:DayOfYear # freq=1044180 freq=112292
+AndHighMedDayTaxoFacets: +which +wife +facets:taxonomy:DayOfYear # freq=1963428 freq=130807
+AndHighMedDayTaxoFacets: +1 +grand +facets:taxonomy:DayOfYear # freq=1641090 freq=139202
+AndHighMedDayTaxoFacets: +it +real +facets:taxonomy:DayOfYear # freq=2675552 freq=151505
+AndHighMedDayTaxoFacets: +its +development +facets:taxonomy:DayOfYear # freq=1173450 freq=230286
+AndHighMedDayTaxoFacets: +3 +office +facets:taxonomy:DayOfYear # freq=1148799 freq=225338
+AndHighMedDayTaxoFacets: +10 +class +facets:taxonomy:DayOfYear # freq=918339 freq=556838
+AndHighMedDayTaxoFacets: +not +abbr +facets:taxonomy:DayOfYear # freq=1713264 freq=96135
+AndHighMedDayTaxoFacets: +accessdate +hand +facets:taxonomy:DayOfYear # freq=1228887 freq=119947
+AndHighMedDayTaxoFacets: +2011 +trade +facets:taxonomy:DayOfYear # freq=871410 freq=106384
+AndHighMedDayTaxoFacets: +that +love +facets:taxonomy:DayOfYear # freq=2931020 freq=177242
+AndHighMedDayTaxoFacets: +from +took +facets:taxonomy:DayOfYear # freq=3224339 freq=247388
+AndHighMedDayTaxoFacets: +united +id +facets:taxonomy:DayOfYear # freq=1196944 freq=579566
+AndHighMedDayTaxoFacets: +s +mi +facets:taxonomy:DayOfYear # freq=1581243 freq=97131
+AndHighMedDayTaxoFacets: +as +young +facets:taxonomy:DayOfYear # freq=3925535 freq=196428
+AndHighMedDayTaxoFacets: +3 +opening +facets:taxonomy:DayOfYear # freq=1148799 freq=84576
+AndHighMedDayTaxoFacets: +other +european +facets:taxonomy:DayOfYear # freq=1269961 freq=193975
+AndHighMedDayTaxoFacets: +ref +chart +facets:taxonomy:DayOfYear # freq=3793973 freq=84194
+AndHighMedDayTaxoFacets: +about +thought +facets:taxonomy:DayOfYear # freq=850283 freq=108963
+AndHighMedDayTaxoFacets: +for +should +facets:taxonomy:DayOfYear # freq=4380011 freq=401379
+AndHighMedDayTaxoFacets: +united +lead +facets:taxonomy:DayOfYear # freq=1196944 freq=141336
+AndHighMedDayTaxoFacets: +this +movie +facets:taxonomy:DayOfYear # freq=2224932 freq=133291
+AndHighMedDayTaxoFacets: +2011 +winning +facets:taxonomy:DayOfYear # freq=871410 freq=95704
+AndHighMedDayTaxoFacets: +new +shows +facets:taxonomy:DayOfYear # freq=1657293 freq=131923
+AndHighMedDayTaxoFacets: +no +him +facets:taxonomy:DayOfYear # freq=1045000 freq=507350
+AndHighMedDayTaxoFacets: +has +always +facets:taxonomy:DayOfYear # freq=1502961 freq=112388
+AndHighMedDayTaxoFacets: +ref +above +facets:taxonomy:DayOfYear # freq=3793973 freq=246135
+AndHighMedDayTaxoFacets: +have +uses +facets:taxonomy:DayOfYear # freq=1297121 freq=134331
+AndHighMedDayTaxoFacets: +who +80 +facets:taxonomy:DayOfYear # freq=1196171 freq=104865
+AndHighMedDayTaxoFacets: +2008 +series +facets:taxonomy:DayOfYear # freq=831253 freq=521861
+AndHighMedDayTaxoFacets: +ref +40 +facets:taxonomy:DayOfYear # freq=3793973 freq=221687
+AndHighMedDayTaxoFacets: +when +second +facets:taxonomy:DayOfYear # freq=1027487 freq=505575
+AndHighMedDayTaxoFacets: +at +parliament +facets:taxonomy:DayOfYear # freq=2857534 freq=127008
+AndHighMedDayTaxoFacets: +were +pacific +facets:taxonomy:DayOfYear # freq=1524630 freq=107648
+AndHighMedDayTaxoFacets: +2 +recent +facets:taxonomy:DayOfYear # freq=1549245 freq=113385
+AndHighMedDayTaxoFacets: +http +close +facets:taxonomy:DayOfYear # freq=3493581 freq=136706
+AndHighMedDayTaxoFacets: +has +power +facets:taxonomy:DayOfYear # freq=1502961 freq=262586
+AndHighMedDayTaxoFacets: +or +words +facets:taxonomy:DayOfYear # freq=1858841 freq=104783
+AndHighMedDayTaxoFacets: +after +mary +facets:taxonomy:DayOfYear # freq=1247398 freq=96445
+AndHighMedDayTaxoFacets: +3 +state +facets:taxonomy:DayOfYear # freq=1148799 freq=702598
+AndHighMedDayTaxoFacets: +its +directed +facets:taxonomy:DayOfYear # freq=1173450 freq=86592
+AndHighMedDayTaxoFacets: +more +army +facets:taxonomy:DayOfYear # freq=963533 freq=228105
+AndHighMedDayTaxoFacets: +see +genre +facets:taxonomy:DayOfYear # freq=1044180 freq=121233
+AndHighMedDayTaxoFacets: +5 +natural +facets:taxonomy:DayOfYear # freq=891361 freq=125503
+AndHighMedDayTaxoFacets: +into +ship +facets:taxonomy:DayOfYear # freq=888684 freq=113012
+AndHighMedDayTaxoFacets: +2005 +construction +facets:taxonomy:DayOfYear # freq=835460 freq=124179
+AndHighMedDayTaxoFacets: +some +found +facets:taxonomy:DayOfYear # freq=839919 freq=313247
+AndHighMedDayTaxoFacets: +2 +actor +facets:taxonomy:DayOfYear # freq=1549245 freq=144573
+AndHighMedDayTaxoFacets: +and +owned +facets:taxonomy:DayOfYear # freq=7318061 freq=93981
+AndHighMedDayTaxoFacets: +which +authority +facets:taxonomy:DayOfYear # freq=1963428 freq=85540
+AndHighMedDayTaxoFacets: +have +r +facets:taxonomy:DayOfYear # freq=1297121 freq=296283
+AndHighMedDayTaxoFacets: +is +approximately +facets:taxonomy:DayOfYear # freq=4074455 freq=88426
+AndHighMedDayTaxoFacets: +he +deletion +facets:taxonomy:DayOfYear # freq=1659434 freq=166633
+AndHighMedDayTaxoFacets: +and +jean +facets:taxonomy:DayOfYear # freq=7318061 freq=84299
+AndHighMedDayTaxoFacets: +have +43 +facets:taxonomy:DayOfYear # freq=1297121 freq=115496
+AndHighMedDayTaxoFacets: +only +daily +facets:taxonomy:DayOfYear # freq=875561 freq=111717
+AndHighMedDayTaxoFacets: +united +zealand +facets:taxonomy:DayOfYear # freq=1196944 freq=92761
+AndHighMedDayTaxoFacets: +also +read +facets:taxonomy:DayOfYear # freq=1959419 freq=86513
+AndHighMedDayTaxoFacets: +are +division +facets:taxonomy:DayOfYear # freq=1877802 freq=182624
+AndHighMedDayTaxoFacets: +for +seat +facets:taxonomy:DayOfYear # freq=4380011 freq=91288
+AndHighMedDayTaxoFacets: +2005 +hand +facets:taxonomy:DayOfYear # freq=835460 freq=119947
+AndHighMedDayTaxoFacets: +publisher +usually +facets:taxonomy:DayOfYear # freq=1289029 freq=176058
+AndHighMedDayTaxoFacets: +from +teams +facets:taxonomy:DayOfYear # freq=3224339 freq=105245
+AndHighMedDayTaxoFacets: +in +wife +facets:taxonomy:DayOfYear # freq=7320987 freq=130807
+AndHighMedDayTaxoFacets: +2006 +james +facets:taxonomy:DayOfYear # freq=889954 freq=281597
+AndHighMedDayTaxoFacets: +2005 +found +facets:taxonomy:DayOfYear # freq=835460 freq=313247
+AndHighMedDayTaxoFacets: +after +replaced +facets:taxonomy:DayOfYear # freq=1247398 freq=112506
+AndHighMedDayTaxoFacets: +5 +played +facets:taxonomy:DayOfYear # freq=891361 freq=248191
+AndHighMedDayTaxoFacets: +last +1945 +facets:taxonomy:DayOfYear # freq=958437 freq=106881
+AndHighMedDayTaxoFacets: +not +william +facets:taxonomy:DayOfYear # freq=1713264 freq=284592
+AndHighMedDayTaxoFacets: +may +changed +facets:taxonomy:DayOfYear # freq=1071932 freq=112032
+AndHighMedDayTaxoFacets: +one +might +facets:taxonomy:DayOfYear # freq=1527689 freq=114290
+AndHighMedDayTaxoFacets: +one +1966 +facets:taxonomy:DayOfYear # freq=1527689 freq=106672
+AndHighMedDayTaxoFacets: +2006 +mother +facets:taxonomy:DayOfYear # freq=889954 freq=122930
+AndHighMedDayTaxoFacets: +no +hi +facets:taxonomy:DayOfYear # freq=1045000 freq=91593
+AndHighMedDayTaxoFacets: +they +my +facets:taxonomy:DayOfYear # freq=1021945 freq=274256
+AndHighMedDayTaxoFacets: +it +london +facets:taxonomy:DayOfYear # freq=2675552 freq=348918
+AndHighMedDayTaxoFacets: +but +according +facets:taxonomy:DayOfYear # freq=1456553 freq=256949
+AndHighMedDayTaxoFacets: +an +results +facets:taxonomy:DayOfYear # freq=2628056 freq=137248
+AndHighMedDayTaxoFacets: +from +you +facets:taxonomy:DayOfYear # freq=3224339 freq=461587
+AndHighMedDayTaxoFacets: +web +single +facets:taxonomy:DayOfYear # freq=1118334 freq=283824
+AndHighMedDayTaxoFacets: +two +old +facets:taxonomy:DayOfYear # freq=1104053 freq=381809
+AndHighMedDayTaxoFacets: +some +daughter +facets:taxonomy:DayOfYear # freq=839919 freq=103883
+AndHighMedDayTaxoFacets: +url +various +facets:taxonomy:DayOfYear # freq=1513595 freq=224593
+AndHighMedDayTaxoFacets: +have +would +facets:taxonomy:DayOfYear # freq=1297121 freq=690480
+AndHighMedDayTaxoFacets: +to +released +facets:taxonomy:DayOfYear # freq=6155577 freq=322473
+AndHighMedDayTaxoFacets: +had +refer +facets:taxonomy:DayOfYear # freq=1246743 freq=110259
+AndHighMedDayTaxoFacets: +url +article +facets:taxonomy:DayOfYear # freq=1513595 freq=610650
+AndHighMedDayTaxoFacets: +when +designed +facets:taxonomy:DayOfYear # freq=1027487 freq=118748
+AndHighMedDayTaxoFacets: +which +party +facets:taxonomy:DayOfYear # freq=1963428 freq=394410
+AndHighMedDayTaxoFacets: +a +florida +facets:taxonomy:DayOfYear # freq=6560531 freq=92166
+AndHighMedDayTaxoFacets: +the +image_caption +facets:taxonomy:DayOfYear # freq=8217362 freq=87977
+AndHighMedDayTaxoFacets: +last +width +facets:taxonomy:DayOfYear # freq=958437 freq=172609
+AndHighMedDayTaxoFacets: +may +r +facets:taxonomy:DayOfYear # freq=1071932 freq=296283
+AndHighMedDayTaxoFacets: +at +inside +facets:taxonomy:DayOfYear # freq=2857534 freq=84712
+AndHighMedDayTaxoFacets: +3 +p +facets:taxonomy:DayOfYear # freq=1148799 freq=616159
+AndHighMedDayTaxoFacets: +2009 +imperial +facets:taxonomy:DayOfYear # freq=887702 freq=86508
+AndHighMedDayTaxoFacets: +for +access +facets:taxonomy:DayOfYear # freq=4380011 freq=100041
+AndHighMedDayTaxoFacets: +some +former +facets:taxonomy:DayOfYear # freq=839919 freq=332750
+AndHighMedDayTaxoFacets: +url +important +facets:taxonomy:DayOfYear # freq=1513595 freq=195851
+AndHighMedDayTaxoFacets: +which +recorded +facets:taxonomy:DayOfYear # freq=1963428 freq=160249
+AndHighMedDayTaxoFacets: +of +family +facets:taxonomy:DayOfYear # freq=8184358 freq=387175
+AndHighMedDayTaxoFacets: +2 +family +facets:taxonomy:DayOfYear # freq=1549245 freq=387175
+AndHighMedDayTaxoFacets: +was +old +facets:taxonomy:DayOfYear # freq=3763623 freq=381809
+AndHighMedDayTaxoFacets: +more +jpg +facets:taxonomy:DayOfYear # freq=963533 freq=322278
+AndHighMedDayTaxoFacets: +2005 +1979 +facets:taxonomy:DayOfYear # freq=835460 freq=145407
+AndHighMedDayTaxoFacets: +are +became +facets:taxonomy:DayOfYear # freq=1877802 freq=465594
+AndHighMedDayTaxoFacets: +new +products +facets:taxonomy:DayOfYear # freq=1657293 freq=88448
+AndHighMedDayTaxoFacets: +first +mexico +facets:taxonomy:DayOfYear # freq=1933372 freq=88689
+AndHighMedDayTaxoFacets: +10 +nbsp +facets:taxonomy:DayOfYear # freq=918339 freq=506054
+AndHighMedDayTaxoFacets: +by +25 +facets:taxonomy:DayOfYear # freq=3826691 freq=491957
+AndHighMedDayTaxoFacets: +was +language +facets:taxonomy:DayOfYear # freq=3763623 freq=416771
+AndHighMedDayTaxoFacets: +and +future +facets:taxonomy:DayOfYear # freq=7318061 freq=136421
+AndHighMedDayTaxoFacets: +their +flight +facets:taxonomy:DayOfYear # freq=1158682 freq=84316
+AndHighMedDayTaxoFacets: +2011 +hold +facets:taxonomy:DayOfYear # freq=871410 freq=82579
+AndHighMedDayTaxoFacets: +there +programs +facets:taxonomy:DayOfYear # freq=956153 freq=83974
+AndHighMedDayTaxoFacets: +after +original +facets:taxonomy:DayOfYear # freq=1247398 freq=323521
+AndHighMedDayTaxoFacets: +only +ten +facets:taxonomy:DayOfYear # freq=875561 freq=114388
+AndHighMedDayTaxoFacets: +to +traditional +facets:taxonomy:DayOfYear # freq=6155577 freq=110425
+AndHighMedDayTaxoFacets: +also +centre +facets:taxonomy:DayOfYear # freq=1959419 freq=159597
+AndHighMedDayTaxoFacets: +all +isbn +facets:taxonomy:DayOfYear # freq=1203572 freq=467574
+AndHighMedDayTaxoFacets: +this +direct +facets:taxonomy:DayOfYear # freq=2224932 freq=82292
+AndHighMedDayTaxoFacets: +http +earlier +facets:taxonomy:DayOfYear # freq=3493581 freq=100372
+AndHighMedDayTaxoFacets: +cite +system +facets:taxonomy:DayOfYear # freq=1741194 freq=412862
+AndHighMedDayTaxoFacets: +were +library +facets:taxonomy:DayOfYear # freq=1524630 freq=138468
+AndHighMedDayTaxoFacets: +first +alone +facets:taxonomy:DayOfYear # freq=1933372 freq=93166
+AndHighMedDayTaxoFacets: +new +century +facets:taxonomy:DayOfYear # freq=1657293 freq=385541
+AndHighMedDayTaxoFacets: +s +reached +facets:taxonomy:DayOfYear # freq=1581243 freq=89854
+AndHighMedDayTaxoFacets: +united +le +facets:taxonomy:DayOfYear # freq=1196944 freq=84979
+AndHighMedDayTaxoFacets: +url +auto +facets:taxonomy:DayOfYear # freq=1513595 freq=103107
+AndHighMedDayTaxoFacets: +3 +practice +facets:taxonomy:DayOfYear # freq=1148799 freq=93287
+AndHighMedDayTaxoFacets: +http +working +facets:taxonomy:DayOfYear # freq=3493581 freq=144617
+AndHighMedDayTaxoFacets: +in +fire +facets:taxonomy:DayOfYear # freq=7320987 freq=133712
+AndHighMedDayTaxoFacets: +10 +52 +facets:taxonomy:DayOfYear # freq=918339 freq=108395
+AndHighMedDayTaxoFacets: +more +singer +facets:taxonomy:DayOfYear # freq=963533 freq=114006
+AndHighMedDayTaxoFacets: +new +low +facets:taxonomy:DayOfYear # freq=1657293 freq=157852
+AndHighMedDayTaxoFacets: +with +previously +facets:taxonomy:DayOfYear # freq=3709421 freq=96083
+AndHighMedDayTaxoFacets: +first +original +facets:taxonomy:DayOfYear # freq=1933372 freq=323521
+AndHighMedDayTaxoFacets: +2008 +wikitable +facets:taxonomy:DayOfYear # freq=831253 freq=210990
+AndHighMedDayTaxoFacets: +http +can +facets:taxonomy:DayOfYear # freq=3493581 freq=765163
+AndHighMedDayTaxoFacets: +year +1965 +facets:taxonomy:DayOfYear # freq=1235231 freq=104539
+AndHighMedDayTaxoFacets: +have +mother +facets:taxonomy:DayOfYear # freq=1297121 freq=122930
+AndHighMedDayTaxoFacets: +states +lived +facets:taxonomy:DayOfYear # freq=1034872 freq=91327
+AndHighMedDayTaxoFacets: +to +me +facets:taxonomy:DayOfYear # freq=6155577 freq=229204
+AndHighMedDayTaxoFacets: +4 +race +facets:taxonomy:DayOfYear # freq=986452 freq=148763
+AndHighMedDayTaxoFacets: +of +54 +facets:taxonomy:DayOfYear # freq=8184358 freq=101462
+AndHighMedDayTaxoFacets: +some +series +facets:taxonomy:DayOfYear # freq=839919 freq=521861
+AndHighMedDayTaxoFacets: +2 +big +facets:taxonomy:DayOfYear # freq=1549245 freq=163394
+AndHighMedDayTaxoFacets: +some +without +facets:taxonomy:DayOfYear # freq=839919 freq=249926
+AndHighMedDayTaxoFacets: +2011 +font +facets:taxonomy:DayOfYear # freq=871410 freq=269439
+AndHighMedDayTaxoFacets: +http +votes +facets:taxonomy:DayOfYear # freq=3493581 freq=93844
+AndHighMedDayTaxoFacets: +2009 +19th +facets:taxonomy:DayOfYear # freq=887702 freq=93290
+AndHighMedDayTaxoFacets: +an +central +facets:taxonomy:DayOfYear # freq=2628056 freq=272531
+AndHighMedDayTaxoFacets: +some +1959 +facets:taxonomy:DayOfYear # freq=839919 freq=87097
+AndHighMedDayTaxoFacets: +cite +out +facets:taxonomy:DayOfYear # freq=1741194 freq=733775
+AndHighMedDayTaxoFacets: +was +cross +facets:taxonomy:DayOfYear # freq=3763623 freq=127216
+AndHighMedDayTaxoFacets: +3 +1950 +facets:taxonomy:DayOfYear # freq=1148799 freq=89746
+AndHighMedDayTaxoFacets: +there +market +facets:taxonomy:DayOfYear # freq=956153 freq=118467
+AndHighMedDayTaxoFacets: +new +mid +facets:taxonomy:DayOfYear # freq=1657293 freq=126355
+AndHighMedDayTaxoFacets: +or +sent +facets:taxonomy:DayOfYear # freq=1858841 freq=103620
+AndHighMedDayTaxoFacets: +may +pp +facets:taxonomy:DayOfYear # freq=1071932 freq=204742
+AndHighMedDayTaxoFacets: +the +flagicon +facets:taxonomy:DayOfYear # freq=8217362 freq=107428
+AndHighMedDayTaxoFacets: +who +genre +facets:taxonomy:DayOfYear # freq=1196171 freq=121233
+AndHighMedDayTaxoFacets: +last +library +facets:taxonomy:DayOfYear # freq=958437 freq=138468
+AndHighMedDayTaxoFacets: +and +none +facets:taxonomy:DayOfYear # freq=7318061 freq=100192
+AndHighMedDayTaxoFacets: +an +majority +facets:taxonomy:DayOfYear # freq=2628056 freq=105058
+AndHighMedDayTaxoFacets: +it +religion +facets:taxonomy:DayOfYear # freq=2675552 freq=96655
+AndHighMedDayTaxoFacets: +first +brown +facets:taxonomy:DayOfYear # freq=1933372 freq=116178
+AndHighMedDayTaxoFacets: +more +standard +facets:taxonomy:DayOfYear # freq=963533 freq=185039
+AndHighMedDayTaxoFacets: +into +process +facets:taxonomy:DayOfYear # freq=888684 freq=152588
+AndHighMedDayTaxoFacets: +for +website +facets:taxonomy:DayOfYear # freq=4380011 freq=435941
+AndHighMedDayTaxoFacets: +name +parts +facets:taxonomy:DayOfYear # freq=2827713 freq=123891
+AndHighMedDayTaxoFacets: +for +few +facets:taxonomy:DayOfYear # freq=4380011 freq=226422
+AndHighMedDayTaxoFacets: +web +available +facets:taxonomy:DayOfYear # freq=1118334 freq=175514
+AndHighMedDayTaxoFacets: +other +christian +facets:taxonomy:DayOfYear # freq=1269961 freq=140312
+AndHighMedDayTaxoFacets: +2 +imperial +facets:taxonomy:DayOfYear # freq=1549245 freq=86508
+AndHighMedDayTaxoFacets: +at +space +facets:taxonomy:DayOfYear # freq=2857534 freq=163436
+AndHighMedDayTaxoFacets: +but +paul +facets:taxonomy:DayOfYear # freq=1456553 freq=207229
+AndHighMedDayTaxoFacets: +into +70 +facets:taxonomy:DayOfYear # freq=888684 freq=90305
+AndHighMedDayTaxoFacets: +s +mdash +facets:taxonomy:DayOfYear # freq=1581243 freq=111708
+AndHighMedDayTaxoFacets: +5 +brown +facets:taxonomy:DayOfYear # freq=891361 freq=116178
+AndHighMedDayTaxoFacets: +2005 +hill +facets:taxonomy:DayOfYear # freq=835460 freq=133714
+AndHighMedDayTaxoFacets: +2006 +eight +facets:taxonomy:DayOfYear # freq=889954 freq=106268
+AndHighMedDayTaxoFacets: +two +era +facets:taxonomy:DayOfYear # freq=1104053 freq=95989
+AndHighMedDayTaxoFacets: +time +100 +facets:taxonomy:DayOfYear # freq=1032071 freq=268978
+AndHighMedDayTaxoFacets: +title +70 +facets:taxonomy:DayOfYear # freq=2397378 freq=90305
+AndHighMedDayTaxoFacets: +3 +empire +facets:taxonomy:DayOfYear # freq=1148799 freq=143207
+AndHighMedDayTaxoFacets: +in +di +facets:taxonomy:DayOfYear # freq=7320987 freq=83139
+AndHighMedDayTaxoFacets: +and +included +facets:taxonomy:DayOfYear # freq=7318061 freq=216978
+AndHighMedDayTaxoFacets: +that +play +facets:taxonomy:DayOfYear # freq=2931020 freq=210199
+AndHighMedDayTaxoFacets: +an +might +facets:taxonomy:DayOfYear # freq=2628056 freq=114290
+AndHighMedDayTaxoFacets: +other +country +facets:taxonomy:DayOfYear # freq=1269961 freq=420052
+AndHighMedDayTaxoFacets: +also +success +facets:taxonomy:DayOfYear # freq=1959419 freq=112195
+AndHighMedDayTaxoFacets: +also +27 +facets:taxonomy:DayOfYear # freq=1959419 freq=383042
+AndHighMedDayTaxoFacets: +more +stations +facets:taxonomy:DayOfYear # freq=963533 freq=92011
+AndHighMedDayTaxoFacets: +they +system +facets:taxonomy:DayOfYear # freq=1021945 freq=412862
+AndHighMedDayTaxoFacets: +in +31 +facets:taxonomy:DayOfYear # freq=7320987 freq=298349
+AndHighMedDayTaxoFacets: +all +provided +facets:taxonomy:DayOfYear # freq=1203572 freq=110088
+AndHighMedDayTaxoFacets: +i +u.s +facets:taxonomy:DayOfYear # freq=956148 freq=428534
+AndHighMedDayTaxoFacets: +a +certain +facets:taxonomy:DayOfYear # freq=6560531 freq=105714
+AndHighMedDayTaxoFacets: +his +summary +facets:taxonomy:DayOfYear # freq=1777780 freq=106702
+AndHighMedDayTaxoFacets: +2009 +america +facets:taxonomy:DayOfYear # freq=887702 freq=240374
+AndHighMedDayTaxoFacets: +1 +chicago +facets:taxonomy:DayOfYear # freq=1641090 freq=117756
+AndHighMedDayTaxoFacets: +other +2000 +facets:taxonomy:DayOfYear # freq=1269961 freq=499639
+AndHighMedDayTaxoFacets: +year +men +facets:taxonomy:DayOfYear # freq=1235231 freq=182445
+AndHighMedDayTaxoFacets: +4 +upon +facets:taxonomy:DayOfYear # freq=986452 freq=169174
+AndHighMedDayTaxoFacets: +in +seems +facets:taxonomy:DayOfYear # freq=7320987 freq=83963
+AndHighMedDayTaxoFacets: +he +bank +facets:taxonomy:DayOfYear # freq=1659434 freq=88080
+AndHighMedDayTaxoFacets: +name +both +facets:taxonomy:DayOfYear # freq=2827713 freq=534900
+AndHighMedDayTaxoFacets: +publisher +e +facets:taxonomy:DayOfYear # freq=1289029 freq=408741
+AndHighMedDayTaxoFacets: +who +computer +facets:taxonomy:DayOfYear # freq=1196171 freq=126524
+AndHighMedDayTaxoFacets: +about +type +facets:taxonomy:DayOfYear # freq=850283 freq=318210
+AndHighMedDayTaxoFacets: +this +people +facets:taxonomy:DayOfYear # freq=2224932 freq=790960
+AndHighMedDayTaxoFacets: +their +1978 +facets:taxonomy:DayOfYear # freq=1158682 freq=135223
+AndHighMedDayTaxoFacets: +url +museum +facets:taxonomy:DayOfYear # freq=1513595 freq=135250
+AndHighMedDayTaxoFacets: +4 +least +facets:taxonomy:DayOfYear # freq=986452 freq=146209
+AndHighMedDayTaxoFacets: +2011 +money +facets:taxonomy:DayOfYear # freq=871410 freq=100440
+AndHighMedDayTaxoFacets: +first +referred +facets:taxonomy:DayOfYear # freq=1933372 freq=94811
+AndHighMedDayTaxoFacets: +he +20 +facets:taxonomy:DayOfYear # freq=1659434 freq=624967
+AndHighMedDayTaxoFacets: +were +events +facets:taxonomy:DayOfYear # freq=1524630 freq=158248
+AndHighMedDayTaxoFacets: +it +because +facets:taxonomy:DayOfYear # freq=2675552 freq=413003
+AndHighMedDayTaxoFacets: +accessdate +large +facets:taxonomy:DayOfYear # freq=1228887 freq=308888
+AndHighMedDayTaxoFacets: +there +usa +facets:taxonomy:DayOfYear # freq=956153 freq=191220
+AndHighMedDayTaxoFacets: +he +association +facets:taxonomy:DayOfYear # freq=1659434 freq=247156
+AndHighMedDayTaxoFacets: +2010 +rest +facets:taxonomy:DayOfYear # freq=950573 freq=95113
+AndHighMedDayTaxoFacets: +he +face +facets:taxonomy:DayOfYear # freq=1659434 freq=95144
+AndHighMedDayTaxoFacets: +title +out +facets:taxonomy:DayOfYear # freq=2397378 freq=733775
+AndHighMedDayTaxoFacets: +first +christian +facets:taxonomy:DayOfYear # freq=1933372 freq=140312
+AndHighMedDayTaxoFacets: +has +april +facets:taxonomy:DayOfYear # freq=1502961 freq=587542
+AndHighMedDayTaxoFacets: +in +very +facets:taxonomy:DayOfYear # freq=7320987 freq=354898
+AndHighMedDayTaxoFacets: +no +century +facets:taxonomy:DayOfYear # freq=1045000 freq=385541
+AndHighMedDayTaxoFacets: +accessdate +recording +facets:taxonomy:DayOfYear # freq=1228887 freq=90757
+AndHighMedDayTaxoFacets: +by +55 +facets:taxonomy:DayOfYear # freq=3826691 freq=110526
+AndHighMedDayTaxoFacets: +2005 +54 +facets:taxonomy:DayOfYear # freq=835460 freq=101462
+AndHighMedDayTaxoFacets: +this +x +facets:taxonomy:DayOfYear # freq=2224932 freq=272695
+AndHighMedDayTaxoFacets: +url +following +facets:taxonomy:DayOfYear # freq=1513595 freq=416515
+AndHighMedDayTaxoFacets: +s +per +facets:taxonomy:DayOfYear # freq=1581243 freq=283568
+AndHighMedDayTaxoFacets: +2005 +bureau +facets:taxonomy:DayOfYear # freq=835460 freq=83671
+AndHighMedDayTaxoFacets: +1 +09 +facets:taxonomy:DayOfYear # freq=1641090 freq=296300
+AndHighMedDayTaxoFacets: +title +buildings +facets:taxonomy:DayOfYear # freq=2397378 freq=89046
+AndHighMedDayTaxoFacets: +by +appears +facets:taxonomy:DayOfYear # freq=3826691 freq=104511
+AndHighMedDayTaxoFacets: +year +taken +facets:taxonomy:DayOfYear # freq=1235231 freq=166217
+AndHighMedDayTaxoFacets: +on +size +facets:taxonomy:DayOfYear # freq=4074624 freq=237662
+AndHighMedDayTaxoFacets: +2005 +thomas +facets:taxonomy:DayOfYear # freq=835460 freq=191625
+AndHighMedDayTaxoFacets: +2008 +chicago +facets:taxonomy:DayOfYear # freq=831253 freq=117756
+AndHighMedDayTaxoFacets: +2 +1991 +facets:taxonomy:DayOfYear # freq=1549245 freq=207589
+AndHighMedDayTaxoFacets: +only +2003 +facets:taxonomy:DayOfYear # freq=875561 freq=456990
+AndHighMedDayTaxoFacets: +their +found +facets:taxonomy:DayOfYear # freq=1158682 freq=313247
+AndHighMedDayTaxoFacets: +for +long +facets:taxonomy:DayOfYear # freq=4380011 freq=385787
+AndHighMedDayTaxoFacets: +2011 +low +facets:taxonomy:DayOfYear # freq=871410 freq=157852
+AndHighMedDayTaxoFacets: +for +iii +facets:taxonomy:DayOfYear # freq=4380011 freq=123618
+AndHighMedDayTaxoFacets: +is +1990s +facets:taxonomy:DayOfYear # freq=4074455 freq=83166
+AndHighMedDayTaxoFacets: +some +instead +facets:taxonomy:DayOfYear # freq=839919 freq=149345
+AndHighMedDayTaxoFacets: +publisher +historical +facets:taxonomy:DayOfYear # freq=1289029 freq=159636
+AndHighMedDayTaxoFacets: +are +please +facets:taxonomy:DayOfYear # freq=1877802 freq=229602
+AndHighMedDayTaxoFacets: +who +brown +facets:taxonomy:DayOfYear # freq=1196171 freq=116178
+AndHighMedDayTaxoFacets: +an +professional +facets:taxonomy:DayOfYear # freq=2628056 freq=138520
+AndHighMedDayTaxoFacets: +name +security +facets:taxonomy:DayOfYear # freq=2827713 freq=89382
+AndHighMedDayTaxoFacets: +name +8 +facets:taxonomy:DayOfYear # freq=2827713 freq=635822
+AndHighMedDayTaxoFacets: +from +china +facets:taxonomy:DayOfYear # freq=3224339 freq=130849
+AndHighMedDayTaxoFacets: +a +early +facets:taxonomy:DayOfYear # freq=6560531 freq=482793
+AndHighMedDayTaxoFacets: +cite +changes +facets:taxonomy:DayOfYear # freq=1741194 freq=105677
+AndHighMedDayTaxoFacets: +it +debate +facets:taxonomy:DayOfYear # freq=2675552 freq=177827
+AndHighMedDayTaxoFacets: +by +total +facets:taxonomy:DayOfYear # freq=3826691 freq=230013
+AndHighMedDayTaxoFacets: +it +event +facets:taxonomy:DayOfYear # freq=2675552 freq=114340
+AndHighMedDayTaxoFacets: +2005 +cup +facets:taxonomy:DayOfYear # freq=835460 freq=141942
+AndHighMedDayTaxoFacets: +publisher +1950 +facets:taxonomy:DayOfYear # freq=1289029 freq=89746
+AndHighMedDayTaxoFacets: +no +christian +facets:taxonomy:DayOfYear # freq=1045000 freq=140312
+AndHighMedDayTaxoFacets: +from +forces +facets:taxonomy:DayOfYear # freq=3224339 freq=152939
+AndHighMedDayTaxoFacets: +when +between +facets:taxonomy:DayOfYear # freq=1027487 freq=630650
+AndHighMedDayTaxoFacets: +its +words +facets:taxonomy:DayOfYear # freq=1173450 freq=104783
+AndHighMedDayTaxoFacets: +a +she +facets:taxonomy:DayOfYear # freq=6560531 freq=426267
+AndHighMedDayTaxoFacets: +s +align +facets:taxonomy:DayOfYear # freq=1581243 freq=300455
+AndHighMedDayTaxoFacets: +http +served +facets:taxonomy:DayOfYear # freq=3493581 freq=188351
+AndHighMedDayTaxoFacets: +of +finally +facets:taxonomy:DayOfYear # freq=8184358 freq=99185
+AndHighMedDayTaxoFacets: +some +pre +facets:taxonomy:DayOfYear # freq=839919 freq=90549
+AndHighMedDayTaxoFacets: +which +am +facets:taxonomy:DayOfYear # freq=1963428 freq=127152
+AndHighMedDayTaxoFacets: +with +governor +facets:taxonomy:DayOfYear # freq=3709421 freq=102274
+AndHighMedDayTaxoFacets: +publisher +f.c +facets:taxonomy:DayOfYear # freq=1289029 freq=83548
+AndHighMedDayTaxoFacets: +on +player +facets:taxonomy:DayOfYear # freq=4074624 freq=241451
+AndHighMedDayTaxoFacets: +time +including +facets:taxonomy:DayOfYear # freq=1032071 freq=521324
+AndHighMedDayTaxoFacets: +work +1950 +facets:taxonomy:DayOfYear # freq=853422 freq=89746
+AndHighMedDayTaxoFacets: +http +now +facets:taxonomy:DayOfYear # freq=3493581 freq=484114
+AndHighMedDayTaxoFacets: +is +separate +facets:taxonomy:DayOfYear # freq=4074455 freq=88604
+AndHighMedDayTaxoFacets: +be +having +facets:taxonomy:DayOfYear # freq=2051702 freq=213416
+AndHighMedDayTaxoFacets: +its +practice +facets:taxonomy:DayOfYear # freq=1173450 freq=93287
+AndHighMedDayTaxoFacets: +new +30 +facets:taxonomy:DayOfYear # freq=1657293 freq=488930
+AndHighMedDayTaxoFacets: +date +most +facets:taxonomy:DayOfYear # freq=2020626 freq=819634
+AndHighMedDayTaxoFacets: +by +railway +facets:taxonomy:DayOfYear # freq=3826691 freq=125543
+AndHighMedDayTaxoFacets: +that +related +facets:taxonomy:DayOfYear # freq=2931020 freq=174856
+AndHighMedDayTaxoFacets: +other +data +facets:taxonomy:DayOfYear # freq=1269961 freq=159657
+AndHighMedDayTaxoFacets: +an +daily +facets:taxonomy:DayOfYear # freq=2628056 freq=111717
+AndHighMedDayTaxoFacets: +web +performance +facets:taxonomy:DayOfYear # freq=1118334 freq=130862
+AndHighMedDayTaxoFacets: +their +engine +facets:taxonomy:DayOfYear # freq=1158682 freq=100930
+AndHighMedDayTaxoFacets: +states +found +facets:taxonomy:DayOfYear # freq=1034872 freq=313247
+AndHighMedDayTaxoFacets: +name +takes +facets:taxonomy:DayOfYear # freq=2827713 freq=95889
+AndHighMedDayTaxoFacets: +cite +editor +facets:taxonomy:DayOfYear # freq=1741194 freq=119419
+AndHighMedDayTaxoFacets: +last +canadian +facets:taxonomy:DayOfYear # freq=958437 freq=181906
+AndHighMedDayTaxoFacets: +2 +jersey +facets:taxonomy:DayOfYear # freq=1549245 freq=88847
+AndHighMedDayTaxoFacets: +5 +far +facets:taxonomy:DayOfYear # freq=891361 freq=143873
+AndHighMedDayTaxoFacets: +it +3rd +facets:taxonomy:DayOfYear # freq=2675552 freq=90723
+AndHighMedDayTaxoFacets: +ref +say +facets:taxonomy:DayOfYear # freq=3793973 freq=110895
+AndHighMedDayTaxoFacets: +be +forces +facets:taxonomy:DayOfYear # freq=2051702 freq=152939
+AndHighMedDayTaxoFacets: +2010 +where +facets:taxonomy:DayOfYear # freq=950573 freq=630647
+AndHighMedDayTaxoFacets: +states +earlier +facets:taxonomy:DayOfYear # freq=1034872 freq=100372
+AndHighMedDayTaxoFacets: +has +organization +facets:taxonomy:DayOfYear # freq=1502961 freq=119614
+AndHighMedDayTaxoFacets: +its +fiction +facets:taxonomy:DayOfYear # freq=1173450 freq=87227
+AndHighMedDayTaxoFacets: +it +star +facets:taxonomy:DayOfYear # freq=2675552 freq=195768
+AndHighMedDayTaxoFacets: +have +speed +facets:taxonomy:DayOfYear # freq=1297121 freq=99899
+AndHighMedDayTaxoFacets: +into +2nd +facets:taxonomy:DayOfYear # freq=888684 freq=167463
+AndHighMedDayTaxoFacets: +name +having +facets:taxonomy:DayOfYear # freq=2827713 freq=213416
+AndHighMedDayTaxoFacets: +his +head +facets:taxonomy:DayOfYear # freq=1777780 freq=194682
+AndHighMedDayTaxoFacets: +when +change +facets:taxonomy:DayOfYear # freq=1027487 freq=182336
+AndHighMedDayTaxoFacets: +2005 +edit +facets:taxonomy:DayOfYear # freq=835460 freq=129064
+AndHighMedDayTaxoFacets: +about +mass +facets:taxonomy:DayOfYear # freq=850283 freq=82794
+AndHighMedDayTaxoFacets: +not +profile +facets:taxonomy:DayOfYear # freq=1713264 freq=86788
+AndHighMedDayTaxoFacets: +of +mayor +facets:taxonomy:DayOfYear # freq=8184358 freq=88578
+AndHighMedDayTaxoFacets: +no +woman +facets:taxonomy:DayOfYear # freq=1045000 freq=92071
+AndHighMedDayTaxoFacets: +from +these +facets:taxonomy:DayOfYear # freq=3224339 freq=623267
+AndHighMedDayTaxoFacets: +2005 +literature +facets:taxonomy:DayOfYear # freq=835460 freq=96743
+AndHighMedDayTaxoFacets: +an +07 +facets:taxonomy:DayOfYear # freq=2628056 freq=299351
+AndHighMedDayTaxoFacets: +that +age +facets:taxonomy:DayOfYear # freq=2931020 freq=395368
+AndHighMedDayTaxoFacets: +2008 +august +facets:taxonomy:DayOfYear # freq=831253 freq=527806
+AndHighMedDayTaxoFacets: +date +type +facets:taxonomy:DayOfYear # freq=2020626 freq=318210
+AndHighMedDayTaxoFacets: +other +most +facets:taxonomy:DayOfYear # freq=1269961 freq=819634
+AndHighMedDayTaxoFacets: +his +mark +facets:taxonomy:DayOfYear # freq=1777780 freq=160033
+AndHighMedDayTaxoFacets: +was +elected +facets:taxonomy:DayOfYear # freq=3763623 freq=119941
+AndHighMedDayTaxoFacets: +title +parliament +facets:taxonomy:DayOfYear # freq=2397378 freq=127008
+AndHighMedDayTaxoFacets: +been +27 +facets:taxonomy:DayOfYear # freq=1041183 freq=383042
+AndHighMedDayTaxoFacets: +publisher +western +facets:taxonomy:DayOfYear # freq=1289029 freq=232781
+AndHighMedDayTaxoFacets: +its +done +facets:taxonomy:DayOfYear # freq=1173450 freq=102033
+AndHighMedDayTaxoFacets: +more +web.archive.org +facets:taxonomy:DayOfYear # freq=963533 freq=95902
+AndHighMedDayTaxoFacets: +date +half +facets:taxonomy:DayOfYear # freq=2020626 freq=155387
+AndHighMedDayTaxoFacets: +that +lower +facets:taxonomy:DayOfYear # freq=2931020 freq=127260
+AndHighMedDayTaxoFacets: +more +already +facets:taxonomy:DayOfYear # freq=963533 freq=126694
+AndHighMedDayTaxoFacets: +for +report +facets:taxonomy:DayOfYear # freq=4380011 freq=153204
+AndHighMedDayTaxoFacets: +5 +ed +facets:taxonomy:DayOfYear # freq=891361 freq=134224
+AndHighMedDayTaxoFacets: +http +1965 +facets:taxonomy:DayOfYear # freq=3493581 freq=104539
+AndHighMedDayTaxoFacets: +s +debate +facets:taxonomy:DayOfYear # freq=1581243 freq=177827
+AndHighMedDayTaxoFacets: +only +official +facets:taxonomy:DayOfYear # freq=875561 freq=326177
+AndHighMedDayTaxoFacets: +2006 +seat +facets:taxonomy:DayOfYear # freq=889954 freq=91288
+AndHighMedDayTaxoFacets: +in +27 +facets:taxonomy:DayOfYear # freq=7320987 freq=383042
+AndHighMedDayTaxoFacets: +cite +fields +facets:taxonomy:DayOfYear # freq=1741194 freq=86938
+AndHighMedDayTaxoFacets: +states +remained +facets:taxonomy:DayOfYear # freq=1034872 freq=107736
+AndHighMedDayTaxoFacets: +for +hold +facets:taxonomy:DayOfYear # freq=4380011 freq=82579
+AndHighMedDayTaxoFacets: +2011 +joseph +facets:taxonomy:DayOfYear # freq=871410 freq=121533
+AndHighMedDayTaxoFacets: +2009 +met +facets:taxonomy:DayOfYear # freq=887702 freq=84001
+AndHighMedDayTaxoFacets: +an +31 +facets:taxonomy:DayOfYear # freq=2628056 freq=298349
+AndHighMedDayTaxoFacets: +there +hill +facets:taxonomy:DayOfYear # freq=956153 freq=133714
+AndHighMedDayTaxoFacets: +3 +allowed +facets:taxonomy:DayOfYear # freq=1148799 freq=98720
+AndHighMedDayTaxoFacets: +4 +table +facets:taxonomy:DayOfYear # freq=986452 freq=99163
+AndHighMedDayTaxoFacets: +accessdate +later +facets:taxonomy:DayOfYear # freq=1228887 freq=604921
+AndHighMedDayTaxoFacets: +2008 +rather +facets:taxonomy:DayOfYear # freq=831253 freq=174136
+AndHighMedDayTaxoFacets: +also +late +facets:taxonomy:DayOfYear # freq=1959419 freq=243636
+AndHighMedDayTaxoFacets: +2008 +60 +facets:taxonomy:DayOfYear # freq=831253 freq=118403
+AndHighMedDayTaxoFacets: +1 +why +facets:taxonomy:DayOfYear # freq=1641090 freq=108161
+AndHighMedDayTaxoFacets: +new +winning +facets:taxonomy:DayOfYear # freq=1657293 freq=95704
+AndHighMedDayTaxoFacets: +accessdate +towards +facets:taxonomy:DayOfYear # freq=1228887 freq=95574
+AndHighMedDayTaxoFacets: +date +t +facets:taxonomy:DayOfYear # freq=2020626 freq=262832
+AndHighMedDayTaxoFacets: +2 +nbsp +facets:taxonomy:DayOfYear # freq=1549245 freq=506054
+AndHighMedDayTaxoFacets: +time +website +facets:taxonomy:DayOfYear # freq=1032071 freq=435941
+AndHighMedDayTaxoFacets: +5 +republic +facets:taxonomy:DayOfYear # freq=891361 freq=166154
+AndHighMedDayTaxoFacets: +were +hold +facets:taxonomy:DayOfYear # freq=1524630 freq=82579
+AndHighMedDayTaxoFacets: +the +whom +facets:taxonomy:DayOfYear # freq=8217362 freq=95520
+AndHighMedDayTaxoFacets: +http +free +facets:taxonomy:DayOfYear # freq=3493581 freq=270199
+AndHighMedDayTaxoFacets: +his +self +facets:taxonomy:DayOfYear # freq=1777780 freq=135012
+AndHighMedDayTaxoFacets: +with +music +facets:taxonomy:DayOfYear # freq=3709421 freq=473240
+AndHighMedDayTaxoFacets: +is +academy +facets:taxonomy:DayOfYear # freq=4074455 freq=119055
+AndHighMedDayTaxoFacets: +year +appearance +facets:taxonomy:DayOfYear # freq=1235231 freq=89229
+AndHighMedDayTaxoFacets: +year +square +facets:taxonomy:DayOfYear # freq=1235231 freq=123538
+AndHighMedDayTaxoFacets: +i +h +facets:taxonomy:DayOfYear # freq=956148 freq=241946
+AndHighMedDayTaxoFacets: +by +35 +facets:taxonomy:DayOfYear # freq=3826691 freq=155506
+AndHighMedDayTaxoFacets: +2005 +sports +facets:taxonomy:DayOfYear # freq=835460 freq=178542
+AndHighMedDayTaxoFacets: +united +series +facets:taxonomy:DayOfYear # freq=1196944 freq=521861
+AndHighMedDayTaxoFacets: +may +congress +facets:taxonomy:DayOfYear # freq=1071932 freq=92382
+AndHighMedDayTaxoFacets: +title +la +facets:taxonomy:DayOfYear # freq=2397378 freq=232610
+AndHighMedDayTaxoFacets: +its +category:american +facets:taxonomy:DayOfYear # freq=1173450 freq=107823
+AndHighMedDayTaxoFacets: +the +lake +facets:taxonomy:DayOfYear # freq=8217362 freq=131603
+AndHighMedDayTaxoFacets: +who +foundation +facets:taxonomy:DayOfYear # freq=1196171 freq=107123
+AndHighMedDayTaxoFacets: +3 +57 +facets:taxonomy:DayOfYear # freq=1148799 freq=93708
+AndHighMedDayTaxoFacets: +date +flag +facets:taxonomy:DayOfYear # freq=2020626 freq=104210
+AndHighMedDayTaxoFacets: +10 +dq +facets:taxonomy:DayOfYear # freq=918339 freq=88557
+AndHighMedDayTaxoFacets: +that +study +facets:taxonomy:DayOfYear # freq=2931020 freq=137170
+AndHighMedDayTaxoFacets: +first +france +facets:taxonomy:DayOfYear # freq=1933372 freq=220058
+AndHighMedDayTaxoFacets: +on +culture +facets:taxonomy:DayOfYear # freq=4074624 freq=157773
+AndHighMedDayTaxoFacets: +to +1984 +facets:taxonomy:DayOfYear # freq=6155577 freq=161404
+AndHighMedDayTaxoFacets: +all +u.s +facets:taxonomy:DayOfYear # freq=1203572 freq=428534
+AndHighMedDayTaxoFacets: +name +era +facets:taxonomy:DayOfYear # freq=2827713 freq=95989
+AndHighMedDayTaxoFacets: +url +02 +facets:taxonomy:DayOfYear # freq=1513595 freq=319783
+AndHighMedDayTaxoFacets: +a +teams +facets:taxonomy:DayOfYear # freq=6560531 freq=105245
+AndHighMedDayTaxoFacets: +name +paul +facets:taxonomy:DayOfYear # freq=2827713 freq=207229
+AndHighMedDayTaxoFacets: +2008 +command +facets:taxonomy:DayOfYear # freq=831253 freq=87496
+AndHighMedDayTaxoFacets: +after +today +facets:taxonomy:DayOfYear # freq=1247398 freq=168864
+AndHighMedDayTaxoFacets: +no +native +facets:taxonomy:DayOfYear # freq=1045000 freq=129103
+AndHighMedDayTaxoFacets: +into +st +facets:taxonomy:DayOfYear # freq=888684 freq=309092
+AndHighMedDayTaxoFacets: +accessdate +m +facets:taxonomy:DayOfYear # freq=1228887 freq=441232
+AndHighMedDayTaxoFacets: +a +heart +facets:taxonomy:DayOfYear # freq=6560531 freq=95365
+AndHighMedDayTaxoFacets: +2010 +1986 +facets:taxonomy:DayOfYear # freq=950573 freq=167724
+AndHighMedDayTaxoFacets: +2008 +remained +facets:taxonomy:DayOfYear # freq=831253 freq=107736
+AndHighMedDayTaxoFacets: +this +college +facets:taxonomy:DayOfYear # freq=2224932 freq=278094
+AndHighMedDayTaxoFacets: +date +note +facets:taxonomy:DayOfYear # freq=2020626 freq=194472
+AndHighMedDayTaxoFacets: +5 +coast +facets:taxonomy:DayOfYear # freq=891361 freq=119047
+AndHighMedDayTaxoFacets: +time +sometimes +facets:taxonomy:DayOfYear # freq=1032071 freq=144078
+AndHighMedDayTaxoFacets: +3 +look +facets:taxonomy:DayOfYear # freq=1148799 freq=91122
+AndHighMedDayTaxoFacets: +states +people +facets:taxonomy:DayOfYear # freq=1034872 freq=790960
+AndHighMedDayTaxoFacets: +to +specific +facets:taxonomy:DayOfYear # freq=6155577 freq=93622
+AndHighMedDayTaxoFacets: +year +between +facets:taxonomy:DayOfYear # freq=1235231 freq=630650
+AndHighMedDayTaxoFacets: +publisher +led +facets:taxonomy:DayOfYear # freq=1289029 freq=210033
+AndHighMedDayTaxoFacets: +a +given +facets:taxonomy:DayOfYear # freq=6560531 freq=235719
+AndHighMedDayTaxoFacets: +2008 +stations +facets:taxonomy:DayOfYear # freq=831253 freq=92011
+AndHighMedDayTaxoFacets: +his +england +facets:taxonomy:DayOfYear # freq=1777780 freq=317884
+AndHighMedDayTaxoFacets: +states +geo +facets:taxonomy:DayOfYear # freq=1034872 freq=83404
+AndHighMedDayTaxoFacets: +at +1960 +facets:taxonomy:DayOfYear # freq=2857534 freq=109083
+AndHighMedDayTaxoFacets: +be +60 +facets:taxonomy:DayOfYear # freq=2051702 freq=118403
+AndHighMedDayTaxoFacets: +there +schools +facets:taxonomy:DayOfYear # freq=956153 freq=141308
+AndHighMedDayTaxoFacets: +that +value +facets:taxonomy:DayOfYear # freq=2931020 freq=86806
+AndHighMedDayTaxoFacets: +no +needed +facets:taxonomy:DayOfYear # freq=1045000 freq=281051
+AndHighMedDayTaxoFacets: +2011 +31 +facets:taxonomy:DayOfYear # freq=871410 freq=298349
+AndHighMedDayTaxoFacets: +year +16 +facets:taxonomy:DayOfYear # freq=1235231 freq=540539
+AndHighMedDayTaxoFacets: +title +set +facets:taxonomy:DayOfYear # freq=2397378 freq=294255
+AndHighMedDayTaxoFacets: +work +sport +facets:taxonomy:DayOfYear # freq=853422 freq=106696
+AndHighMedDayTaxoFacets: +all +42 +facets:taxonomy:DayOfYear # freq=1203572 freq=124253
+OrHighMedDayTaxoFacets: there background +facets:taxonomy:DayOfYear # freq=956153 freq=314229
+OrHighMedDayTaxoFacets: be important +facets:taxonomy:DayOfYear # freq=2051702 freq=195851
+OrHighMedDayTaxoFacets: name cd +facets:taxonomy:DayOfYear # freq=2827713 freq=87105
+OrHighMedDayTaxoFacets: when regular +facets:taxonomy:DayOfYear # freq=1027487 freq=93809
+OrHighMedDayTaxoFacets: 1 called +facets:taxonomy:DayOfYear # freq=1641090 freq=454580
+OrHighMedDayTaxoFacets: may force +facets:taxonomy:DayOfYear # freq=1071932 freq=198556
+OrHighMedDayTaxoFacets: 1 regular +facets:taxonomy:DayOfYear # freq=1641090 freq=93809
+OrHighMedDayTaxoFacets: s 1986 +facets:taxonomy:DayOfYear # freq=1581243 freq=167724
+OrHighMedDayTaxoFacets: 2011 co +facets:taxonomy:DayOfYear # freq=871410 freq=209086
+OrHighMedDayTaxoFacets: he artist +facets:taxonomy:DayOfYear # freq=1659434 freq=210591
+OrHighMedDayTaxoFacets: 2009 him +facets:taxonomy:DayOfYear # freq=887702 freq=507350
+OrHighMedDayTaxoFacets: at interest +facets:taxonomy:DayOfYear # freq=2857534 freq=108551
+OrHighMedDayTaxoFacets: and 1959 +facets:taxonomy:DayOfYear # freq=7318061 freq=87097
+OrHighMedDayTaxoFacets: had few +facets:taxonomy:DayOfYear # freq=1246743 freq=226422
+OrHighMedDayTaxoFacets: this era +facets:taxonomy:DayOfYear # freq=2224932 freq=95989
+OrHighMedDayTaxoFacets: also video +facets:taxonomy:DayOfYear # freq=1959419 freq=202380
+OrHighMedDayTaxoFacets: into capital +facets:taxonomy:DayOfYear # freq=888684 freq=120421
+OrHighMedDayTaxoFacets: who los +facets:taxonomy:DayOfYear # freq=1196171 freq=145404
+OrHighMedDayTaxoFacets: that ii +facets:taxonomy:DayOfYear # freq=2931020 freq=340800
+OrHighMedDayTaxoFacets: as working +facets:taxonomy:DayOfYear # freq=3925535 freq=144617
+OrHighMedDayTaxoFacets: accessdate status +facets:taxonomy:DayOfYear # freq=1228887 freq=133818
+OrHighMedDayTaxoFacets: not put +facets:taxonomy:DayOfYear # freq=1713264 freq=139882
+OrHighMedDayTaxoFacets: cite soviet +facets:taxonomy:DayOfYear # freq=1741194 freq=89070
+OrHighMedDayTaxoFacets: see reading +facets:taxonomy:DayOfYear # freq=1044180 freq=101214
+OrHighMedDayTaxoFacets: all area +facets:taxonomy:DayOfYear # freq=1203572 freq=559023
+OrHighMedDayTaxoFacets: his influence +facets:taxonomy:DayOfYear # freq=1777780 freq=83101
+OrHighMedDayTaxoFacets: new less +facets:taxonomy:DayOfYear # freq=1657293 freq=170266
+OrHighMedDayTaxoFacets: states 14 +facets:taxonomy:DayOfYear # freq=1034872 freq=534005
+OrHighMedDayTaxoFacets: no april +facets:taxonomy:DayOfYear # freq=1045000 freq=587542
+OrHighMedDayTaxoFacets: http wife +facets:taxonomy:DayOfYear # freq=3493581 freq=130807
+OrHighMedDayTaxoFacets: had stories +facets:taxonomy:DayOfYear # freq=1246743 freq=110223
+OrHighMedDayTaxoFacets: this established +facets:taxonomy:DayOfYear # freq=2224932 freq=282471
+OrHighMedDayTaxoFacets: other source +facets:taxonomy:DayOfYear # freq=1269961 freq=231838
+OrHighMedDayTaxoFacets: 1 alone +facets:taxonomy:DayOfYear # freq=1641090 freq=93166
+OrHighMedDayTaxoFacets: and per +facets:taxonomy:DayOfYear # freq=7318061 freq=283568
+OrHighMedDayTaxoFacets: into larger +facets:taxonomy:DayOfYear # freq=888684 freq=87424
+OrHighMedDayTaxoFacets: to book +facets:taxonomy:DayOfYear # freq=6155577 freq=617297
+OrHighMedDayTaxoFacets: at london +facets:taxonomy:DayOfYear # freq=2857534 freq=348918
+OrHighMedDayTaxoFacets: at km +facets:taxonomy:DayOfYear # freq=2857534 freq=233831
+OrHighMedDayTaxoFacets: in convert +facets:taxonomy:DayOfYear # freq=7320987 freq=267974
+OrHighMedDayTaxoFacets: s yet +facets:taxonomy:DayOfYear # freq=1581243 freq=100857
+OrHighMedDayTaxoFacets: 1 1973 +facets:taxonomy:DayOfYear # freq=1641090 freq=125985
+OrHighMedDayTaxoFacets: 1 yet +facets:taxonomy:DayOfYear # freq=1641090 freq=100857
+OrHighMedDayTaxoFacets: 3 preserved +facets:taxonomy:DayOfYear # freq=1148799 freq=111088
+OrHighMedDayTaxoFacets: when various +facets:taxonomy:DayOfYear # freq=1027487 freq=224593
+OrHighMedDayTaxoFacets: his result +facets:taxonomy:DayOfYear # freq=1777780 freq=276803
+OrHighMedDayTaxoFacets: into film +facets:taxonomy:DayOfYear # freq=888684 freq=432758
+OrHighMedDayTaxoFacets: was leader +facets:taxonomy:DayOfYear # freq=3763623 freq=127591
+OrHighMedDayTaxoFacets: see list +facets:taxonomy:DayOfYear # freq=1044180 freq=585922
+OrHighMedDayTaxoFacets: first institute +facets:taxonomy:DayOfYear # freq=1933372 freq=136311
+OrHighMedDayTaxoFacets: work got +facets:taxonomy:DayOfYear # freq=853422 freq=92640
+OrHighMedDayTaxoFacets: had rule +facets:taxonomy:DayOfYear # freq=1246743 freq=86729
+OrHighMedDayTaxoFacets: 1 thought +facets:taxonomy:DayOfYear # freq=1641090 freq=108963
+OrHighMedDayTaxoFacets: an hard +facets:taxonomy:DayOfYear # freq=2628056 freq=90149
+OrHighMedDayTaxoFacets: only 1972 +facets:taxonomy:DayOfYear # freq=875561 freq=130791
+OrHighMedDayTaxoFacets: was american +facets:taxonomy:DayOfYear # freq=3763623 freq=758337
+OrHighMedDayTaxoFacets: 2009 lines +facets:taxonomy:DayOfYear # freq=887702 freq=96969
+OrHighMedDayTaxoFacets: no followed +facets:taxonomy:DayOfYear # freq=1045000 freq=121848
+OrHighMedDayTaxoFacets: had five +facets:taxonomy:DayOfYear # freq=1246743 freq=262923
+OrHighMedDayTaxoFacets: was q +facets:taxonomy:DayOfYear # freq=3763623 freq=149271
+OrHighMedDayTaxoFacets: cite wikipedia +facets:taxonomy:DayOfYear # freq=1741194 freq=149673
+OrHighMedDayTaxoFacets: other already +facets:taxonomy:DayOfYear # freq=1269961 freq=126694
+OrHighMedDayTaxoFacets: it keep +facets:taxonomy:DayOfYear # freq=2675552 freq=177996
+OrHighMedDayTaxoFacets: states t +facets:taxonomy:DayOfYear # freq=1034872 freq=262832
+OrHighMedDayTaxoFacets: 1 listed +facets:taxonomy:DayOfYear # freq=1641090 freq=94990
+OrHighMedDayTaxoFacets: there modify +facets:taxonomy:DayOfYear # freq=956153 freq=109819
+OrHighMedDayTaxoFacets: url win +facets:taxonomy:DayOfYear # freq=1513595 freq=121070
+OrHighMedDayTaxoFacets: may 39 +facets:taxonomy:DayOfYear # freq=1071932 freq=132689
+OrHighMedDayTaxoFacets: two charles +facets:taxonomy:DayOfYear # freq=1104053 freq=204987
+OrHighMedDayTaxoFacets: also appears +facets:taxonomy:DayOfYear # freq=1959419 freq=104511
+OrHighMedDayTaxoFacets: more rowspan +facets:taxonomy:DayOfYear # freq=963533 freq=124637
+OrHighMedDayTaxoFacets: web north +facets:taxonomy:DayOfYear # freq=1118334 freq=564195
+OrHighMedDayTaxoFacets: 1 smith +facets:taxonomy:DayOfYear # freq=1641090 freq=126344
+OrHighMedDayTaxoFacets: 2010 2000 +facets:taxonomy:DayOfYear # freq=950573 freq=499639
+OrHighMedDayTaxoFacets: they features +facets:taxonomy:DayOfYear # freq=1021945 freq=156867
+OrHighMedDayTaxoFacets: 2 project +facets:taxonomy:DayOfYear # freq=1549245 freq=180139
+OrHighMedDayTaxoFacets: http instead +facets:taxonomy:DayOfYear # freq=3493581 freq=149345
+OrHighMedDayTaxoFacets: by am +facets:taxonomy:DayOfYear # freq=3826691 freq=127152
+OrHighMedDayTaxoFacets: it pacific +facets:taxonomy:DayOfYear # freq=2675552 freq=107648
+OrHighMedDayTaxoFacets: states times +facets:taxonomy:DayOfYear # freq=1034872 freq=407155
+OrHighMedDayTaxoFacets: name middle +facets:taxonomy:DayOfYear # freq=2827713 freq=156728
+OrHighMedDayTaxoFacets: is 1988 +facets:taxonomy:DayOfYear # freq=4074455 freq=181327
+OrHighMedDayTaxoFacets: 5 c +facets:taxonomy:DayOfYear # freq=891361 freq=444247
+OrHighMedDayTaxoFacets: their court +facets:taxonomy:DayOfYear # freq=1158682 freq=169309
+OrHighMedDayTaxoFacets: they double +facets:taxonomy:DayOfYear # freq=1021945 freq=87304
+OrHighMedDayTaxoFacets: in george +facets:taxonomy:DayOfYear # freq=7320987 freq=256196
+OrHighMedDayTaxoFacets: after appears +facets:taxonomy:DayOfYear # freq=1247398 freq=104511
+OrHighMedDayTaxoFacets: is thomas +facets:taxonomy:DayOfYear # freq=4074455 freq=191625
+OrHighMedDayTaxoFacets: about specific +facets:taxonomy:DayOfYear # freq=850283 freq=93622
+OrHighMedDayTaxoFacets: be captain +facets:taxonomy:DayOfYear # freq=2051702 freq=91635
+OrHighMedDayTaxoFacets: be journal +facets:taxonomy:DayOfYear # freq=2051702 freq=348162
+OrHighMedDayTaxoFacets: this month +facets:taxonomy:DayOfYear # freq=2224932 freq=162128
+OrHighMedDayTaxoFacets: last given +facets:taxonomy:DayOfYear # freq=958437 freq=235719
+OrHighMedDayTaxoFacets: from running +facets:taxonomy:DayOfYear # freq=3224339 freq=101764
+OrHighMedDayTaxoFacets: 2008 liberal +facets:taxonomy:DayOfYear # freq=831253 freq=93070
+OrHighMedDayTaxoFacets: i island +facets:taxonomy:DayOfYear # freq=956148 freq=203023
+OrHighMedDayTaxoFacets: or pp +facets:taxonomy:DayOfYear # freq=1858841 freq=204742
+OrHighMedDayTaxoFacets: which earth +facets:taxonomy:DayOfYear # freq=1963428 freq=110512
+OrHighMedDayTaxoFacets: united school +facets:taxonomy:DayOfYear # freq=1196944 freq=462166
+OrHighMedDayTaxoFacets: at fall +facets:taxonomy:DayOfYear # freq=2857534 freq=103379
+OrHighMedDayTaxoFacets: by talk +facets:taxonomy:DayOfYear # freq=3826691 freq=364194
+OrHighMedDayTaxoFacets: title appropriate +facets:taxonomy:DayOfYear # freq=2397378 freq=135343
+OrHighMedDayTaxoFacets: first data +facets:taxonomy:DayOfYear # freq=1933372 freq=159657
+OrHighMedDayTaxoFacets: by community +facets:taxonomy:DayOfYear # freq=3826691 freq=225571
+OrHighMedDayTaxoFacets: it anti +facets:taxonomy:DayOfYear # freq=2675552 freq=99993
+OrHighMedDayTaxoFacets: 2005 would +facets:taxonomy:DayOfYear # freq=835460 freq=690480
+OrHighMedDayTaxoFacets: no archive +facets:taxonomy:DayOfYear # freq=1045000 freq=215381
+OrHighMedDayTaxoFacets: had 11 +facets:taxonomy:DayOfYear # freq=1246743 freq=730505
+OrHighMedDayTaxoFacets: which 978 +facets:taxonomy:DayOfYear # freq=1963428 freq=101276
+OrHighMedDayTaxoFacets: accessdate seems +facets:taxonomy:DayOfYear # freq=1228887 freq=83963
+OrHighMedDayTaxoFacets: 2011 commission +facets:taxonomy:DayOfYear # freq=871410 freq=91476
+OrHighMedDayTaxoFacets: that county +facets:taxonomy:DayOfYear # freq=2931020 freq=521126
+OrHighMedDayTaxoFacets: they hard +facets:taxonomy:DayOfYear # freq=1021945 freq=90149
+OrHighMedDayTaxoFacets: first historic +facets:taxonomy:DayOfYear # freq=1933372 freq=112292
+OrHighMedDayTaxoFacets: this category +facets:taxonomy:DayOfYear # freq=2224932 freq=595446
+OrHighMedDayTaxoFacets: its counties +facets:taxonomy:DayOfYear # freq=1173450 freq=87574
+OrHighMedDayTaxoFacets: year 1963 +facets:taxonomy:DayOfYear # freq=1235231 freq=96439
+OrHighMedDayTaxoFacets: this include +facets:taxonomy:DayOfYear # freq=2224932 freq=276466
+OrHighMedDayTaxoFacets: one british +facets:taxonomy:DayOfYear # freq=1527689 freq=417307
+OrHighMedDayTaxoFacets: was world +facets:taxonomy:DayOfYear # freq=3763623 freq=808563
+OrHighMedDayTaxoFacets: the references +facets:taxonomy:DayOfYear # freq=8217362 freq=760306
+OrHighMedDayTaxoFacets: its 56 +facets:taxonomy:DayOfYear # freq=1173450 freq=96215
+OrHighMedDayTaxoFacets: their son +facets:taxonomy:DayOfYear # freq=1158682 freq=202340
+OrHighMedDayTaxoFacets: the federal +facets:taxonomy:DayOfYear # freq=8217362 freq=166274
+OrHighMedDayTaxoFacets: with jpg +facets:taxonomy:DayOfYear # freq=3709421 freq=322278
+OrHighMedDayTaxoFacets: on training +facets:taxonomy:DayOfYear # freq=4074624 freq=107271
+OrHighMedDayTaxoFacets: for famous +facets:taxonomy:DayOfYear # freq=4380011 freq=139092
+OrHighMedDayTaxoFacets: work run +facets:taxonomy:DayOfYear # freq=853422 freq=183609
+OrHighMedDayTaxoFacets: which start +facets:taxonomy:DayOfYear # freq=1963428 freq=233925
+OrHighMedDayTaxoFacets: and author +facets:taxonomy:DayOfYear # freq=7318061 freq=567768
+OrHighMedDayTaxoFacets: name mother +facets:taxonomy:DayOfYear # freq=2827713 freq=122930
+OrHighMedDayTaxoFacets: who current +facets:taxonomy:DayOfYear # freq=1196171 freq=217174
+OrHighMedDayTaxoFacets: s vote +facets:taxonomy:DayOfYear # freq=1581243 freq=96871
+OrHighMedDayTaxoFacets: 4 51 +facets:taxonomy:DayOfYear # freq=986452 freq=108800
+OrHighMedDayTaxoFacets: 2011 special +facets:taxonomy:DayOfYear # freq=871410 freq=198917
+OrHighMedDayTaxoFacets: accessdate st +facets:taxonomy:DayOfYear # freq=1228887 freq=309092
+OrHighMedDayTaxoFacets: about must +facets:taxonomy:DayOfYear # freq=850283 freq=228491
+OrHighMedDayTaxoFacets: had census +facets:taxonomy:DayOfYear # freq=1246743 freq=205166
+OrHighMedDayTaxoFacets: publisher 56 +facets:taxonomy:DayOfYear # freq=1289029 freq=96215
+OrHighMedDayTaxoFacets: other 12 +facets:taxonomy:DayOfYear # freq=1269961 freq=774572
+OrHighMedDayTaxoFacets: or 22 +facets:taxonomy:DayOfYear # freq=1858841 freq=502778
+OrHighMedDayTaxoFacets: of deletion +facets:taxonomy:DayOfYear # freq=8184358 freq=166633
+OrHighMedDayTaxoFacets: as married +facets:taxonomy:DayOfYear # freq=3925535 freq=156752
+OrHighMedDayTaxoFacets: also do +facets:taxonomy:DayOfYear # freq=1959419 freq=511178
+OrHighMedDayTaxoFacets: of larger +facets:taxonomy:DayOfYear # freq=8184358 freq=87424
+OrHighMedDayTaxoFacets: the wikipedia:persondata +facets:taxonomy:DayOfYear # freq=8217362 freq=222385
+OrHighMedDayTaxoFacets: be books +facets:taxonomy:DayOfYear # freq=2051702 freq=341376
+OrHighMedDayTaxoFacets: url george +facets:taxonomy:DayOfYear # freq=1513595 freq=256196
+OrHighMedDayTaxoFacets: accessdate del +facets:taxonomy:DayOfYear # freq=1228887 freq=82614
+OrHighMedDayTaxoFacets: about command +facets:taxonomy:DayOfYear # freq=850283 freq=87496
+OrHighMedDayTaxoFacets: there soon +facets:taxonomy:DayOfYear # freq=956153 freq=123657
+OrHighMedDayTaxoFacets: url special +facets:taxonomy:DayOfYear # freq=1513595 freq=198917
+OrHighMedDayTaxoFacets: may authority +facets:taxonomy:DayOfYear # freq=1071932 freq=85540
+OrHighMedDayTaxoFacets: url ever +facets:taxonomy:DayOfYear # freq=1513595 freq=128732
+OrHighMedDayTaxoFacets: see 1987 +facets:taxonomy:DayOfYear # freq=1044180 freq=172453
+OrHighMedDayTaxoFacets: his ended +facets:taxonomy:DayOfYear # freq=1777780 freq=84664
+OrHighMedDayTaxoFacets: who prime +facets:taxonomy:DayOfYear # freq=1196171 freq=96945
+OrHighMedDayTaxoFacets: a success +facets:taxonomy:DayOfYear # freq=6560531 freq=112195
+OrHighMedDayTaxoFacets: cite elected +facets:taxonomy:DayOfYear # freq=1741194 freq=119941
+OrHighMedDayTaxoFacets: 2008 without +facets:taxonomy:DayOfYear # freq=831253 freq=249926
+OrHighMedDayTaxoFacets: after km +facets:taxonomy:DayOfYear # freq=1247398 freq=233831
+OrHighMedDayTaxoFacets: no fields +facets:taxonomy:DayOfYear # freq=1045000 freq=86938
+OrHighMedDayTaxoFacets: the financial +facets:taxonomy:DayOfYear # freq=8217362 freq=82536
+OrHighMedDayTaxoFacets: had features +facets:taxonomy:DayOfYear # freq=1246743 freq=156867
+OrHighMedDayTaxoFacets: into dead +facets:taxonomy:DayOfYear # freq=888684 freq=171386
+OrHighMedDayTaxoFacets: of caused +facets:taxonomy:DayOfYear # freq=8184358 freq=86397
+OrHighMedDayTaxoFacets: as changes +facets:taxonomy:DayOfYear # freq=3925535 freq=105677
+OrHighMedDayTaxoFacets: no president +facets:taxonomy:DayOfYear # freq=1045000 freq=263341
+OrHighMedDayTaxoFacets: one within +facets:taxonomy:DayOfYear # freq=1527689 freq=291049
+OrHighMedDayTaxoFacets: at mark +facets:taxonomy:DayOfYear # freq=2857534 freq=160033
+OrHighMedDayTaxoFacets: first down +facets:taxonomy:DayOfYear # freq=1933372 freq=280662
+OrHighMedDayTaxoFacets: be leader +facets:taxonomy:DayOfYear # freq=2051702 freq=127591
+OrHighMedDayTaxoFacets: were know +facets:taxonomy:DayOfYear # freq=1524630 freq=129655
+OrHighMedDayTaxoFacets: s england +facets:taxonomy:DayOfYear # freq=1581243 freq=317884
+OrHighMedDayTaxoFacets: one set +facets:taxonomy:DayOfYear # freq=1527689 freq=294255
+OrHighMedDayTaxoFacets: 5 flight +facets:taxonomy:DayOfYear # freq=891361 freq=84316
+OrHighMedDayTaxoFacets: i works +facets:taxonomy:DayOfYear # freq=956148 freq=199177
+OrHighMedDayTaxoFacets: was 1982 +facets:taxonomy:DayOfYear # freq=3763623 freq=153269
+OrHighMedDayTaxoFacets: but 57 +facets:taxonomy:DayOfYear # freq=1456553 freq=93708
+OrHighMedDayTaxoFacets: date coord +facets:taxonomy:DayOfYear # freq=2020626 freq=180590
+OrHighMedDayTaxoFacets: cite science +facets:taxonomy:DayOfYear # freq=1741194 freq=219988
+OrHighMedDayTaxoFacets: two past +facets:taxonomy:DayOfYear # freq=1104053 freq=126130
+OrHighMedDayTaxoFacets: first albums +facets:taxonomy:DayOfYear # freq=1933372 freq=118322
+OrHighMedDayTaxoFacets: its 14 +facets:taxonomy:DayOfYear # freq=1173450 freq=534005
+OrHighMedDayTaxoFacets: when rowspan +facets:taxonomy:DayOfYear # freq=1027487 freq=124637
+OrHighMedDayTaxoFacets: for league +facets:taxonomy:DayOfYear # freq=4380011 freq=270223
+OrHighMedDayTaxoFacets: to keep +facets:taxonomy:DayOfYear # freq=6155577 freq=177996
+OrHighMedDayTaxoFacets: a baseball +facets:taxonomy:DayOfYear # freq=6560531 freq=93326
+OrHighMedDayTaxoFacets: publisher colspan +facets:taxonomy:DayOfYear # freq=1289029 freq=134521
+OrHighMedDayTaxoFacets: when release +facets:taxonomy:DayOfYear # freq=1027487 freq=189375
+OrHighMedDayTaxoFacets: see down +facets:taxonomy:DayOfYear # freq=1044180 freq=280662
+OrHighMedDayTaxoFacets: date does +facets:taxonomy:DayOfYear # freq=2020626 freq=232202
+OrHighMedDayTaxoFacets: s boston +facets:taxonomy:DayOfYear # freq=1581243 freq=85235
+OrHighMedDayTaxoFacets: but center +facets:taxonomy:DayOfYear # freq=1456553 freq=489673
+OrHighMedDayTaxoFacets: some originally +facets:taxonomy:DayOfYear # freq=839919 freq=168282
+OrHighMedDayTaxoFacets: all movement +facets:taxonomy:DayOfYear # freq=1203572 freq=131692
+OrHighMedDayTaxoFacets: an human +facets:taxonomy:DayOfYear # freq=2628056 freq=182617
+OrHighMedDayTaxoFacets: time life +facets:taxonomy:DayOfYear # freq=1032071 freq=477007
+OrHighMedDayTaxoFacets: first bridge +facets:taxonomy:DayOfYear # freq=1933372 freq=92398
+OrHighMedDayTaxoFacets: one comments +facets:taxonomy:DayOfYear # freq=1527689 freq=185637
+OrHighMedDayTaxoFacets: he background +facets:taxonomy:DayOfYear # freq=1659434 freq=314229
+OrHighMedDayTaxoFacets: 2006 1988 +facets:taxonomy:DayOfYear # freq=889954 freq=181327
+OrHighMedDayTaxoFacets: http fiction +facets:taxonomy:DayOfYear # freq=3493581 freq=87227
+OrHighMedDayTaxoFacets: 4 case +facets:taxonomy:DayOfYear # freq=986452 freq=207307
+OrHighMedDayTaxoFacets: there mike +facets:taxonomy:DayOfYear # freq=956153 freq=91795
+OrHighMedDayTaxoFacets: there 29 +facets:taxonomy:DayOfYear # freq=956153 freq=372091
+OrHighMedDayTaxoFacets: 2010 near +facets:taxonomy:DayOfYear # freq=950573 freq=254492
+OrHighMedDayTaxoFacets: url channel +facets:taxonomy:DayOfYear # freq=1513595 freq=101401
+OrHighMedDayTaxoFacets: two robert +facets:taxonomy:DayOfYear # freq=1104053 freq=246405
+OrHighMedDayTaxoFacets: or public +facets:taxonomy:DayOfYear # freq=1858841 freq=368868
+OrHighMedDayTaxoFacets: other robert +facets:taxonomy:DayOfYear # freq=1269961 freq=246405
+OrHighMedDayTaxoFacets: ref germany +facets:taxonomy:DayOfYear # freq=3793973 freq=190478
+OrHighMedDayTaxoFacets: one english +facets:taxonomy:DayOfYear # freq=1527689 freq=412061
+OrHighMedDayTaxoFacets: no cd +facets:taxonomy:DayOfYear # freq=1045000 freq=87105
+OrHighMedDayTaxoFacets: publisher what +facets:taxonomy:DayOfYear # freq=1289029 freq=394675
+OrHighMedDayTaxoFacets: their win +facets:taxonomy:DayOfYear # freq=1158682 freq=121070
+OrHighMedDayTaxoFacets: an 1959 +facets:taxonomy:DayOfYear # freq=2628056 freq=87097
+OrHighMedDayTaxoFacets: but digital +facets:taxonomy:DayOfYear # freq=1456553 freq=82650
+OrHighMedDayTaxoFacets: but 30 +facets:taxonomy:DayOfYear # freq=1456553 freq=488930
+OrHighMedDayTaxoFacets: work information +facets:taxonomy:DayOfYear # freq=853422 freq=353153
+OrHighMedDayTaxoFacets: by population +facets:taxonomy:DayOfYear # freq=3826691 freq=374481
+OrHighMedDayTaxoFacets: in post +facets:taxonomy:DayOfYear # freq=7320987 freq=218570
+OrHighMedDayTaxoFacets: who birth +facets:taxonomy:DayOfYear # freq=1196171 freq=425138
+OrHighMedDayTaxoFacets: who multiple +facets:taxonomy:DayOfYear # freq=1196171 freq=89684
+OrHighMedDayTaxoFacets: ref trade +facets:taxonomy:DayOfYear # freq=3793973 freq=106384
+OrHighMedDayTaxoFacets: after lord +facets:taxonomy:DayOfYear # freq=1247398 freq=106633
+OrHighMedDayTaxoFacets: to significant +facets:taxonomy:DayOfYear # freq=6155577 freq=111574
+OrHighMedDayTaxoFacets: also 1976 +facets:taxonomy:DayOfYear # freq=1959419 freq=134555
+OrHighMedDayTaxoFacets: which awards +facets:taxonomy:DayOfYear # freq=1963428 freq=159679
+OrHighMedDayTaxoFacets: by blue +facets:taxonomy:DayOfYear # freq=3826691 freq=156658
+OrHighMedDayTaxoFacets: that cause +facets:taxonomy:DayOfYear # freq=2931020 freq=83898
+OrHighMedDayTaxoFacets: about began +facets:taxonomy:DayOfYear # freq=850283 freq=276036
+OrHighMedDayTaxoFacets: other entire +facets:taxonomy:DayOfYear # freq=1269961 freq=97485
+OrHighMedDayTaxoFacets: has internet +facets:taxonomy:DayOfYear # freq=1502961 freq=85510
+OrHighMedDayTaxoFacets: url highest +facets:taxonomy:DayOfYear # freq=1513595 freq=91072
+OrHighMedDayTaxoFacets: an stage +facets:taxonomy:DayOfYear # freq=2628056 freq=113041
+OrHighMedDayTaxoFacets: title imagesize +facets:taxonomy:DayOfYear # freq=2397378 freq=82746
+OrHighMedDayTaxoFacets: see span +facets:taxonomy:DayOfYear # freq=1044180 freq=146676
+OrHighMedDayTaxoFacets: states 2007 +facets:taxonomy:DayOfYear # freq=1034872 freq=801586
+OrHighMedDayTaxoFacets: in clear +facets:taxonomy:DayOfYear # freq=7320987 freq=109812
+OrHighMedDayTaxoFacets: with jean +facets:taxonomy:DayOfYear # freq=3709421 freq=84299
+OrHighMedDayTaxoFacets: other dq +facets:taxonomy:DayOfYear # freq=1269961 freq=88557
+OrHighMedDayTaxoFacets: from chris +facets:taxonomy:DayOfYear # freq=3224339 freq=85523
+OrHighMedDayTaxoFacets: no next +facets:taxonomy:DayOfYear # freq=1045000 freq=259039
+OrHighMedDayTaxoFacets: for musical +facets:taxonomy:DayOfYear # freq=4380011 freq=132600
+OrHighMedDayTaxoFacets: see came +facets:taxonomy:DayOfYear # freq=1044180 freq=197126
+OrHighMedDayTaxoFacets: two wales +facets:taxonomy:DayOfYear # freq=1104053 freq=103595
+OrHighMedDayTaxoFacets: new eastern +facets:taxonomy:DayOfYear # freq=1657293 freq=176853
+OrHighMedDayTaxoFacets: 2 marriage +facets:taxonomy:DayOfYear # freq=1549245 freq=97658
+OrHighMedDayTaxoFacets: 2009 forces +facets:taxonomy:DayOfYear # freq=887702 freq=152939
+OrHighMedDayTaxoFacets: at any +facets:taxonomy:DayOfYear # freq=2857534 freq=483514
+OrHighMedDayTaxoFacets: as live +facets:taxonomy:DayOfYear # freq=3925535 freq=242147
+OrHighMedDayTaxoFacets: see academy +facets:taxonomy:DayOfYear # freq=1044180 freq=119055
+OrHighMedDayTaxoFacets: their get +facets:taxonomy:DayOfYear # freq=1158682 freq=187847
+OrHighMedDayTaxoFacets: about via +facets:taxonomy:DayOfYear # freq=850283 freq=109090
+OrHighMedDayTaxoFacets: only fields +facets:taxonomy:DayOfYear # freq=875561 freq=86938
+OrHighMedDayTaxoFacets: time central +facets:taxonomy:DayOfYear # freq=1032071 freq=272531
+OrHighMedDayTaxoFacets: two my +facets:taxonomy:DayOfYear # freq=1104053 freq=274256
+OrHighMedDayTaxoFacets: with land +facets:taxonomy:DayOfYear # freq=3709421 freq=230284
+OrHighMedDayTaxoFacets: two financial +facets:taxonomy:DayOfYear # freq=1104053 freq=82536
+OrHighMedDayTaxoFacets: was convert +facets:taxonomy:DayOfYear # freq=3763623 freq=267974
+OrHighMedDayTaxoFacets: not course +facets:taxonomy:DayOfYear # freq=1713264 freq=106126
+OrHighMedDayTaxoFacets: 10 producer +facets:taxonomy:DayOfYear # freq=918339 freq=137098
+OrHighMedDayTaxoFacets: 3 52 +facets:taxonomy:DayOfYear # freq=1148799 freq=108395
+OrHighMedDayTaxoFacets: 2008 final +facets:taxonomy:DayOfYear # freq=831253 freq=230006
+OrHighMedDayTaxoFacets: from sir +facets:taxonomy:DayOfYear # freq=3224339 freq=107709
+OrHighMedDayTaxoFacets: to majority +facets:taxonomy:DayOfYear # freq=6155577 freq=105058
+OrHighMedDayTaxoFacets: work published +facets:taxonomy:DayOfYear # freq=853422 freq=243548
+OrHighMedDayTaxoFacets: but might +facets:taxonomy:DayOfYear # freq=1456553 freq=114290
+OrHighMedDayTaxoFacets: has radio +facets:taxonomy:DayOfYear # freq=1502961 freq=183866
+OrHighMedDayTaxoFacets: of 45 +facets:taxonomy:DayOfYear # freq=8184358 freq=180879
+OrHighMedDayTaxoFacets: some africa +facets:taxonomy:DayOfYear # freq=839919 freq=124511
+OrHighMedDayTaxoFacets: title club +facets:taxonomy:DayOfYear # freq=2397378 freq=232173
+OrHighMedDayTaxoFacets: his bgcolor +facets:taxonomy:DayOfYear # freq=1777780 freq=124305
+OrHighMedDayTaxoFacets: that opened +facets:taxonomy:DayOfYear # freq=2931020 freq=140033
+OrHighMedDayTaxoFacets: new station +facets:taxonomy:DayOfYear # freq=1657293 freq=239572
+OrHighMedDayTaxoFacets: were value +facets:taxonomy:DayOfYear # freq=1524630 freq=86806
+OrHighMedDayTaxoFacets: time end +facets:taxonomy:DayOfYear # freq=1032071 freq=526636
+OrHighMedDayTaxoFacets: date start +facets:taxonomy:DayOfYear # freq=2020626 freq=233925
+OrHighMedDayTaxoFacets: 3 across +facets:taxonomy:DayOfYear # freq=1148799 freq=134478
+OrHighMedDayTaxoFacets: 1 j +facets:taxonomy:DayOfYear # freq=1641090 freq=327713
+OrHighMedDayTaxoFacets: the ever +facets:taxonomy:DayOfYear # freq=8217362 freq=128732
+OrHighMedDayTaxoFacets: s archive +facets:taxonomy:DayOfYear # freq=1581243 freq=215381
+OrHighMedDayTaxoFacets: date style +facets:taxonomy:DayOfYear # freq=2020626 freq=606000
+OrHighMedDayTaxoFacets: 2010 caused +facets:taxonomy:DayOfYear # freq=950573 freq=86397
+OrHighMedDayTaxoFacets: or past +facets:taxonomy:DayOfYear # freq=1858841 freq=126130
+OrHighMedDayTaxoFacets: also edits +facets:taxonomy:DayOfYear # freq=1959419 freq=134321
+OrHighMedDayTaxoFacets: http stated +facets:taxonomy:DayOfYear # freq=3493581 freq=89795
+OrHighMedDayTaxoFacets: publisher association +facets:taxonomy:DayOfYear # freq=1289029 freq=247156
+OrHighMedDayTaxoFacets: other europe +facets:taxonomy:DayOfYear # freq=1269961 freq=188671
+OrHighMedDayTaxoFacets: work japan +facets:taxonomy:DayOfYear # freq=853422 freq=163103
+OrHighMedDayTaxoFacets: been committee +facets:taxonomy:DayOfYear # freq=1041183 freq=108636
+OrHighMedDayTaxoFacets: about five +facets:taxonomy:DayOfYear # freq=850283 freq=262923
+OrHighMedDayTaxoFacets: the throughout +facets:taxonomy:DayOfYear # freq=8217362 freq=143603
+OrHighMedDayTaxoFacets: first studies +facets:taxonomy:DayOfYear # freq=1933372 freq=128020
+OrHighMedDayTaxoFacets: his university +facets:taxonomy:DayOfYear # freq=1777780 freq=636959
+OrHighMedDayTaxoFacets: there legal +facets:taxonomy:DayOfYear # freq=956153 freq=90645
+OrHighMedDayTaxoFacets: all italian +facets:taxonomy:DayOfYear # freq=1203572 freq=107082
+OrHighMedDayTaxoFacets: may buildings +facets:taxonomy:DayOfYear # freq=1071932 freq=89046
+OrHighMedDayTaxoFacets: with day +facets:taxonomy:DayOfYear # freq=3709421 freq=402096
+OrHighMedDayTaxoFacets: is code +facets:taxonomy:DayOfYear # freq=4074455 freq=170156
+OrHighMedDayTaxoFacets: date asia +facets:taxonomy:DayOfYear # freq=2020626 freq=90307
+OrHighMedDayTaxoFacets: and thumb +facets:taxonomy:DayOfYear # freq=7318061 freq=672667
+OrHighMedDayTaxoFacets: 10 1970 +facets:taxonomy:DayOfYear # freq=918339 freq=139043
+OrHighMedDayTaxoFacets: from generated +facets:taxonomy:DayOfYear # freq=3224339 freq=97908
+OrHighMedDayTaxoFacets: for light +facets:taxonomy:DayOfYear # freq=4380011 freq=161671
+OrHighMedDayTaxoFacets: about 1970 +facets:taxonomy:DayOfYear # freq=850283 freq=139043
+OrHighMedDayTaxoFacets: states start +facets:taxonomy:DayOfYear # freq=1034872 freq=233925
+OrHighMedDayTaxoFacets: 2 sir +facets:taxonomy:DayOfYear # freq=1549245 freq=107709
+OrHighMedDayTaxoFacets: from information +facets:taxonomy:DayOfYear # freq=3224339 freq=353153
+OrHighMedDayTaxoFacets: 3 reflist +facets:taxonomy:DayOfYear # freq=1148799 freq=561253
+OrHighMedDayTaxoFacets: year modern +facets:taxonomy:DayOfYear # freq=1235231 freq=218831
+OrHighMedDayTaxoFacets: states successful +facets:taxonomy:DayOfYear # freq=1034872 freq=106021
+OrHighMedDayTaxoFacets: on local +facets:taxonomy:DayOfYear # freq=4074624 freq=299012
+OrHighMedDayTaxoFacets: also production +facets:taxonomy:DayOfYear # freq=1959419 freq=191554
+OrHighMedDayTaxoFacets: ref white +facets:taxonomy:DayOfYear # freq=3793973 freq=299411
+OrHighMedDayTaxoFacets: that too +facets:taxonomy:DayOfYear # freq=2931020 freq=161626
+OrHighMedDayTaxoFacets: 2 20 +facets:taxonomy:DayOfYear # freq=1549245 freq=624967
+OrHighMedDayTaxoFacets: 2008 strong +facets:taxonomy:DayOfYear # freq=831253 freq=125611
+OrHighMedDayTaxoFacets: no list +facets:taxonomy:DayOfYear # freq=1045000 freq=585922
+OrHighMedDayTaxoFacets: first label +facets:taxonomy:DayOfYear # freq=1933372 freq=159161
+OrHighMedDayTaxoFacets: see metadata +facets:taxonomy:DayOfYear # freq=1044180 freq=298533
+OrHighMedDayTaxoFacets: they before +facets:taxonomy:DayOfYear # freq=1021945 freq=580481
+OrHighMedDayTaxoFacets: been volume +facets:taxonomy:DayOfYear # freq=1041183 freq=312846
+OrHighMedDayTaxoFacets: last division +facets:taxonomy:DayOfYear # freq=958437 freq=182624
+OrHighMedDayTaxoFacets: new 1988 +facets:taxonomy:DayOfYear # freq=1657293 freq=181327
+OrHighMedDayTaxoFacets: its single +facets:taxonomy:DayOfYear # freq=1173450 freq=283824
+OrHighMedDayTaxoFacets: accessdate awards +facets:taxonomy:DayOfYear # freq=1228887 freq=159679
+OrHighMedDayTaxoFacets: of 1974 +facets:taxonomy:DayOfYear # freq=8184358 freq=132835
+OrHighMedDayTaxoFacets: and st +facets:taxonomy:DayOfYear # freq=7318061 freq=309092
+OrHighMedDayTaxoFacets: which 2002 +facets:taxonomy:DayOfYear # freq=1963428 freq=406953
+OrHighMedDayTaxoFacets: 10 role +facets:taxonomy:DayOfYear # freq=918339 freq=208579
+OrHighMedDayTaxoFacets: 2008 infobox +facets:taxonomy:DayOfYear # freq=831253 freq=524810
+OrHighMedDayTaxoFacets: by units +facets:taxonomy:DayOfYear # freq=3826691 freq=118189
+OrHighMedDayTaxoFacets: see reported +facets:taxonomy:DayOfYear # freq=1044180 freq=91533
+OrHighMedDayTaxoFacets: were love +facets:taxonomy:DayOfYear # freq=1524630 freq=177242
+OrHighMedDayTaxoFacets: their london +facets:taxonomy:DayOfYear # freq=1158682 freq=348918
+OrHighMedDayTaxoFacets: who persondata +facets:taxonomy:DayOfYear # freq=1196171 freq=246119
+OrHighMedDayTaxoFacets: be uk +facets:taxonomy:DayOfYear # freq=2051702 freq=319211
+OrHighMedDayTaxoFacets: for f +facets:taxonomy:DayOfYear # freq=4380011 freq=278015
+OrHighMedDayTaxoFacets: only hold +facets:taxonomy:DayOfYear # freq=875561 freq=82579
+OrHighMedDayTaxoFacets: new way +facets:taxonomy:DayOfYear # freq=1657293 freq=318344
+OrHighMedDayTaxoFacets: which lines +facets:taxonomy:DayOfYear # freq=1963428 freq=96969
+OrHighMedDayTaxoFacets: has div +facets:taxonomy:DayOfYear # freq=1502961 freq=206057
+OrHighMedDayTaxoFacets: all francisco +facets:taxonomy:DayOfYear # freq=1203572 freq=83200
+OrHighMedDayTaxoFacets: from per +facets:taxonomy:DayOfYear # freq=3224339 freq=283568
+OrHighMedDayTaxoFacets: it marriage +facets:taxonomy:DayOfYear # freq=2675552 freq=97658
+OrHighMedDayTaxoFacets: states small +facets:taxonomy:DayOfYear # freq=1034872 freq=581643
+OrHighMedDayTaxoFacets: 2011 july +facets:taxonomy:DayOfYear # freq=871410 freq=529655
+OrHighMedDayTaxoFacets: and mid +facets:taxonomy:DayOfYear # freq=7318061 freq=126355
+OrHighMedDayTaxoFacets: year copy +facets:taxonomy:DayOfYear # freq=1235231 freq=95252
+OrHighMedDayTaxoFacets: not ft +facets:taxonomy:DayOfYear # freq=1713264 freq=88505
+OrHighMedDayTaxoFacets: this 1988 +facets:taxonomy:DayOfYear # freq=2224932 freq=181327
+OrHighMedDayTaxoFacets: accessdate father +facets:taxonomy:DayOfYear # freq=1228887 freq=175393
+OrHighMedDayTaxoFacets: this continued +facets:taxonomy:DayOfYear # freq=2224932 freq=151209
+OrHighMedDayTaxoFacets: with union +facets:taxonomy:DayOfYear # freq=3709421 freq=214164
+OrHighMedDayTaxoFacets: 2011 festival +facets:taxonomy:DayOfYear # freq=871410 freq=85717
+OrHighMedDayTaxoFacets: states hall +facets:taxonomy:DayOfYear # freq=1034872 freq=177247
+OrHighMedDayTaxoFacets: after thomas +facets:taxonomy:DayOfYear # freq=1247398 freq=191625
+OrHighMedDayTaxoFacets: 2 god +facets:taxonomy:DayOfYear # freq=1549245 freq=97443
+OrHighMedDayTaxoFacets: states owned +facets:taxonomy:DayOfYear # freq=1034872 freq=93981
+OrHighMedDayTaxoFacets: were european +facets:taxonomy:DayOfYear # freq=1524630 freq=193975
+OrHighMedDayTaxoFacets: have jack +facets:taxonomy:DayOfYear # freq=1297121 freq=91552
+OrHighMedDayTaxoFacets: time majority +facets:taxonomy:DayOfYear # freq=1032071 freq=105058
+OrHighMedDayTaxoFacets: were went +facets:taxonomy:DayOfYear # freq=1524630 freq=172677
+OrHighMedDayTaxoFacets: only game +facets:taxonomy:DayOfYear # freq=875561 freq=315157
+OrHighMedDayTaxoFacets: a review +facets:taxonomy:DayOfYear # freq=6560531 freq=240157
+OrHighMedDayTaxoFacets: united thomas +facets:taxonomy:DayOfYear # freq=1196944 freq=191625
+OrHighMedDayTaxoFacets: may off +facets:taxonomy:DayOfYear # freq=1071932 freq=315473
+OrHighMedDayTaxoFacets: url persondata +facets:taxonomy:DayOfYear # freq=1513595 freq=246119
+OrHighMedDayTaxoFacets: new hill +facets:taxonomy:DayOfYear # freq=1657293 freq=133714
+OrHighMedDayTaxoFacets: at ice +facets:taxonomy:DayOfYear # freq=2857534 freq=87086
+OrHighMedDayTaxoFacets: 2008 fourth +facets:taxonomy:DayOfYear # freq=831253 freq=102351
+OrHighMedDayTaxoFacets: for 3rd +facets:taxonomy:DayOfYear # freq=4380011 freq=90723
+OrHighMedDayTaxoFacets: more cross +facets:taxonomy:DayOfYear # freq=963533 freq=127216
+OrHighMedDayTaxoFacets: not index.php +facets:taxonomy:DayOfYear # freq=1713264 freq=126813
+OrHighMedDayTaxoFacets: but census +facets:taxonomy:DayOfYear # freq=1456553 freq=205166
+OrHighMedDayTaxoFacets: work replaced +facets:taxonomy:DayOfYear # freq=853422 freq=112506
+OrHighMedDayTaxoFacets: some groups +facets:taxonomy:DayOfYear # freq=839919 freq=146670
+OrHighMedDayTaxoFacets: 10 collection +facets:taxonomy:DayOfYear # freq=918339 freq=110483
+OrHighMedDayTaxoFacets: not opening +facets:taxonomy:DayOfYear # freq=1713264 freq=84576
+OrHighMedDayTaxoFacets: see september +facets:taxonomy:DayOfYear # freq=1044180 freq=553409
+OrHighMedDayTaxoFacets: 4 steve +facets:taxonomy:DayOfYear # freq=986452 freq=84364
+OrHighMedDayTaxoFacets: ref appears +facets:taxonomy:DayOfYear # freq=3793973 freq=104511
+OrHighMedDayTaxoFacets: a named +facets:taxonomy:DayOfYear # freq=6560531 freq=310150
+OrHighMedDayTaxoFacets: which pre +facets:taxonomy:DayOfYear # freq=1963428 freq=90549
+OrHighMedDayTaxoFacets: has stone +facets:taxonomy:DayOfYear # freq=1502961 freq=92132
+OrHighMedDayTaxoFacets: to energy +facets:taxonomy:DayOfYear # freq=6155577 freq=91150
+OrHighMedDayTaxoFacets: not should +facets:taxonomy:DayOfYear # freq=1713264 freq=401379
+OrHighMedDayTaxoFacets: 2010 media +facets:taxonomy:DayOfYear # freq=950573 freq=206574
+OrHighMedDayTaxoFacets: was behind +facets:taxonomy:DayOfYear # freq=3763623 freq=112070
+OrHighMedDayTaxoFacets: that black +facets:taxonomy:DayOfYear # freq=2931020 freq=256526
+OrHighMedDayTaxoFacets: are itself +facets:taxonomy:DayOfYear # freq=1877802 freq=138231
+OrHighMedDayTaxoFacets: only 90 +facets:taxonomy:DayOfYear # freq=875561 freq=116206
+OrHighMedDayTaxoFacets: 4 main +facets:taxonomy:DayOfYear # freq=986452 freq=470429
+OrHighMedDayTaxoFacets: with august +facets:taxonomy:DayOfYear # freq=3709421 freq=527806
+OrHighMedDayTaxoFacets: have age +facets:taxonomy:DayOfYear # freq=1297121 freq=395368
+OrHighMedDayTaxoFacets: time citation +facets:taxonomy:DayOfYear # freq=1032071 freq=291478
+OrHighMedDayTaxoFacets: his notes +facets:taxonomy:DayOfYear # freq=1777780 freq=210029
+OrHighMedDayTaxoFacets: year 17 +facets:taxonomy:DayOfYear # freq=1235231 freq=507396
+OrHighMedDayTaxoFacets: i bbc +facets:taxonomy:DayOfYear # freq=956148 freq=138548
+OrHighMedDayTaxoFacets: name 1984 +facets:taxonomy:DayOfYear # freq=2827713 freq=161404
+OrHighMedDayTaxoFacets: his greek +facets:taxonomy:DayOfYear # freq=1777780 freq=94348
+OrHighMedDayTaxoFacets: cite votes +facets:taxonomy:DayOfYear # freq=1741194 freq=93844
+OrHighMedDayTaxoFacets: be fire +facets:taxonomy:DayOfYear # freq=2051702 freq=133712
+OrHighMedDayTaxoFacets: in sometimes +facets:taxonomy:DayOfYear # freq=7320987 freq=144078
+OrHighMedDayTaxoFacets: last better +facets:taxonomy:DayOfYear # freq=958437 freq=125889
+OrHighMedDayTaxoFacets: by considered +facets:taxonomy:DayOfYear # freq=3826691 freq=186840
+OrHighMedDayTaxoFacets: no leading +facets:taxonomy:DayOfYear # freq=1045000 freq=120945
+OrHighMedDayTaxoFacets: name influence +facets:taxonomy:DayOfYear # freq=2827713 freq=83101
+OrHighMedDayTaxoFacets: 2009 power +facets:taxonomy:DayOfYear # freq=887702 freq=262586
+OrHighMedDayTaxoFacets: is institute +facets:taxonomy:DayOfYear # freq=4074455 freq=136311
+OrHighMedDayTaxoFacets: into doi +facets:taxonomy:DayOfYear # freq=888684 freq=170085
+OrHighMedDayTaxoFacets: into short +facets:taxonomy:DayOfYear # freq=888684 freq=465205
+OrHighMedDayTaxoFacets: were gr +facets:taxonomy:DayOfYear # freq=1524630 freq=83712
+OrHighMedDayTaxoFacets: has 16 +facets:taxonomy:DayOfYear # freq=1502961 freq=540539
+OrHighMedDayTaxoFacets: this towards +facets:taxonomy:DayOfYear # freq=2224932 freq=95574
+OrHighMedDayTaxoFacets: the div +facets:taxonomy:DayOfYear # freq=8217362 freq=206057
+OrHighMedDayTaxoFacets: its jean +facets:taxonomy:DayOfYear # freq=1173450 freq=84299
+OrHighMedDayTaxoFacets: their continued +facets:taxonomy:DayOfYear # freq=1158682 freq=151209
+OrHighMedDayTaxoFacets: publisher come +facets:taxonomy:DayOfYear # freq=1289029 freq=139047
+OrHighMedDayTaxoFacets: name yet +facets:taxonomy:DayOfYear # freq=2827713 freq=100857
+OrHighMedDayTaxoFacets: be before +facets:taxonomy:DayOfYear # freq=2051702 freq=580481
+OrHighMedDayTaxoFacets: ref britain +facets:taxonomy:DayOfYear # freq=3793973 freq=101080
+OrHighMedDayTaxoFacets: 10 returned +facets:taxonomy:DayOfYear # freq=918339 freq=141639
+OrHighMedDayTaxoFacets: 2006 02 +facets:taxonomy:DayOfYear # freq=889954 freq=319783
+OrHighMedDayTaxoFacets: 2011 daughter +facets:taxonomy:DayOfYear # freq=871410 freq=103883
+OrHighMedDayTaxoFacets: be independent +facets:taxonomy:DayOfYear # freq=2051702 freq=164766
+OrHighMedDayTaxoFacets: more self +facets:taxonomy:DayOfYear # freq=963533 freq=135012
+OrHighMedDayTaxoFacets: in particular +facets:taxonomy:DayOfYear # freq=7320987 freq=103643
+OrHighMedDayTaxoFacets: which non +facets:taxonomy:DayOfYear # freq=1963428 freq=348142
+OrHighMedDayTaxoFacets: his birth +facets:taxonomy:DayOfYear # freq=1777780 freq=425138
+OrHighMedDayTaxoFacets: ref stations +facets:taxonomy:DayOfYear # freq=3793973 freq=92011
+OrHighMedDayTaxoFacets: united include +facets:taxonomy:DayOfYear # freq=1196944 freq=276466
+OrHighMedDayTaxoFacets: http flight +facets:taxonomy:DayOfYear # freq=3493581 freq=84316
+OrHighMedDayTaxoFacets: http singles +facets:taxonomy:DayOfYear # freq=3493581 freq=89221
+OrHighMedDayTaxoFacets: year northern +facets:taxonomy:DayOfYear # freq=1235231 freq=194363
+OrHighMedDayTaxoFacets: been htm +facets:taxonomy:DayOfYear # freq=1041183 freq=191479
+OrHighMedDayTaxoFacets: one alone +facets:taxonomy:DayOfYear # freq=1527689 freq=93166
+OrHighMedDayTaxoFacets: their systems +facets:taxonomy:DayOfYear # freq=1158682 freq=134476
+OrHighMedDayTaxoFacets: to yet +facets:taxonomy:DayOfYear # freq=6155577 freq=100857
+OrHighMedDayTaxoFacets: see leader +facets:taxonomy:DayOfYear # freq=1044180 freq=127591
+OrHighMedDayTaxoFacets: on seen +facets:taxonomy:DayOfYear # freq=4074624 freq=173530
+OrHighMedDayTaxoFacets: has 200px +facets:taxonomy:DayOfYear # freq=1502961 freq=102661
+OrHighMedDayTaxoFacets: that 56 +facets:taxonomy:DayOfYear # freq=2931020 freq=96215
+OrHighMedDayTaxoFacets: about women +facets:taxonomy:DayOfYear # freq=850283 freq=128847
+OrHighMedDayTaxoFacets: only michael +facets:taxonomy:DayOfYear # freq=875561 freq=217311
+OrHighMedDayTaxoFacets: 2009 provided +facets:taxonomy:DayOfYear # freq=887702 freq=110088
+OrHighMedDayTaxoFacets: with show +facets:taxonomy:DayOfYear # freq=3709421 freq=293934
+OrHighMedDayTaxoFacets: 2011 utc +facets:taxonomy:DayOfYear # freq=871410 freq=450225
+OrHighMedDayTaxoFacets: which give +facets:taxonomy:DayOfYear # freq=1963428 freq=116375
+OrHighMedDayTaxoFacets: 2010 support +facets:taxonomy:DayOfYear # freq=950573 freq=236989
+OrHighMedDayTaxoFacets: 4 very +facets:taxonomy:DayOfYear # freq=986452 freq=354898
+OrHighMedDayTaxoFacets: 2 foreign +facets:taxonomy:DayOfYear # freq=1549245 freq=109174
+OrHighMedDayTaxoFacets: were 59 +facets:taxonomy:DayOfYear # freq=1524630 freq=93856
+OrHighMedDayTaxoFacets: 2010 take +facets:taxonomy:DayOfYear # freq=950573 freq=224260
+OrHighMedDayTaxoFacets: by york +facets:taxonomy:DayOfYear # freq=3826691 freq=521383
+OrHighMedDayTaxoFacets: http kingdom +facets:taxonomy:DayOfYear # freq=3493581 freq=299825
+OrHighMedDayTaxoFacets: only brother +facets:taxonomy:DayOfYear # freq=875561 freq=110146
+OrHighMedDayTaxoFacets: no died +facets:taxonomy:DayOfYear # freq=1045000 freq=202125
+OrHighMedDayTaxoFacets: other november +facets:taxonomy:DayOfYear # freq=1269961 freq=527131
+OrHighMedDayTaxoFacets: 2008 system +facets:taxonomy:DayOfYear # freq=831253 freq=412862
+OrHighMedDayTaxoFacets: 5 still +facets:taxonomy:DayOfYear # freq=891361 freq=332543
+OrHighMedDayTaxoFacets: by required +facets:taxonomy:DayOfYear # freq=3826691 freq=100578
+OrHighMedDayTaxoFacets: title era +facets:taxonomy:DayOfYear # freq=2397378 freq=95989
+OrHighMedDayTaxoFacets: 3 larger +facets:taxonomy:DayOfYear # freq=1148799 freq=87424
+OrHighMedDayTaxoFacets: into within +facets:taxonomy:DayOfYear # freq=888684 freq=291049
+OrHighMedDayTaxoFacets: http where +facets:taxonomy:DayOfYear # freq=3493581 freq=630647
+OrHighMedDayTaxoFacets: united say +facets:taxonomy:DayOfYear # freq=1196944 freq=110895
+OrHighMedDayTaxoFacets: no second +facets:taxonomy:DayOfYear # freq=1045000 freq=505575
+OrHighMedDayTaxoFacets: work 1998 +facets:taxonomy:DayOfYear # freq=853422 freq=300506
+OrHighMedDayTaxoFacets: 1 think +facets:taxonomy:DayOfYear # freq=1641090 freq=129332
+OrHighMedDayTaxoFacets: by b +facets:taxonomy:DayOfYear # freq=3826691 freq=369454
+OrHighMedDayTaxoFacets: 4 thumb +facets:taxonomy:DayOfYear # freq=986452 freq=672667
+OrHighMedDayTaxoFacets: be usa +facets:taxonomy:DayOfYear # freq=2051702 freq=191220
+OrHighMedDayTaxoFacets: not african +facets:taxonomy:DayOfYear # freq=1713264 freq=128682
+OrHighMedDayTaxoFacets: 1 president +facets:taxonomy:DayOfYear # freq=1641090 freq=263341
+OrHighMedDayTaxoFacets: 4 worked +facets:taxonomy:DayOfYear # freq=986452 freq=119896
+OrHighMedDayTaxoFacets: http added +facets:taxonomy:DayOfYear # freq=3493581 freq=138409
+OrHighMedDayTaxoFacets: s deletion +facets:taxonomy:DayOfYear # freq=1581243 freq=166633
+OrHighMedDayTaxoFacets: time nbsp +facets:taxonomy:DayOfYear # freq=1032071 freq=506054
+OrHighMedDayTaxoFacets: when 02 +facets:taxonomy:DayOfYear # freq=1027487 freq=319783
+OrHighMedDayTaxoFacets: may la +facets:taxonomy:DayOfYear # freq=1071932 freq=232610
+OrHighMedDayTaxoFacets: 2 royal +facets:taxonomy:DayOfYear # freq=1549245 freq=211710
+OrHighMedDayTaxoFacets: from office +facets:taxonomy:DayOfYear # freq=3224339 freq=225338
+OrHighMedDayTaxoFacets: and 22 +facets:taxonomy:DayOfYear # freq=7318061 freq=502778
+OrHighMedDayTaxoFacets: cite order +facets:taxonomy:DayOfYear # freq=1741194 freq=360915
+OrHighMedDayTaxoFacets: of upper +facets:taxonomy:DayOfYear # freq=8184358 freq=86379
+OrHighMedDayTaxoFacets: all htm +facets:taxonomy:DayOfYear # freq=1203572 freq=191479
+OrHighMedDayTaxoFacets: he towards +facets:taxonomy:DayOfYear # freq=1659434 freq=95574
+OrHighMedDayTaxoFacets: are traditional +facets:taxonomy:DayOfYear # freq=1877802 freq=110425
+OrHighMedDayTaxoFacets: a team +facets:taxonomy:DayOfYear # freq=6560531 freq=379028
+OrHighMedDayTaxoFacets: or imagesize +facets:taxonomy:DayOfYear # freq=1858841 freq=82746
+OrHighMedDayTaxoFacets: date regular +facets:taxonomy:DayOfYear # freq=2020626 freq=93809
+OrHighMedDayTaxoFacets: or birth_date +facets:taxonomy:DayOfYear # freq=1858841 freq=122665
+OrHighMedDayTaxoFacets: name each +facets:taxonomy:DayOfYear # freq=2827713 freq=354583
+OrHighMedDayTaxoFacets: but begin +facets:taxonomy:DayOfYear # freq=1456553 freq=104303
+OrHighMedDayTaxoFacets: 2 developed +facets:taxonomy:DayOfYear # freq=1549245 freq=151220
+OrHighMedDayTaxoFacets: ref note +facets:taxonomy:DayOfYear # freq=3793973 freq=194472
+OrHighMedDayTaxoFacets: united programs +facets:taxonomy:DayOfYear # freq=1196944 freq=83974
+
+# Range facet tasks -- non-overlapping uses NonOverlappingLongRangeFacetCutter,
+# overlapping uses OverlappingLongRangeFacetCutter (segment tree).
+# lastMod is SORTED_NUMERIC (multi-value leaf cutter); id is NUMERIC (single-value leaf cutter).
+BrowseLastModRangeFacets: *:* +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000
+BrowseLastModOvlpRangeFacets: *:* +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000
+BrowseIDRangeFacets: *:* +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000
+BrowseIDOvlpRangeFacets: *:* +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999
+
+MedTermLastModRangeFacets: most +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=819634
+MedTermLastModRangeFacets: up +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=818546
+MedTermLastModRangeFacets: world +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=808563
+MedTermLastModRangeFacets: 2007 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=801586
+MedTermLastModRangeFacets: during +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=798114
+MedTermLastModRangeFacets: people +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=790960
+MedTermLastModRangeFacets: years +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=789628
+MedTermLastModRangeFacets: such +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=787877
+MedTermLastModRangeFacets: 12 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=774572
+MedTermLastModRangeFacets: over +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=774312
+MedTermLastModRangeFacets: can +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=765163
+MedTermLastModRangeFacets: references +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=760306
+MedTermLastModRangeFacets: city +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=760272
+MedTermLastModRangeFacets: 6 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=759234
+MedTermLastModRangeFacets: american +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=758337
+MedTermLastModRangeFacets: news +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=756063
+MedTermLastModRangeFacets: history +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=755471
+MedTermLastModRangeFacets: 0 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=754451
+MedTermLastModRangeFacets: made +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=742313
+MedTermLastModRangeFacets: out +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=733775
+MedTermLastModRangeFacets: 11 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=730505
+MedTermLastModRangeFacets: used +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=708455
+MedTermLastModRangeFacets: links +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=703350
+MedTermLastModRangeFacets: state +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=702598
+MedTermLastModRangeFacets: many +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=694439
+MedTermLastModRangeFacets: would +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=690480
+MedTermLastModRangeFacets: page +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=681036
+MedTermLastModRangeFacets: national +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=677281
+MedTermLastModRangeFacets: than +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=676864
+MedTermLastModRangeFacets: thumb +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=672667
+MedTermLastModRangeFacets: 7 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=660220
+MedTermLastModRangeFacets: place +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=654158
+MedTermLastModRangeFacets: de +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=652242
+MedTermLastModRangeFacets: if +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=640551
+MedTermLastModRangeFacets: university +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=636959
+MedTermLastModRangeFacets: 8 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=635822
+MedTermLastModRangeFacets: external +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=635450
+MedTermLastModRangeFacets: between +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=630650
+MedTermLastModRangeFacets: where +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=630647
+MedTermLastModRangeFacets: right +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=630423
+MedTermLastModRangeFacets: 20 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=624967
+MedTermLastModRangeFacets: under +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=623872
+MedTermLastModRangeFacets: these +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=623267
+MedTermLastModRangeFacets: march +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=620393
+MedTermLastModRangeFacets: br +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=617824
+MedTermLastModRangeFacets: book +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=617297
+MedTermLastModRangeFacets: p +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=616159
+MedTermLastModRangeFacets: article +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=610650
+MedTermLastModRangeFacets: known +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=607158
+MedTermLastModRangeFacets: then +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=606159
+MedTermLastModRangeFacets: style +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=606000
+MedTermLastModRangeFacets: later +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=604921
+MedTermLastModRangeFacets: three +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=598349
+MedTermLastModRangeFacets: use +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=597053
+MedTermLastModRangeFacets: category +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=595446
+MedTermLastModRangeFacets: john +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=594461
+MedTermLastModRangeFacets: part +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=594224
+MedTermLastModRangeFacets: left +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=593967
+MedTermLastModRangeFacets: 2004 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=593934
+MedTermLastModRangeFacets: 15 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=592407
+MedTermLastModRangeFacets: december +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=590171
+MedTermLastModRangeFacets: april +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=587542
+MedTermLastModRangeFacets: list +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=585922
+MedTermLastModRangeFacets: 18 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=585631
+MedTermLastModRangeFacets: small +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=581643
+MedTermLastModRangeFacets: january +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=581309
+MedTermLastModRangeFacets: before +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=580481
+MedTermLastModRangeFacets: being +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=580185
+MedTermLastModRangeFacets: well +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=580011
+MedTermLastModRangeFacets: id +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=579566
+MedTermLastModRangeFacets: while +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=579117
+MedTermLastModRangeFacets: 9 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=574434
+MedTermLastModRangeFacets: death +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=568895
+MedTermLastModRangeFacets: author +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=567768
+MedTermLastModRangeFacets: however +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=566494
+MedTermLastModRangeFacets: october +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=566229
+MedTermLastModRangeFacets: north +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=564195
+MedTermLastModRangeFacets: so +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=562598
+MedTermLastModRangeFacets: reflist +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=561253
+MedTermLastModRangeFacets: south +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=560468
+MedTermLastModRangeFacets: area +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=559023
+MedTermLastModRangeFacets: class +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=556838
+MedTermLastModRangeFacets: september +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=553409
+MedTermLastModRangeFacets: war +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=547417
+MedTermLastModRangeFacets: image +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=541747
+MedTermLastModRangeFacets: 16 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=540539
+MedTermLastModRangeFacets: both +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=534900
+MedTermLastModRangeFacets: 14 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=534005
+MedTermLastModRangeFacets: 13 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=530419
+MedTermLastModRangeFacets: july +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=529655
+MedTermLastModRangeFacets: august +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=527806
+MedTermLastModRangeFacets: november +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=527131
+MedTermLastModRangeFacets: end +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=526636
+MedTermLastModRangeFacets: february +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=524886
+MedTermLastModRangeFacets: infobox +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=524810
+MedTermLastModRangeFacets: june +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=522519
+MedTermLastModRangeFacets: series +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=521861
+MedTermLastModRangeFacets: york +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=521383
+MedTermLastModRangeFacets: including +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=521324
+MedTermLastModRangeFacets: county +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=521126
+MedTermLastModRangeFacets: them +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=520298
+MedTermLastModRangeFacets: her +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=518717
+MedTermLastModRangeFacets: through +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=514966
+MedTermLastModRangeFacets: do +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=511178
+MedTermLastModRangeFacets: 17 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=507396
+MedTermLastModRangeFacets: him +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=507350
+MedTermLastModRangeFacets: nbsp +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=506054
+MedTermLastModRangeFacets: second +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=505575
+MedTermLastModRangeFacets: 22 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=502778
+MedTermLastModRangeFacets: html +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=500198
+MedTermLastModRangeFacets: 2000 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=499639
+MedTermLastModRangeFacets: 25 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=491957
+MedTermLastModRangeFacets: location +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=489791
+MedTermLastModRangeFacets: will +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=489711
+MedTermLastModRangeFacets: center +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=489673
+MedTermLastModRangeFacets: 30 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=488930
+MedTermLastModRangeFacets: since +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=485325
+MedTermLastModRangeFacets: 19 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=484187
+MedTermLastModRangeFacets: now +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=484114
+MedTermLastModRangeFacets: any +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=483514
+MedTermLastModRangeFacets: early +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=482793
+MedTermLastModRangeFacets: 21 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=482314
+MedTermLastModRangeFacets: high +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=482152
+MedTermLastModRangeFacets: like +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=479390
+MedTermLastModRangeFacets: life +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=477007
+MedTermLastModRangeFacets: general +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=476690
+MedTermLastModRangeFacets: music +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=473240
+MedTermLastModRangeFacets: number +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=473154
+MedTermLastModRangeFacets: 24 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=470708
+MedTermLastModRangeFacets: main +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=470429
+MedTermLastModRangeFacets: isbn +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=467574
+MedTermLastModRangeFacets: pages +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=466290
+MedTermLastModRangeFacets: became +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=465594
+MedTermLastModRangeFacets: short +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=465205
+MedTermLastModRangeFacets: school +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=462166
+MedTermLastModRangeFacets: you +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=461587
+MedTermLastModRangeFacets: 23 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=457097
+MedTermLastModRangeFacets: 2003 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=456990
+MedTermLastModRangeFacets: called +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=454580
+MedTermLastModRangeFacets: utc +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=450225
+MedTermLastModRangeFacets: n +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=449994
+MedTermLastModRangeFacets: c +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=444247
+MedTermLastModRangeFacets: group +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=442503
+MedTermLastModRangeFacets: m +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=441232
+MedTermLastModRangeFacets: several +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=436129
+MedTermLastModRangeFacets: website +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=435941
+MedTermLastModRangeFacets: film +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=432758
+MedTermLastModRangeFacets: west +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=431006
+MedTermLastModRangeFacets: u.s +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=428534
+MedTermLastModRangeFacets: she +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=426267
+MedTermLastModRangeFacets: until +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=425389
+MedTermLastModRangeFacets: birth +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=425138
+MedTermLastModRangeFacets: us +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=421210
+MedTermLastModRangeFacets: same +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=420741
+MedTermLastModRangeFacets: country +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=420052
+MedTermLastModRangeFacets: international +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=418261
+MedTermLastModRangeFacets: british +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=417307
+MedTermLastModRangeFacets: language +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=416771
+MedTermLastModRangeFacets: following +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=416515
+MedTermLastModRangeFacets: because +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=413003
+MedTermLastModRangeFacets: system +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=412862
+MedTermLastModRangeFacets: english +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=412061
+MedTermLastModRangeFacets: 2001 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=410364
+MedTermLastModRangeFacets: e +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=408741
+MedTermLastModRangeFacets: times +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=407155
+MedTermLastModRangeFacets: 2002 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=406953
+MedTermLastModRangeFacets: names +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=404796
+MedTermLastModRangeFacets: w +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=404764
+MedTermLastModRangeFacets: day +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=402096
+MedTermLastModRangeFacets: should +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=401379
+MedTermLastModRangeFacets: against +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=399228
+MedTermLastModRangeFacets: press +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=398988
+MedTermLastModRangeFacets: based +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=398415
+MedTermLastModRangeFacets: age +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=395368
+MedTermLastModRangeFacets: what +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=394675
+MedTermLastModRangeFacets: party +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=394410
+MedTermLastModRangeFacets: company +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=391520
+MedTermLastModRangeFacets: four +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=389818
+MedTermLastModRangeFacets: 28 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=389552
+MedTermLastModRangeFacets: 26 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=389026
+MedTermLastModRangeFacets: family +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=387175
+MedTermLastModRangeFacets: long +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=385787
+MedTermLastModRangeFacets: century +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=385541
+MedTermLastModRangeFacets: government +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=384004
+MedTermLastModRangeFacets: 27 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=383042
+MedTermLastModRangeFacets: old +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=381809
+MedTermLastModRangeFacets: team +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=379028
+MedTermLastModRangeFacets: house +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=377336
+MedTermLastModRangeFacets: population +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=374481
+MedTermLastModRangeFacets: 29 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=372091
+MedTermLastModRangeFacets: b +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=369454
+MedTermLastModRangeFacets: public +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=368868
+MedTermLastModRangeFacets: home +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=367819
+MedTermLastModRangeFacets: top +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=364628
+MedTermLastModRangeFacets: east +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=364582
+MedTermLastModRangeFacets: talk +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=364194
+MedTermLastModRangeFacets: order +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=360915
+MedTermLastModRangeFacets: line +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=360442
+MedTermLastModRangeFacets: could +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=356679
+MedTermLastModRangeFacets: 2012 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=355641
+MedTermLastModRangeFacets: description +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=355070
+MedTermLastModRangeFacets: very +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=354898
+MedTermLastModRangeFacets: each +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=354583
+MedTermLastModRangeFacets: information +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=353153
+MedTermLastModRangeFacets: another +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=352496
+MedTermLastModRangeFacets: born +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=352196
+MedTermLastModRangeFacets: back +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=349276
+MedTermLastModRangeFacets: london +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=348918
+MedTermLastModRangeFacets: just +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=348911
+MedTermLastModRangeFacets: town +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=348598
+MedTermLastModRangeFacets: journal +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=348162
+MedTermLastModRangeFacets: non +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=348142
+MedTermLastModRangeFacets: color +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=347941
+MedTermLastModRangeFacets: 01 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=347922
+MedTermLastModRangeFacets: great +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=347499
+MedTermLastModRangeFacets: although +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=341432
+MedTermLastModRangeFacets: books +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=341376
+MedTermLastModRangeFacets: ii +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=340800
+MedTermLastModRangeFacets: major +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=340345
+MedTermLastModRangeFacets: further +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=339350
+MedTermLastModRangeFacets: 1999 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=334887
+MedTermLastModRangeFacets: around +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=334840
+MedTermLastModRangeFacets: best +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=334550
+MedTermLastModRangeFacets: former +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=332750
+MedTermLastModRangeFacets: still +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=332543
+MedTermLastModRangeFacets: album +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=331360
+MedTermLastModRangeFacets: stub +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=329768
+MedTermLastModRangeFacets: did +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=328303
+MedTermLastModRangeFacets: j +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=327713
+MedTermLastModRangeFacets: even +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=326231
+MedTermLastModRangeFacets: official +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=326177
+MedTermLastModRangeFacets: original +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=323521
+MedTermLastModRangeFacets: user +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=323242
+MedTermLastModRangeFacets: alternative +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=322536
+MedTermLastModRangeFacets: released +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=322473
+MedTermLastModRangeFacets: jpg +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=322278
+MedTermLastModRangeFacets: issue +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=322106
+MedTermLastModRangeFacets: own +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=321703
+MedTermLastModRangeFacets: season +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=320228
+MedTermLastModRangeFacets: those +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=320013
+MedTermLastModRangeFacets: 02 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=319783
+MedTermLastModRangeFacets: uk +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=319211
+MedTermLastModRangeFacets: way +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=318344
+MedTermLastModRangeFacets: type +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=318210
+MedTermLastModRangeFacets: 03 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=318112
+MedTermLastModRangeFacets: england +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=317884
+MedTermLastModRangeFacets: much +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=317670
+MedTermLastModRangeFacets: off +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=315473
+MedTermLastModRangeFacets: game +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=315157
+MedTermLastModRangeFacets: background +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=314229
+MedTermLastModRangeFacets: 04 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=313827
+MedTermLastModRangeFacets: found +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=313247
+MedTermLastModRangeFacets: volume +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=312846
+MedTermLastModRangeFacets: named +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=310150
+MedTermLastModRangeFacets: service +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=309976
+MedTermLastModRangeFacets: d +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=309729
+MedTermLastModRangeFacets: st +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=309092
+MedTermLastModRangeFacets: large +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=308888
+MedTermLastModRangeFacets: often +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=307684
+MedTermLastModRangeFacets: 06 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=305698
+MedTermLastModRangeFacets: 05 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=302860
+MedTermLastModRangeFacets: 1998 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=300506
+MedTermLastModRangeFacets: align +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=300455
+MedTermLastModRangeFacets: kingdom +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=299825
+MedTermLastModRangeFacets: using +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=299474
+MedTermLastModRangeFacets: white +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=299411
+MedTermLastModRangeFacets: 07 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=299351
+MedTermLastModRangeFacets: district +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=299108
+MedTermLastModRangeFacets: local +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=299012
+MedTermLastModRangeFacets: metadata +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=298533
+MedTermLastModRangeFacets: 31 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=298349
+MedTermLastModRangeFacets: 08 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=297258
+MedTermLastModRangeFacets: 09 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=296300
+MedTermLastModRangeFacets: r +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=296283
+MedTermLastModRangeFacets: set +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=294255
+MedTermLastModRangeFacets: show +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=293934
+MedTermLastModRangeFacets: david +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=292847
+MedTermLastModRangeFacets: make +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=292607
+MedTermLastModRangeFacets: story +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=292404
+MedTermLastModRangeFacets: citation +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=291478
+MedTermLastModRangeFacets: within +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=291049
+MedTermLastModRangeFacets: due +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=290531
+MedTermLastModRangeFacets: link +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=287552
+MedTermLastModRangeFacets: 1997 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=286789
+MedTermLastModRangeFacets: members +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=286028
+MedTermLastModRangeFacets: william +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=284592
+MedTermLastModRangeFacets: along +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=284442
+MedTermLastModRangeFacets: v +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=284318
+MedTermLastModRangeFacets: located +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=283899
+MedTermLastModRangeFacets: single +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=283824
+MedTermLastModRangeFacets: per +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=283568
+MedTermLastModRangeFacets: established +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=282471
+MedTermLastModRangeFacets: james +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=281597
+MedTermLastModRangeFacets: needed +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=281051
+MedTermLastModRangeFacets: down +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=280662
+MedTermLastModRangeFacets: present +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=278449
+MedTermLastModRangeFacets: man +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=278112
+MedTermLastModRangeFacets: college +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=278094
+MedTermLastModRangeFacets: f +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=278015
+MedTermLastModRangeFacets: site +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=277788
+MedTermLastModRangeFacets: football +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=277738
+MedTermLastModRangeFacets: en +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=277463
+MedTermLastModRangeFacets: result +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=276803
+MedTermLastModRangeFacets: include +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=276466
+MedTermLastModRangeFacets: began +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=276036
+MedTermLastModRangeFacets: my +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=274256
+MedTermLastModRangeFacets: x +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=272695
+MedTermLastModRangeFacets: central +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=272531
+MedTermLastModRangeFacets: band +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=272207
+MedTermLastModRangeFacets: 1996 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=271980
+MedTermLastModRangeFacets: form +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=271966
+MedTermLastModRangeFacets: member +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=271607
+MedTermLastModRangeFacets: television +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=271426
+MedTermLastModRangeFacets: league +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=270223
+MedTermLastModRangeFacets: free +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=270199
+MedTermLastModRangeFacets: political +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=269665
+MedTermLastModRangeFacets: font +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=269439
+MedTermLastModRangeFacets: 100 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=268978
+MedTermLastModRangeFacets: convert +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=267974
+MedTermLastModRangeFacets: red +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=266177
+MedTermLastModRangeFacets: president +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=263341
+MedTermLastModRangeFacets: five +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=262923
+MedTermLastModRangeFacets: t +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=262832
+MedTermLastModRangeFacets: power +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=262586
+MedTermLastModRangeFacets: river +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=262231
+MedTermLastModRangeFacets: we +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=261001
+MedTermLastModRangeFacets: song +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=260741
+MedTermLastModRangeFacets: next +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=259039
+MedTermLastModRangeFacets: articles +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=258949
+MedTermLastModRangeFacets: point +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=258471
+MedTermLastModRangeFacets: text +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=257803
+MedTermLastModRangeFacets: according +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=256949
+MedTermLastModRangeFacets: black +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=256526
+MedTermLastModRangeFacets: george +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=256196
+MedTermLastModRangeFacets: different +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=255951
+MedTermLastModRangeFacets: ndash +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=255747
+MedTermLastModRangeFacets: third +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=255690
+MedTermLastModRangeFacets: tv +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=255429
+MedTermLastModRangeFacets: law +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=255248
+MedTermLastModRangeFacets: canada +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=254867
+MedTermLastModRangeFacets: near +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=254492
+MedTermLastModRangeFacets: built +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=254491
+MedTermLastModRangeFacets: 1995 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=252837
+MedTermLastModRangeFacets: how +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=252284
+MedTermLastModRangeFacets: record +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=250484
+MedTermLastModRangeFacets: french +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=250453
+MedTermLastModRangeFacets: air +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=250411
+MedTermLastModRangeFacets: king +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=250321
+MedTermLastModRangeFacets: without +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=249926
+MedTermLastModRangeFacets: though +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=248968
+MedTermLastModRangeFacets: played +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=248191
+MedTermLastModRangeFacets: park +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=247801
+MedTermLastModRangeFacets: took +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=247388
+MedTermLastModRangeFacets: association +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=247156
+MedTermLastModRangeFacets: military +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=246727
+MedTermLastModRangeFacets: robert +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=246405
+MedTermLastModRangeFacets: above +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=246135
+MedTermLastModRangeFacets: persondata +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=246119
+MedTermLastModRangeFacets: career +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=245439
+MedTermLastModRangeFacets: version +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=244541
+MedTermLastModRangeFacets: again +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=244255
+MedTermLastModRangeFacets: late +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=243636
+MedTermLastModRangeFacets: published +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=243548
+MedTermLastModRangeFacets: live +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=242147
+MedTermLastModRangeFacets: h +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=241946
+MedTermLastModRangeFacets: good +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=241649
+MedTermLastModRangeFacets: player +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=241451
+MedTermLastModRangeFacets: others +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=240487
+MedTermLastModRangeFacets: america +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=240374
+MedTermLastModRangeFacets: review +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=240157
+MedTermLastModRangeFacets: station +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=239572
+MedTermLastModRangeFacets: among +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=238986
+MedTermLastModRangeFacets: section +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=238874
+MedTermLastModRangeFacets: border +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=238540
+MedTermLastModRangeFacets: your +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=237723
+MedTermLastModRangeFacets: size +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=237662
+MedTermLastModRangeFacets: births +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=237033
+MedTermLastModRangeFacets: support +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=236989
+MedTermLastModRangeFacets: german +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=236721
+MedTermLastModRangeFacets: california +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=236086
+MedTermLastModRangeFacets: given +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=235719
+MedTermLastModRangeFacets: commons +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=235235
+MedTermLastModRangeFacets: 1994 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=235100
+MedTermLastModRangeFacets: start +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=233925
+MedTermLastModRangeFacets: km +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=233831
+MedTermLastModRangeFacets: said +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=233066
+MedTermLastModRangeFacets: western +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=232781
+MedTermLastModRangeFacets: won +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=232751
+MedTermLastModRangeFacets: la +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=232610
+MedTermLastModRangeFacets: held +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=232354
+MedTermLastModRangeFacets: children +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=232342
+MedTermLastModRangeFacets: does +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=232202
+MedTermLastModRangeFacets: club +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=232173
+MedTermLastModRangeFacets: source +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=231838
+MedTermLastModRangeFacets: church +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=231667
+MedTermLastModRangeFacets: format +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=231300
+MedTermLastModRangeFacets: example +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=230457
+MedTermLastModRangeFacets: development +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=230286
+MedTermLastModRangeFacets: land +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=230284
+MedTermLastModRangeFacets: total +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=230013
+MedTermLastModRangeFacets: final +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=230006
+MedTermLastModRangeFacets: 50 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=229614
+MedTermLastModRangeFacets: please +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=229602
+MedTermLastModRangeFacets: region +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=229561
+MedTermLastModRangeFacets: here +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=229505
+MedTermLastModRangeFacets: me +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=229204
+MedTermLastModRangeFacets: caption +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=229172
+MedTermLastModRangeFacets: must +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=228491
+MedTermLastModRangeFacets: army +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=228105
+MedTermLastModRangeFacets: l +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=227974
+MedTermLastModRangeFacets: side +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=227747
+MedTermLastModRangeFacets: society +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=226742
+MedTermLastModRangeFacets: full +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=226457
+MedTermLastModRangeFacets: few +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=226422
+MedTermLastModRangeFacets: records +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=225886
+MedTermLastModRangeFacets: below +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=225843
+MedTermLastModRangeFacets: community +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=225571
+MedTermLastModRangeFacets: office +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=225338
+MedTermLastModRangeFacets: 1992 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=225200
+MedTermLastModRangeFacets: road +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=225050
+MedTermLastModRangeFacets: research +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=224925
+MedTermLastModRangeFacets: various +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=224593
+MedTermLastModRangeFacets: take +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=224260
+MedTermLastModRangeFacets: wikipedia:persondata +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=222385
+MedTermLastModRangeFacets: 1990 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=222154
+MedTermLastModRangeFacets: 40 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=221687
+MedTermLastModRangeFacets: created +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=220831
+MedTermLastModRangeFacets: 1993 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=220776
+MedTermLastModRangeFacets: france +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=220058
+MedTermLastModRangeFacets: science +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=219988
+MedTermLastModRangeFacets: every +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=219884
+MedTermLastModRangeFacets: become +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=219753
+MedTermLastModRangeFacets: modern +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=218831
+MedTermLastModRangeFacets: post +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=218570
+MedTermLastModRangeFacets: games +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=218434
+MedTermLastModRangeFacets: michael +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=217311
+MedTermLastModRangeFacets: current +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=217174
+MedTermLastModRangeFacets: included +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=216978
+MedTermLastModRangeFacets: ja +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=216549
+MedTermLastModRangeFacets: magazine +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=215725
+MedTermLastModRangeFacets: position +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=215493
+MedTermLastModRangeFacets: australia +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=215391
+MedTermLastModRangeFacets: archive +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=215381
+MedTermLastModRangeFacets: union +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=214164
+MedTermLastModRangeFacets: having +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=213416
+MedTermLastModRangeFacets: g +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=212936
+MedTermLastModRangeFacets: popular +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=212493
+MedTermLastModRangeFacets: royal +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=211710
+MedTermLastModRangeFacets: period +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=211690
+MedTermLastModRangeFacets: little +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=211124
+MedTermLastModRangeFacets: wikitable +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=210990
+MedTermLastModRangeFacets: rock +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=210815
+MedTermLastModRangeFacets: artist +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=210591
+MedTermLastModRangeFacets: play +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=210199
+MedTermLastModRangeFacets: led +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=210033
+MedTermLastModRangeFacets: notes +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=210029
+MedTermLastModRangeFacets: water +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=209444
+MedTermLastModRangeFacets: business +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=209353
+MedTermLastModRangeFacets: art +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=209322
+MedTermLastModRangeFacets: common +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=209310
+MedTermLastModRangeFacets: co +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=209086
+MedTermLastModRangeFacets: education +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=208909
+MedTermLastModRangeFacets: role +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=208579
+MedTermLastModRangeFacets: 1991 +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=207589
+MedTermLastModRangeFacets: case +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=207307
+MedTermLastModRangeFacets: paul +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=207229
+MedTermLastModRangeFacets: media +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=206574
+MedTermLastModRangeFacets: div +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=206057
+MedTermLastModRangeFacets: census +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=205166
+MedTermLastModRangeFacets: charles +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=204987
+MedTermLastModRangeFacets: written +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=204891
+MedTermLastModRangeFacets: pp +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=204742
+MedTermLastModRangeFacets: green +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=203371
+MedTermLastModRangeFacets: island +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=203023
+MedTermLastModRangeFacets: never +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=203017
+MedTermLastModRangeFacets: making +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=203003
+MedTermLastModRangeFacets: term +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=202691
+MedTermLastModRangeFacets: video +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=202380
+MedTermLastModRangeFacets: son +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=202340
+MedTermLastModRangeFacets: discussion +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=202145
+MedTermLastModRangeFacets: died +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=202125
+MedTermLastModRangeFacets: view +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=201593
+MedTermLastModRangeFacets: street +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=200985
+MedTermLastModRangeFacets: council +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=200706
+MedTermLastModRangeFacets: re +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=199632
+MedTermLastModRangeFacets: award +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=199318
+MedTermLastModRangeFacets: works +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=199177
+MedTermLastModRangeFacets: special +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=198917
+MedTermLastModRangeFacets: force +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=198556
+MedTermLastModRangeFacets: six +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=197970
+MedTermLastModRangeFacets: came +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=197126
+MedTermLastModRangeFacets: building +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=196508
+MedTermLastModRangeFacets: young +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=196428
+MedTermLastModRangeFacets: together +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=195949
+MedTermLastModRangeFacets: important +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=195851
+MedTermLastModRangeFacets: star +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=195768
+MedTermLastModRangeFacets: similar +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=195171
+MedTermLastModRangeFacets: received +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=194983
+MedTermLastModRangeFacets: sup +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=194723
+MedTermLastModRangeFacets: head +facets:range:long|lastMod|1041379200000-1100000000000,1150000000000-1230768000000,1280000000000-1325376000000 # freq=194682
+
+MedTermLastModOvlpRangeFacets: most +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=819634
+MedTermLastModOvlpRangeFacets: up +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=818546
+MedTermLastModOvlpRangeFacets: world +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=808563
+MedTermLastModOvlpRangeFacets: 2007 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=801586
+MedTermLastModOvlpRangeFacets: during +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=798114
+MedTermLastModOvlpRangeFacets: people +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=790960
+MedTermLastModOvlpRangeFacets: years +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=789628
+MedTermLastModOvlpRangeFacets: such +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=787877
+MedTermLastModOvlpRangeFacets: 12 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=774572
+MedTermLastModOvlpRangeFacets: over +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=774312
+MedTermLastModOvlpRangeFacets: can +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=765163
+MedTermLastModOvlpRangeFacets: references +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=760306
+MedTermLastModOvlpRangeFacets: city +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=760272
+MedTermLastModOvlpRangeFacets: 6 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=759234
+MedTermLastModOvlpRangeFacets: american +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=758337
+MedTermLastModOvlpRangeFacets: news +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=756063
+MedTermLastModOvlpRangeFacets: history +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=755471
+MedTermLastModOvlpRangeFacets: 0 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=754451
+MedTermLastModOvlpRangeFacets: made +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=742313
+MedTermLastModOvlpRangeFacets: out +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=733775
+MedTermLastModOvlpRangeFacets: 11 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=730505
+MedTermLastModOvlpRangeFacets: used +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=708455
+MedTermLastModOvlpRangeFacets: links +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=703350
+MedTermLastModOvlpRangeFacets: state +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=702598
+MedTermLastModOvlpRangeFacets: many +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=694439
+MedTermLastModOvlpRangeFacets: would +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=690480
+MedTermLastModOvlpRangeFacets: page +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=681036
+MedTermLastModOvlpRangeFacets: national +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=677281
+MedTermLastModOvlpRangeFacets: than +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=676864
+MedTermLastModOvlpRangeFacets: thumb +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=672667
+MedTermLastModOvlpRangeFacets: 7 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=660220
+MedTermLastModOvlpRangeFacets: place +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=654158
+MedTermLastModOvlpRangeFacets: de +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=652242
+MedTermLastModOvlpRangeFacets: if +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=640551
+MedTermLastModOvlpRangeFacets: university +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=636959
+MedTermLastModOvlpRangeFacets: 8 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=635822
+MedTermLastModOvlpRangeFacets: external +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=635450
+MedTermLastModOvlpRangeFacets: between +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=630650
+MedTermLastModOvlpRangeFacets: where +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=630647
+MedTermLastModOvlpRangeFacets: right +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=630423
+MedTermLastModOvlpRangeFacets: 20 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=624967
+MedTermLastModOvlpRangeFacets: under +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=623872
+MedTermLastModOvlpRangeFacets: these +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=623267
+MedTermLastModOvlpRangeFacets: march +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=620393
+MedTermLastModOvlpRangeFacets: br +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=617824
+MedTermLastModOvlpRangeFacets: book +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=617297
+MedTermLastModOvlpRangeFacets: p +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=616159
+MedTermLastModOvlpRangeFacets: article +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=610650
+MedTermLastModOvlpRangeFacets: known +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=607158
+MedTermLastModOvlpRangeFacets: then +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=606159
+MedTermLastModOvlpRangeFacets: style +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=606000
+MedTermLastModOvlpRangeFacets: later +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=604921
+MedTermLastModOvlpRangeFacets: three +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=598349
+MedTermLastModOvlpRangeFacets: use +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=597053
+MedTermLastModOvlpRangeFacets: category +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=595446
+MedTermLastModOvlpRangeFacets: john +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=594461
+MedTermLastModOvlpRangeFacets: part +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=594224
+MedTermLastModOvlpRangeFacets: left +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=593967
+MedTermLastModOvlpRangeFacets: 2004 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=593934
+MedTermLastModOvlpRangeFacets: 15 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=592407
+MedTermLastModOvlpRangeFacets: december +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=590171
+MedTermLastModOvlpRangeFacets: april +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=587542
+MedTermLastModOvlpRangeFacets: list +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=585922
+MedTermLastModOvlpRangeFacets: 18 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=585631
+MedTermLastModOvlpRangeFacets: small +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=581643
+MedTermLastModOvlpRangeFacets: january +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=581309
+MedTermLastModOvlpRangeFacets: before +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=580481
+MedTermLastModOvlpRangeFacets: being +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=580185
+MedTermLastModOvlpRangeFacets: well +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=580011
+MedTermLastModOvlpRangeFacets: id +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=579566
+MedTermLastModOvlpRangeFacets: while +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=579117
+MedTermLastModOvlpRangeFacets: 9 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=574434
+MedTermLastModOvlpRangeFacets: death +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=568895
+MedTermLastModOvlpRangeFacets: author +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=567768
+MedTermLastModOvlpRangeFacets: however +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=566494
+MedTermLastModOvlpRangeFacets: october +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=566229
+MedTermLastModOvlpRangeFacets: north +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=564195
+MedTermLastModOvlpRangeFacets: so +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=562598
+MedTermLastModOvlpRangeFacets: reflist +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=561253
+MedTermLastModOvlpRangeFacets: south +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=560468
+MedTermLastModOvlpRangeFacets: area +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=559023
+MedTermLastModOvlpRangeFacets: class +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=556838
+MedTermLastModOvlpRangeFacets: september +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=553409
+MedTermLastModOvlpRangeFacets: war +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=547417
+MedTermLastModOvlpRangeFacets: image +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=541747
+MedTermLastModOvlpRangeFacets: 16 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=540539
+MedTermLastModOvlpRangeFacets: both +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=534900
+MedTermLastModOvlpRangeFacets: 14 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=534005
+MedTermLastModOvlpRangeFacets: 13 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=530419
+MedTermLastModOvlpRangeFacets: july +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=529655
+MedTermLastModOvlpRangeFacets: august +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=527806
+MedTermLastModOvlpRangeFacets: november +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=527131
+MedTermLastModOvlpRangeFacets: end +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=526636
+MedTermLastModOvlpRangeFacets: february +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=524886
+MedTermLastModOvlpRangeFacets: infobox +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=524810
+MedTermLastModOvlpRangeFacets: june +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=522519
+MedTermLastModOvlpRangeFacets: series +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=521861
+MedTermLastModOvlpRangeFacets: york +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=521383
+MedTermLastModOvlpRangeFacets: including +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=521324
+MedTermLastModOvlpRangeFacets: county +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=521126
+MedTermLastModOvlpRangeFacets: them +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=520298
+MedTermLastModOvlpRangeFacets: her +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=518717
+MedTermLastModOvlpRangeFacets: through +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=514966
+MedTermLastModOvlpRangeFacets: do +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=511178
+MedTermLastModOvlpRangeFacets: 17 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=507396
+MedTermLastModOvlpRangeFacets: him +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=507350
+MedTermLastModOvlpRangeFacets: nbsp +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=506054
+MedTermLastModOvlpRangeFacets: second +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=505575
+MedTermLastModOvlpRangeFacets: 22 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=502778
+MedTermLastModOvlpRangeFacets: html +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=500198
+MedTermLastModOvlpRangeFacets: 2000 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=499639
+MedTermLastModOvlpRangeFacets: 25 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=491957
+MedTermLastModOvlpRangeFacets: location +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=489791
+MedTermLastModOvlpRangeFacets: will +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=489711
+MedTermLastModOvlpRangeFacets: center +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=489673
+MedTermLastModOvlpRangeFacets: 30 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=488930
+MedTermLastModOvlpRangeFacets: since +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=485325
+MedTermLastModOvlpRangeFacets: 19 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=484187
+MedTermLastModOvlpRangeFacets: now +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=484114
+MedTermLastModOvlpRangeFacets: any +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=483514
+MedTermLastModOvlpRangeFacets: early +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=482793
+MedTermLastModOvlpRangeFacets: 21 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=482314
+MedTermLastModOvlpRangeFacets: high +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=482152
+MedTermLastModOvlpRangeFacets: like +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=479390
+MedTermLastModOvlpRangeFacets: life +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=477007
+MedTermLastModOvlpRangeFacets: general +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=476690
+MedTermLastModOvlpRangeFacets: music +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=473240
+MedTermLastModOvlpRangeFacets: number +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=473154
+MedTermLastModOvlpRangeFacets: 24 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=470708
+MedTermLastModOvlpRangeFacets: main +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=470429
+MedTermLastModOvlpRangeFacets: isbn +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=467574
+MedTermLastModOvlpRangeFacets: pages +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=466290
+MedTermLastModOvlpRangeFacets: became +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=465594
+MedTermLastModOvlpRangeFacets: short +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=465205
+MedTermLastModOvlpRangeFacets: school +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=462166
+MedTermLastModOvlpRangeFacets: you +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=461587
+MedTermLastModOvlpRangeFacets: 23 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=457097
+MedTermLastModOvlpRangeFacets: 2003 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=456990
+MedTermLastModOvlpRangeFacets: called +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=454580
+MedTermLastModOvlpRangeFacets: utc +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=450225
+MedTermLastModOvlpRangeFacets: n +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=449994
+MedTermLastModOvlpRangeFacets: c +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=444247
+MedTermLastModOvlpRangeFacets: group +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=442503
+MedTermLastModOvlpRangeFacets: m +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=441232
+MedTermLastModOvlpRangeFacets: several +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=436129
+MedTermLastModOvlpRangeFacets: website +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=435941
+MedTermLastModOvlpRangeFacets: film +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=432758
+MedTermLastModOvlpRangeFacets: west +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=431006
+MedTermLastModOvlpRangeFacets: u.s +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=428534
+MedTermLastModOvlpRangeFacets: she +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=426267
+MedTermLastModOvlpRangeFacets: until +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=425389
+MedTermLastModOvlpRangeFacets: birth +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=425138
+MedTermLastModOvlpRangeFacets: us +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=421210
+MedTermLastModOvlpRangeFacets: same +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=420741
+MedTermLastModOvlpRangeFacets: country +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=420052
+MedTermLastModOvlpRangeFacets: international +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=418261
+MedTermLastModOvlpRangeFacets: british +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=417307
+MedTermLastModOvlpRangeFacets: language +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=416771
+MedTermLastModOvlpRangeFacets: following +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=416515
+MedTermLastModOvlpRangeFacets: because +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=413003
+MedTermLastModOvlpRangeFacets: system +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=412862
+MedTermLastModOvlpRangeFacets: english +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=412061
+MedTermLastModOvlpRangeFacets: 2001 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=410364
+MedTermLastModOvlpRangeFacets: e +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=408741
+MedTermLastModOvlpRangeFacets: times +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=407155
+MedTermLastModOvlpRangeFacets: 2002 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=406953
+MedTermLastModOvlpRangeFacets: names +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=404796
+MedTermLastModOvlpRangeFacets: w +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=404764
+MedTermLastModOvlpRangeFacets: day +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=402096
+MedTermLastModOvlpRangeFacets: should +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=401379
+MedTermLastModOvlpRangeFacets: against +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=399228
+MedTermLastModOvlpRangeFacets: press +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=398988
+MedTermLastModOvlpRangeFacets: based +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=398415
+MedTermLastModOvlpRangeFacets: age +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=395368
+MedTermLastModOvlpRangeFacets: what +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=394675
+MedTermLastModOvlpRangeFacets: party +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=394410
+MedTermLastModOvlpRangeFacets: company +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=391520
+MedTermLastModOvlpRangeFacets: four +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=389818
+MedTermLastModOvlpRangeFacets: 28 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=389552
+MedTermLastModOvlpRangeFacets: 26 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=389026
+MedTermLastModOvlpRangeFacets: family +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=387175
+MedTermLastModOvlpRangeFacets: long +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=385787
+MedTermLastModOvlpRangeFacets: century +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=385541
+MedTermLastModOvlpRangeFacets: government +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=384004
+MedTermLastModOvlpRangeFacets: 27 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=383042
+MedTermLastModOvlpRangeFacets: old +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=381809
+MedTermLastModOvlpRangeFacets: team +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=379028
+MedTermLastModOvlpRangeFacets: house +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=377336
+MedTermLastModOvlpRangeFacets: population +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=374481
+MedTermLastModOvlpRangeFacets: 29 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=372091
+MedTermLastModOvlpRangeFacets: b +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=369454
+MedTermLastModOvlpRangeFacets: public +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=368868
+MedTermLastModOvlpRangeFacets: home +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=367819
+MedTermLastModOvlpRangeFacets: top +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=364628
+MedTermLastModOvlpRangeFacets: east +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=364582
+MedTermLastModOvlpRangeFacets: talk +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=364194
+MedTermLastModOvlpRangeFacets: order +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=360915
+MedTermLastModOvlpRangeFacets: line +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=360442
+MedTermLastModOvlpRangeFacets: could +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=356679
+MedTermLastModOvlpRangeFacets: 2012 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=355641
+MedTermLastModOvlpRangeFacets: description +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=355070
+MedTermLastModOvlpRangeFacets: very +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=354898
+MedTermLastModOvlpRangeFacets: each +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=354583
+MedTermLastModOvlpRangeFacets: information +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=353153
+MedTermLastModOvlpRangeFacets: another +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=352496
+MedTermLastModOvlpRangeFacets: born +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=352196
+MedTermLastModOvlpRangeFacets: back +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=349276
+MedTermLastModOvlpRangeFacets: london +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=348918
+MedTermLastModOvlpRangeFacets: just +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=348911
+MedTermLastModOvlpRangeFacets: town +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=348598
+MedTermLastModOvlpRangeFacets: journal +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=348162
+MedTermLastModOvlpRangeFacets: non +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=348142
+MedTermLastModOvlpRangeFacets: color +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=347941
+MedTermLastModOvlpRangeFacets: 01 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=347922
+MedTermLastModOvlpRangeFacets: great +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=347499
+MedTermLastModOvlpRangeFacets: although +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=341432
+MedTermLastModOvlpRangeFacets: books +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=341376
+MedTermLastModOvlpRangeFacets: ii +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=340800
+MedTermLastModOvlpRangeFacets: major +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=340345
+MedTermLastModOvlpRangeFacets: further +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=339350
+MedTermLastModOvlpRangeFacets: 1999 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=334887
+MedTermLastModOvlpRangeFacets: around +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=334840
+MedTermLastModOvlpRangeFacets: best +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=334550
+MedTermLastModOvlpRangeFacets: former +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=332750
+MedTermLastModOvlpRangeFacets: still +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=332543
+MedTermLastModOvlpRangeFacets: album +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=331360
+MedTermLastModOvlpRangeFacets: stub +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=329768
+MedTermLastModOvlpRangeFacets: did +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=328303
+MedTermLastModOvlpRangeFacets: j +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=327713
+MedTermLastModOvlpRangeFacets: even +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=326231
+MedTermLastModOvlpRangeFacets: official +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=326177
+MedTermLastModOvlpRangeFacets: original +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=323521
+MedTermLastModOvlpRangeFacets: user +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=323242
+MedTermLastModOvlpRangeFacets: alternative +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=322536
+MedTermLastModOvlpRangeFacets: released +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=322473
+MedTermLastModOvlpRangeFacets: jpg +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=322278
+MedTermLastModOvlpRangeFacets: issue +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=322106
+MedTermLastModOvlpRangeFacets: own +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=321703
+MedTermLastModOvlpRangeFacets: season +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=320228
+MedTermLastModOvlpRangeFacets: those +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=320013
+MedTermLastModOvlpRangeFacets: 02 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=319783
+MedTermLastModOvlpRangeFacets: uk +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=319211
+MedTermLastModOvlpRangeFacets: way +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=318344
+MedTermLastModOvlpRangeFacets: type +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=318210
+MedTermLastModOvlpRangeFacets: 03 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=318112
+MedTermLastModOvlpRangeFacets: england +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=317884
+MedTermLastModOvlpRangeFacets: much +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=317670
+MedTermLastModOvlpRangeFacets: off +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=315473
+MedTermLastModOvlpRangeFacets: game +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=315157
+MedTermLastModOvlpRangeFacets: background +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=314229
+MedTermLastModOvlpRangeFacets: 04 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=313827
+MedTermLastModOvlpRangeFacets: found +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=313247
+MedTermLastModOvlpRangeFacets: volume +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=312846
+MedTermLastModOvlpRangeFacets: named +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=310150
+MedTermLastModOvlpRangeFacets: service +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=309976
+MedTermLastModOvlpRangeFacets: d +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=309729
+MedTermLastModOvlpRangeFacets: st +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=309092
+MedTermLastModOvlpRangeFacets: large +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=308888
+MedTermLastModOvlpRangeFacets: often +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=307684
+MedTermLastModOvlpRangeFacets: 06 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=305698
+MedTermLastModOvlpRangeFacets: 05 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=302860
+MedTermLastModOvlpRangeFacets: 1998 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=300506
+MedTermLastModOvlpRangeFacets: align +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=300455
+MedTermLastModOvlpRangeFacets: kingdom +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=299825
+MedTermLastModOvlpRangeFacets: using +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=299474
+MedTermLastModOvlpRangeFacets: white +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=299411
+MedTermLastModOvlpRangeFacets: 07 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=299351
+MedTermLastModOvlpRangeFacets: district +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=299108
+MedTermLastModOvlpRangeFacets: local +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=299012
+MedTermLastModOvlpRangeFacets: metadata +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=298533
+MedTermLastModOvlpRangeFacets: 31 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=298349
+MedTermLastModOvlpRangeFacets: 08 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=297258
+MedTermLastModOvlpRangeFacets: 09 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=296300
+MedTermLastModOvlpRangeFacets: r +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=296283
+MedTermLastModOvlpRangeFacets: set +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=294255
+MedTermLastModOvlpRangeFacets: show +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=293934
+MedTermLastModOvlpRangeFacets: david +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=292847
+MedTermLastModOvlpRangeFacets: make +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=292607
+MedTermLastModOvlpRangeFacets: story +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=292404
+MedTermLastModOvlpRangeFacets: citation +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=291478
+MedTermLastModOvlpRangeFacets: within +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=291049
+MedTermLastModOvlpRangeFacets: due +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=290531
+MedTermLastModOvlpRangeFacets: link +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=287552
+MedTermLastModOvlpRangeFacets: 1997 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=286789
+MedTermLastModOvlpRangeFacets: members +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=286028
+MedTermLastModOvlpRangeFacets: william +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=284592
+MedTermLastModOvlpRangeFacets: along +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=284442
+MedTermLastModOvlpRangeFacets: v +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=284318
+MedTermLastModOvlpRangeFacets: located +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=283899
+MedTermLastModOvlpRangeFacets: single +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=283824
+MedTermLastModOvlpRangeFacets: per +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=283568
+MedTermLastModOvlpRangeFacets: established +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=282471
+MedTermLastModOvlpRangeFacets: james +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=281597
+MedTermLastModOvlpRangeFacets: needed +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=281051
+MedTermLastModOvlpRangeFacets: down +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=280662
+MedTermLastModOvlpRangeFacets: present +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=278449
+MedTermLastModOvlpRangeFacets: man +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=278112
+MedTermLastModOvlpRangeFacets: college +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=278094
+MedTermLastModOvlpRangeFacets: f +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=278015
+MedTermLastModOvlpRangeFacets: site +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=277788
+MedTermLastModOvlpRangeFacets: football +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=277738
+MedTermLastModOvlpRangeFacets: en +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=277463
+MedTermLastModOvlpRangeFacets: result +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=276803
+MedTermLastModOvlpRangeFacets: include +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=276466
+MedTermLastModOvlpRangeFacets: began +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=276036
+MedTermLastModOvlpRangeFacets: my +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=274256
+MedTermLastModOvlpRangeFacets: x +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=272695
+MedTermLastModOvlpRangeFacets: central +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=272531
+MedTermLastModOvlpRangeFacets: band +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=272207
+MedTermLastModOvlpRangeFacets: 1996 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=271980
+MedTermLastModOvlpRangeFacets: form +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=271966
+MedTermLastModOvlpRangeFacets: member +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=271607
+MedTermLastModOvlpRangeFacets: television +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=271426
+MedTermLastModOvlpRangeFacets: league +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=270223
+MedTermLastModOvlpRangeFacets: free +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=270199
+MedTermLastModOvlpRangeFacets: political +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=269665
+MedTermLastModOvlpRangeFacets: font +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=269439
+MedTermLastModOvlpRangeFacets: 100 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=268978
+MedTermLastModOvlpRangeFacets: convert +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=267974
+MedTermLastModOvlpRangeFacets: red +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=266177
+MedTermLastModOvlpRangeFacets: president +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=263341
+MedTermLastModOvlpRangeFacets: five +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=262923
+MedTermLastModOvlpRangeFacets: t +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=262832
+MedTermLastModOvlpRangeFacets: power +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=262586
+MedTermLastModOvlpRangeFacets: river +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=262231
+MedTermLastModOvlpRangeFacets: we +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=261001
+MedTermLastModOvlpRangeFacets: song +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=260741
+MedTermLastModOvlpRangeFacets: next +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=259039
+MedTermLastModOvlpRangeFacets: articles +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=258949
+MedTermLastModOvlpRangeFacets: point +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=258471
+MedTermLastModOvlpRangeFacets: text +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=257803
+MedTermLastModOvlpRangeFacets: according +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=256949
+MedTermLastModOvlpRangeFacets: black +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=256526
+MedTermLastModOvlpRangeFacets: george +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=256196
+MedTermLastModOvlpRangeFacets: different +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=255951
+MedTermLastModOvlpRangeFacets: ndash +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=255747
+MedTermLastModOvlpRangeFacets: third +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=255690
+MedTermLastModOvlpRangeFacets: tv +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=255429
+MedTermLastModOvlpRangeFacets: law +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=255248
+MedTermLastModOvlpRangeFacets: canada +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=254867
+MedTermLastModOvlpRangeFacets: near +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=254492
+MedTermLastModOvlpRangeFacets: built +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=254491
+MedTermLastModOvlpRangeFacets: 1995 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=252837
+MedTermLastModOvlpRangeFacets: how +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=252284
+MedTermLastModOvlpRangeFacets: record +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=250484
+MedTermLastModOvlpRangeFacets: french +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=250453
+MedTermLastModOvlpRangeFacets: air +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=250411
+MedTermLastModOvlpRangeFacets: king +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=250321
+MedTermLastModOvlpRangeFacets: without +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=249926
+MedTermLastModOvlpRangeFacets: though +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=248968
+MedTermLastModOvlpRangeFacets: played +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=248191
+MedTermLastModOvlpRangeFacets: park +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=247801
+MedTermLastModOvlpRangeFacets: took +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=247388
+MedTermLastModOvlpRangeFacets: association +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=247156
+MedTermLastModOvlpRangeFacets: military +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=246727
+MedTermLastModOvlpRangeFacets: robert +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=246405
+MedTermLastModOvlpRangeFacets: above +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=246135
+MedTermLastModOvlpRangeFacets: persondata +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=246119
+MedTermLastModOvlpRangeFacets: career +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=245439
+MedTermLastModOvlpRangeFacets: version +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=244541
+MedTermLastModOvlpRangeFacets: again +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=244255
+MedTermLastModOvlpRangeFacets: late +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=243636
+MedTermLastModOvlpRangeFacets: published +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=243548
+MedTermLastModOvlpRangeFacets: live +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=242147
+MedTermLastModOvlpRangeFacets: h +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=241946
+MedTermLastModOvlpRangeFacets: good +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=241649
+MedTermLastModOvlpRangeFacets: player +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=241451
+MedTermLastModOvlpRangeFacets: others +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=240487
+MedTermLastModOvlpRangeFacets: america +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=240374
+MedTermLastModOvlpRangeFacets: review +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=240157
+MedTermLastModOvlpRangeFacets: station +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=239572
+MedTermLastModOvlpRangeFacets: among +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=238986
+MedTermLastModOvlpRangeFacets: section +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=238874
+MedTermLastModOvlpRangeFacets: border +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=238540
+MedTermLastModOvlpRangeFacets: your +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=237723
+MedTermLastModOvlpRangeFacets: size +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=237662
+MedTermLastModOvlpRangeFacets: births +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=237033
+MedTermLastModOvlpRangeFacets: support +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=236989
+MedTermLastModOvlpRangeFacets: german +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=236721
+MedTermLastModOvlpRangeFacets: california +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=236086
+MedTermLastModOvlpRangeFacets: given +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=235719
+MedTermLastModOvlpRangeFacets: commons +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=235235
+MedTermLastModOvlpRangeFacets: 1994 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=235100
+MedTermLastModOvlpRangeFacets: start +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=233925
+MedTermLastModOvlpRangeFacets: km +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=233831
+MedTermLastModOvlpRangeFacets: said +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=233066
+MedTermLastModOvlpRangeFacets: western +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=232781
+MedTermLastModOvlpRangeFacets: won +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=232751
+MedTermLastModOvlpRangeFacets: la +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=232610
+MedTermLastModOvlpRangeFacets: held +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=232354
+MedTermLastModOvlpRangeFacets: children +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=232342
+MedTermLastModOvlpRangeFacets: does +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=232202
+MedTermLastModOvlpRangeFacets: club +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=232173
+MedTermLastModOvlpRangeFacets: source +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=231838
+MedTermLastModOvlpRangeFacets: church +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=231667
+MedTermLastModOvlpRangeFacets: format +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=231300
+MedTermLastModOvlpRangeFacets: example +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=230457
+MedTermLastModOvlpRangeFacets: development +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=230286
+MedTermLastModOvlpRangeFacets: land +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=230284
+MedTermLastModOvlpRangeFacets: total +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=230013
+MedTermLastModOvlpRangeFacets: final +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=230006
+MedTermLastModOvlpRangeFacets: 50 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=229614
+MedTermLastModOvlpRangeFacets: please +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=229602
+MedTermLastModOvlpRangeFacets: region +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=229561
+MedTermLastModOvlpRangeFacets: here +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=229505
+MedTermLastModOvlpRangeFacets: me +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=229204
+MedTermLastModOvlpRangeFacets: caption +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=229172
+MedTermLastModOvlpRangeFacets: must +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=228491
+MedTermLastModOvlpRangeFacets: army +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=228105
+MedTermLastModOvlpRangeFacets: l +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=227974
+MedTermLastModOvlpRangeFacets: side +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=227747
+MedTermLastModOvlpRangeFacets: society +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=226742
+MedTermLastModOvlpRangeFacets: full +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=226457
+MedTermLastModOvlpRangeFacets: few +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=226422
+MedTermLastModOvlpRangeFacets: records +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=225886
+MedTermLastModOvlpRangeFacets: below +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=225843
+MedTermLastModOvlpRangeFacets: community +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=225571
+MedTermLastModOvlpRangeFacets: office +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=225338
+MedTermLastModOvlpRangeFacets: 1992 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=225200
+MedTermLastModOvlpRangeFacets: road +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=225050
+MedTermLastModOvlpRangeFacets: research +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=224925
+MedTermLastModOvlpRangeFacets: various +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=224593
+MedTermLastModOvlpRangeFacets: take +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=224260
+MedTermLastModOvlpRangeFacets: wikipedia:persondata +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=222385
+MedTermLastModOvlpRangeFacets: 1990 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=222154
+MedTermLastModOvlpRangeFacets: 40 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=221687
+MedTermLastModOvlpRangeFacets: created +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=220831
+MedTermLastModOvlpRangeFacets: 1993 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=220776
+MedTermLastModOvlpRangeFacets: france +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=220058
+MedTermLastModOvlpRangeFacets: science +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=219988
+MedTermLastModOvlpRangeFacets: every +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=219884
+MedTermLastModOvlpRangeFacets: become +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=219753
+MedTermLastModOvlpRangeFacets: modern +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=218831
+MedTermLastModOvlpRangeFacets: post +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=218570
+MedTermLastModOvlpRangeFacets: games +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=218434
+MedTermLastModOvlpRangeFacets: michael +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=217311
+MedTermLastModOvlpRangeFacets: current +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=217174
+MedTermLastModOvlpRangeFacets: included +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=216978
+MedTermLastModOvlpRangeFacets: ja +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=216549
+MedTermLastModOvlpRangeFacets: magazine +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=215725
+MedTermLastModOvlpRangeFacets: position +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=215493
+MedTermLastModOvlpRangeFacets: australia +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=215391
+MedTermLastModOvlpRangeFacets: archive +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=215381
+MedTermLastModOvlpRangeFacets: union +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=214164
+MedTermLastModOvlpRangeFacets: having +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=213416
+MedTermLastModOvlpRangeFacets: g +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=212936
+MedTermLastModOvlpRangeFacets: popular +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=212493
+MedTermLastModOvlpRangeFacets: royal +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=211710
+MedTermLastModOvlpRangeFacets: period +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=211690
+MedTermLastModOvlpRangeFacets: little +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=211124
+MedTermLastModOvlpRangeFacets: wikitable +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=210990
+MedTermLastModOvlpRangeFacets: rock +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=210815
+MedTermLastModOvlpRangeFacets: artist +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=210591
+MedTermLastModOvlpRangeFacets: play +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=210199
+MedTermLastModOvlpRangeFacets: led +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=210033
+MedTermLastModOvlpRangeFacets: notes +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=210029
+MedTermLastModOvlpRangeFacets: water +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=209444
+MedTermLastModOvlpRangeFacets: business +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=209353
+MedTermLastModOvlpRangeFacets: art +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=209322
+MedTermLastModOvlpRangeFacets: common +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=209310
+MedTermLastModOvlpRangeFacets: co +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=209086
+MedTermLastModOvlpRangeFacets: education +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=208909
+MedTermLastModOvlpRangeFacets: role +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=208579
+MedTermLastModOvlpRangeFacets: 1991 +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=207589
+MedTermLastModOvlpRangeFacets: case +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=207307
+MedTermLastModOvlpRangeFacets: paul +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=207229
+MedTermLastModOvlpRangeFacets: media +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=206574
+MedTermLastModOvlpRangeFacets: div +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=206057
+MedTermLastModOvlpRangeFacets: census +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=205166
+MedTermLastModOvlpRangeFacets: charles +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=204987
+MedTermLastModOvlpRangeFacets: written +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=204891
+MedTermLastModOvlpRangeFacets: pp +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=204742
+MedTermLastModOvlpRangeFacets: green +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=203371
+MedTermLastModOvlpRangeFacets: island +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=203023
+MedTermLastModOvlpRangeFacets: never +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=203017
+MedTermLastModOvlpRangeFacets: making +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=203003
+MedTermLastModOvlpRangeFacets: term +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=202691
+MedTermLastModOvlpRangeFacets: video +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=202380
+MedTermLastModOvlpRangeFacets: son +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=202340
+MedTermLastModOvlpRangeFacets: discussion +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=202145
+MedTermLastModOvlpRangeFacets: died +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=202125
+MedTermLastModOvlpRangeFacets: view +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=201593
+MedTermLastModOvlpRangeFacets: street +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=200985
+MedTermLastModOvlpRangeFacets: council +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=200706
+MedTermLastModOvlpRangeFacets: re +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=199632
+MedTermLastModOvlpRangeFacets: award +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=199318
+MedTermLastModOvlpRangeFacets: works +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=199177
+MedTermLastModOvlpRangeFacets: special +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=198917
+MedTermLastModOvlpRangeFacets: force +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=198556
+MedTermLastModOvlpRangeFacets: six +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=197970
+MedTermLastModOvlpRangeFacets: came +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=197126
+MedTermLastModOvlpRangeFacets: building +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=196508
+MedTermLastModOvlpRangeFacets: young +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=196428
+MedTermLastModOvlpRangeFacets: together +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=195949
+MedTermLastModOvlpRangeFacets: important +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=195851
+MedTermLastModOvlpRangeFacets: star +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=195768
+MedTermLastModOvlpRangeFacets: similar +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=195171
+MedTermLastModOvlpRangeFacets: received +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=194983
+MedTermLastModOvlpRangeFacets: sup +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=194723
+MedTermLastModOvlpRangeFacets: head +facets:range:long|lastMod|1041379200000-1167609600000,1104537600000-1230768000000,1167609600000-1325376000000 # freq=194682
+
+MedTermIDRangeFacets: most +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=819634
+MedTermIDRangeFacets: up +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=818546
+MedTermIDRangeFacets: world +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=808563
+MedTermIDRangeFacets: 2007 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=801586
+MedTermIDRangeFacets: during +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=798114
+MedTermIDRangeFacets: people +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=790960
+MedTermIDRangeFacets: years +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=789628
+MedTermIDRangeFacets: such +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=787877
+MedTermIDRangeFacets: 12 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=774572
+MedTermIDRangeFacets: over +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=774312
+MedTermIDRangeFacets: can +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=765163
+MedTermIDRangeFacets: references +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=760306
+MedTermIDRangeFacets: city +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=760272
+MedTermIDRangeFacets: 6 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=759234
+MedTermIDRangeFacets: american +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=758337
+MedTermIDRangeFacets: news +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=756063
+MedTermIDRangeFacets: history +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=755471
+MedTermIDRangeFacets: 0 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=754451
+MedTermIDRangeFacets: made +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=742313
+MedTermIDRangeFacets: out +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=733775
+MedTermIDRangeFacets: 11 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=730505
+MedTermIDRangeFacets: used +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=708455
+MedTermIDRangeFacets: links +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=703350
+MedTermIDRangeFacets: state +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=702598
+MedTermIDRangeFacets: many +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=694439
+MedTermIDRangeFacets: would +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=690480
+MedTermIDRangeFacets: page +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=681036
+MedTermIDRangeFacets: national +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=677281
+MedTermIDRangeFacets: than +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=676864
+MedTermIDRangeFacets: thumb +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=672667
+MedTermIDRangeFacets: 7 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=660220
+MedTermIDRangeFacets: place +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=654158
+MedTermIDRangeFacets: de +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=652242
+MedTermIDRangeFacets: if +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=640551
+MedTermIDRangeFacets: university +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=636959
+MedTermIDRangeFacets: 8 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=635822
+MedTermIDRangeFacets: external +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=635450
+MedTermIDRangeFacets: between +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=630650
+MedTermIDRangeFacets: where +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=630647
+MedTermIDRangeFacets: right +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=630423
+MedTermIDRangeFacets: 20 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=624967
+MedTermIDRangeFacets: under +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=623872
+MedTermIDRangeFacets: these +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=623267
+MedTermIDRangeFacets: march +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=620393
+MedTermIDRangeFacets: br +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=617824
+MedTermIDRangeFacets: book +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=617297
+MedTermIDRangeFacets: p +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=616159
+MedTermIDRangeFacets: article +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=610650
+MedTermIDRangeFacets: known +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=607158
+MedTermIDRangeFacets: then +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=606159
+MedTermIDRangeFacets: style +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=606000
+MedTermIDRangeFacets: later +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=604921
+MedTermIDRangeFacets: three +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=598349
+MedTermIDRangeFacets: use +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=597053
+MedTermIDRangeFacets: category +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=595446
+MedTermIDRangeFacets: john +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=594461
+MedTermIDRangeFacets: part +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=594224
+MedTermIDRangeFacets: left +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=593967
+MedTermIDRangeFacets: 2004 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=593934
+MedTermIDRangeFacets: 15 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=592407
+MedTermIDRangeFacets: december +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=590171
+MedTermIDRangeFacets: april +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=587542
+MedTermIDRangeFacets: list +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=585922
+MedTermIDRangeFacets: 18 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=585631
+MedTermIDRangeFacets: small +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=581643
+MedTermIDRangeFacets: january +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=581309
+MedTermIDRangeFacets: before +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=580481
+MedTermIDRangeFacets: being +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=580185
+MedTermIDRangeFacets: well +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=580011
+MedTermIDRangeFacets: id +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=579566
+MedTermIDRangeFacets: while +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=579117
+MedTermIDRangeFacets: 9 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=574434
+MedTermIDRangeFacets: death +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=568895
+MedTermIDRangeFacets: author +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=567768
+MedTermIDRangeFacets: however +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=566494
+MedTermIDRangeFacets: october +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=566229
+MedTermIDRangeFacets: north +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=564195
+MedTermIDRangeFacets: so +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=562598
+MedTermIDRangeFacets: reflist +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=561253
+MedTermIDRangeFacets: south +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=560468
+MedTermIDRangeFacets: area +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=559023
+MedTermIDRangeFacets: class +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=556838
+MedTermIDRangeFacets: september +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=553409
+MedTermIDRangeFacets: war +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=547417
+MedTermIDRangeFacets: image +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=541747
+MedTermIDRangeFacets: 16 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=540539
+MedTermIDRangeFacets: both +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=534900
+MedTermIDRangeFacets: 14 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=534005
+MedTermIDRangeFacets: 13 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=530419
+MedTermIDRangeFacets: july +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=529655
+MedTermIDRangeFacets: august +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=527806
+MedTermIDRangeFacets: november +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=527131
+MedTermIDRangeFacets: end +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=526636
+MedTermIDRangeFacets: february +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=524886
+MedTermIDRangeFacets: infobox +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=524810
+MedTermIDRangeFacets: june +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=522519
+MedTermIDRangeFacets: series +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=521861
+MedTermIDRangeFacets: york +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=521383
+MedTermIDRangeFacets: including +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=521324
+MedTermIDRangeFacets: county +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=521126
+MedTermIDRangeFacets: them +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=520298
+MedTermIDRangeFacets: her +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=518717
+MedTermIDRangeFacets: through +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=514966
+MedTermIDRangeFacets: do +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=511178
+MedTermIDRangeFacets: 17 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=507396
+MedTermIDRangeFacets: him +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=507350
+MedTermIDRangeFacets: nbsp +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=506054
+MedTermIDRangeFacets: second +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=505575
+MedTermIDRangeFacets: 22 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=502778
+MedTermIDRangeFacets: html +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=500198
+MedTermIDRangeFacets: 2000 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=499639
+MedTermIDRangeFacets: 25 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=491957
+MedTermIDRangeFacets: location +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=489791
+MedTermIDRangeFacets: will +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=489711
+MedTermIDRangeFacets: center +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=489673
+MedTermIDRangeFacets: 30 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=488930
+MedTermIDRangeFacets: since +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=485325
+MedTermIDRangeFacets: 19 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=484187
+MedTermIDRangeFacets: now +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=484114
+MedTermIDRangeFacets: any +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=483514
+MedTermIDRangeFacets: early +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=482793
+MedTermIDRangeFacets: 21 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=482314
+MedTermIDRangeFacets: high +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=482152
+MedTermIDRangeFacets: like +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=479390
+MedTermIDRangeFacets: life +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=477007
+MedTermIDRangeFacets: general +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=476690
+MedTermIDRangeFacets: music +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=473240
+MedTermIDRangeFacets: number +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=473154
+MedTermIDRangeFacets: 24 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=470708
+MedTermIDRangeFacets: main +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=470429
+MedTermIDRangeFacets: isbn +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=467574
+MedTermIDRangeFacets: pages +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=466290
+MedTermIDRangeFacets: became +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=465594
+MedTermIDRangeFacets: short +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=465205
+MedTermIDRangeFacets: school +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=462166
+MedTermIDRangeFacets: you +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=461587
+MedTermIDRangeFacets: 23 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=457097
+MedTermIDRangeFacets: 2003 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=456990
+MedTermIDRangeFacets: called +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=454580
+MedTermIDRangeFacets: utc +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=450225
+MedTermIDRangeFacets: n +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=449994
+MedTermIDRangeFacets: c +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=444247
+MedTermIDRangeFacets: group +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=442503
+MedTermIDRangeFacets: m +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=441232
+MedTermIDRangeFacets: several +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=436129
+MedTermIDRangeFacets: website +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=435941
+MedTermIDRangeFacets: film +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=432758
+MedTermIDRangeFacets: west +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=431006
+MedTermIDRangeFacets: u.s +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=428534
+MedTermIDRangeFacets: she +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=426267
+MedTermIDRangeFacets: until +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=425389
+MedTermIDRangeFacets: birth +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=425138
+MedTermIDRangeFacets: us +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=421210
+MedTermIDRangeFacets: same +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=420741
+MedTermIDRangeFacets: country +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=420052
+MedTermIDRangeFacets: international +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=418261
+MedTermIDRangeFacets: british +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=417307
+MedTermIDRangeFacets: language +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=416771
+MedTermIDRangeFacets: following +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=416515
+MedTermIDRangeFacets: because +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=413003
+MedTermIDRangeFacets: system +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=412862
+MedTermIDRangeFacets: english +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=412061
+MedTermIDRangeFacets: 2001 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=410364
+MedTermIDRangeFacets: e +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=408741
+MedTermIDRangeFacets: times +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=407155
+MedTermIDRangeFacets: 2002 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=406953
+MedTermIDRangeFacets: names +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=404796
+MedTermIDRangeFacets: w +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=404764
+MedTermIDRangeFacets: day +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=402096
+MedTermIDRangeFacets: should +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=401379
+MedTermIDRangeFacets: against +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=399228
+MedTermIDRangeFacets: press +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=398988
+MedTermIDRangeFacets: based +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=398415
+MedTermIDRangeFacets: age +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=395368
+MedTermIDRangeFacets: what +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=394675
+MedTermIDRangeFacets: party +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=394410
+MedTermIDRangeFacets: company +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=391520
+MedTermIDRangeFacets: four +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=389818
+MedTermIDRangeFacets: 28 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=389552
+MedTermIDRangeFacets: 26 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=389026
+MedTermIDRangeFacets: family +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=387175
+MedTermIDRangeFacets: long +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=385787
+MedTermIDRangeFacets: century +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=385541
+MedTermIDRangeFacets: government +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=384004
+MedTermIDRangeFacets: 27 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=383042
+MedTermIDRangeFacets: old +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=381809
+MedTermIDRangeFacets: team +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=379028
+MedTermIDRangeFacets: house +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=377336
+MedTermIDRangeFacets: population +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=374481
+MedTermIDRangeFacets: 29 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=372091
+MedTermIDRangeFacets: b +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=369454
+MedTermIDRangeFacets: public +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=368868
+MedTermIDRangeFacets: home +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=367819
+MedTermIDRangeFacets: top +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=364628
+MedTermIDRangeFacets: east +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=364582
+MedTermIDRangeFacets: talk +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=364194
+MedTermIDRangeFacets: order +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=360915
+MedTermIDRangeFacets: line +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=360442
+MedTermIDRangeFacets: could +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=356679
+MedTermIDRangeFacets: 2012 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=355641
+MedTermIDRangeFacets: description +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=355070
+MedTermIDRangeFacets: very +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=354898
+MedTermIDRangeFacets: each +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=354583
+MedTermIDRangeFacets: information +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=353153
+MedTermIDRangeFacets: another +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=352496
+MedTermIDRangeFacets: born +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=352196
+MedTermIDRangeFacets: back +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=349276
+MedTermIDRangeFacets: london +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=348918
+MedTermIDRangeFacets: just +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=348911
+MedTermIDRangeFacets: town +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=348598
+MedTermIDRangeFacets: journal +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=348162
+MedTermIDRangeFacets: non +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=348142
+MedTermIDRangeFacets: color +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=347941
+MedTermIDRangeFacets: 01 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=347922
+MedTermIDRangeFacets: great +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=347499
+MedTermIDRangeFacets: although +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=341432
+MedTermIDRangeFacets: books +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=341376
+MedTermIDRangeFacets: ii +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=340800
+MedTermIDRangeFacets: major +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=340345
+MedTermIDRangeFacets: further +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=339350
+MedTermIDRangeFacets: 1999 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=334887
+MedTermIDRangeFacets: around +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=334840
+MedTermIDRangeFacets: best +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=334550
+MedTermIDRangeFacets: former +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=332750
+MedTermIDRangeFacets: still +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=332543
+MedTermIDRangeFacets: album +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=331360
+MedTermIDRangeFacets: stub +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=329768
+MedTermIDRangeFacets: did +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=328303
+MedTermIDRangeFacets: j +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=327713
+MedTermIDRangeFacets: even +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=326231
+MedTermIDRangeFacets: official +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=326177
+MedTermIDRangeFacets: original +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=323521
+MedTermIDRangeFacets: user +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=323242
+MedTermIDRangeFacets: alternative +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=322536
+MedTermIDRangeFacets: released +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=322473
+MedTermIDRangeFacets: jpg +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=322278
+MedTermIDRangeFacets: issue +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=322106
+MedTermIDRangeFacets: own +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=321703
+MedTermIDRangeFacets: season +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=320228
+MedTermIDRangeFacets: those +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=320013
+MedTermIDRangeFacets: 02 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=319783
+MedTermIDRangeFacets: uk +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=319211
+MedTermIDRangeFacets: way +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=318344
+MedTermIDRangeFacets: type +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=318210
+MedTermIDRangeFacets: 03 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=318112
+MedTermIDRangeFacets: england +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=317884
+MedTermIDRangeFacets: much +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=317670
+MedTermIDRangeFacets: off +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=315473
+MedTermIDRangeFacets: game +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=315157
+MedTermIDRangeFacets: background +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=314229
+MedTermIDRangeFacets: 04 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=313827
+MedTermIDRangeFacets: found +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=313247
+MedTermIDRangeFacets: volume +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=312846
+MedTermIDRangeFacets: named +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=310150
+MedTermIDRangeFacets: service +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=309976
+MedTermIDRangeFacets: d +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=309729
+MedTermIDRangeFacets: st +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=309092
+MedTermIDRangeFacets: large +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=308888
+MedTermIDRangeFacets: often +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=307684
+MedTermIDRangeFacets: 06 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=305698
+MedTermIDRangeFacets: 05 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=302860
+MedTermIDRangeFacets: 1998 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=300506
+MedTermIDRangeFacets: align +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=300455
+MedTermIDRangeFacets: kingdom +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=299825
+MedTermIDRangeFacets: using +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=299474
+MedTermIDRangeFacets: white +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=299411
+MedTermIDRangeFacets: 07 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=299351
+MedTermIDRangeFacets: district +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=299108
+MedTermIDRangeFacets: local +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=299012
+MedTermIDRangeFacets: metadata +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=298533
+MedTermIDRangeFacets: 31 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=298349
+MedTermIDRangeFacets: 08 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=297258
+MedTermIDRangeFacets: 09 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=296300
+MedTermIDRangeFacets: r +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=296283
+MedTermIDRangeFacets: set +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=294255
+MedTermIDRangeFacets: show +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=293934
+MedTermIDRangeFacets: david +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=292847
+MedTermIDRangeFacets: make +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=292607
+MedTermIDRangeFacets: story +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=292404
+MedTermIDRangeFacets: citation +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=291478
+MedTermIDRangeFacets: within +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=291049
+MedTermIDRangeFacets: due +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=290531
+MedTermIDRangeFacets: link +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=287552
+MedTermIDRangeFacets: 1997 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=286789
+MedTermIDRangeFacets: members +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=286028
+MedTermIDRangeFacets: william +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=284592
+MedTermIDRangeFacets: along +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=284442
+MedTermIDRangeFacets: v +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=284318
+MedTermIDRangeFacets: located +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=283899
+MedTermIDRangeFacets: single +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=283824
+MedTermIDRangeFacets: per +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=283568
+MedTermIDRangeFacets: established +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=282471
+MedTermIDRangeFacets: james +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=281597
+MedTermIDRangeFacets: needed +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=281051
+MedTermIDRangeFacets: down +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=280662
+MedTermIDRangeFacets: present +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=278449
+MedTermIDRangeFacets: man +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=278112
+MedTermIDRangeFacets: college +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=278094
+MedTermIDRangeFacets: f +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=278015
+MedTermIDRangeFacets: site +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=277788
+MedTermIDRangeFacets: football +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=277738
+MedTermIDRangeFacets: en +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=277463
+MedTermIDRangeFacets: result +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=276803
+MedTermIDRangeFacets: include +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=276466
+MedTermIDRangeFacets: began +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=276036
+MedTermIDRangeFacets: my +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=274256
+MedTermIDRangeFacets: x +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=272695
+MedTermIDRangeFacets: central +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=272531
+MedTermIDRangeFacets: band +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=272207
+MedTermIDRangeFacets: 1996 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=271980
+MedTermIDRangeFacets: form +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=271966
+MedTermIDRangeFacets: member +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=271607
+MedTermIDRangeFacets: television +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=271426
+MedTermIDRangeFacets: league +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=270223
+MedTermIDRangeFacets: free +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=270199
+MedTermIDRangeFacets: political +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=269665
+MedTermIDRangeFacets: font +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=269439
+MedTermIDRangeFacets: 100 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=268978
+MedTermIDRangeFacets: convert +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=267974
+MedTermIDRangeFacets: red +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=266177
+MedTermIDRangeFacets: president +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=263341
+MedTermIDRangeFacets: five +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=262923
+MedTermIDRangeFacets: t +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=262832
+MedTermIDRangeFacets: power +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=262586
+MedTermIDRangeFacets: river +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=262231
+MedTermIDRangeFacets: we +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=261001
+MedTermIDRangeFacets: song +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=260741
+MedTermIDRangeFacets: next +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=259039
+MedTermIDRangeFacets: articles +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=258949
+MedTermIDRangeFacets: point +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=258471
+MedTermIDRangeFacets: text +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=257803
+MedTermIDRangeFacets: according +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=256949
+MedTermIDRangeFacets: black +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=256526
+MedTermIDRangeFacets: george +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=256196
+MedTermIDRangeFacets: different +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=255951
+MedTermIDRangeFacets: ndash +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=255747
+MedTermIDRangeFacets: third +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=255690
+MedTermIDRangeFacets: tv +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=255429
+MedTermIDRangeFacets: law +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=255248
+MedTermIDRangeFacets: canada +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=254867
+MedTermIDRangeFacets: near +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=254492
+MedTermIDRangeFacets: built +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=254491
+MedTermIDRangeFacets: 1995 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=252837
+MedTermIDRangeFacets: how +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=252284
+MedTermIDRangeFacets: record +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=250484
+MedTermIDRangeFacets: french +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=250453
+MedTermIDRangeFacets: air +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=250411
+MedTermIDRangeFacets: king +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=250321
+MedTermIDRangeFacets: without +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=249926
+MedTermIDRangeFacets: though +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=248968
+MedTermIDRangeFacets: played +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=248191
+MedTermIDRangeFacets: park +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=247801
+MedTermIDRangeFacets: took +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=247388
+MedTermIDRangeFacets: association +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=247156
+MedTermIDRangeFacets: military +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=246727
+MedTermIDRangeFacets: robert +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=246405
+MedTermIDRangeFacets: above +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=246135
+MedTermIDRangeFacets: persondata +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=246119
+MedTermIDRangeFacets: career +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=245439
+MedTermIDRangeFacets: version +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=244541
+MedTermIDRangeFacets: again +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=244255
+MedTermIDRangeFacets: late +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=243636
+MedTermIDRangeFacets: published +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=243548
+MedTermIDRangeFacets: live +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=242147
+MedTermIDRangeFacets: h +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=241946
+MedTermIDRangeFacets: good +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=241649
+MedTermIDRangeFacets: player +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=241451
+MedTermIDRangeFacets: others +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=240487
+MedTermIDRangeFacets: america +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=240374
+MedTermIDRangeFacets: review +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=240157
+MedTermIDRangeFacets: station +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=239572
+MedTermIDRangeFacets: among +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=238986
+MedTermIDRangeFacets: section +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=238874
+MedTermIDRangeFacets: border +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=238540
+MedTermIDRangeFacets: your +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=237723
+MedTermIDRangeFacets: size +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=237662
+MedTermIDRangeFacets: births +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=237033
+MedTermIDRangeFacets: support +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=236989
+MedTermIDRangeFacets: german +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=236721
+MedTermIDRangeFacets: california +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=236086
+MedTermIDRangeFacets: given +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=235719
+MedTermIDRangeFacets: commons +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=235235
+MedTermIDRangeFacets: 1994 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=235100
+MedTermIDRangeFacets: start +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=233925
+MedTermIDRangeFacets: km +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=233831
+MedTermIDRangeFacets: said +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=233066
+MedTermIDRangeFacets: western +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=232781
+MedTermIDRangeFacets: won +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=232751
+MedTermIDRangeFacets: la +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=232610
+MedTermIDRangeFacets: held +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=232354
+MedTermIDRangeFacets: children +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=232342
+MedTermIDRangeFacets: does +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=232202
+MedTermIDRangeFacets: club +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=232173
+MedTermIDRangeFacets: source +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=231838
+MedTermIDRangeFacets: church +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=231667
+MedTermIDRangeFacets: format +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=231300
+MedTermIDRangeFacets: example +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=230457
+MedTermIDRangeFacets: development +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=230286
+MedTermIDRangeFacets: land +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=230284
+MedTermIDRangeFacets: total +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=230013
+MedTermIDRangeFacets: final +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=230006
+MedTermIDRangeFacets: 50 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=229614
+MedTermIDRangeFacets: please +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=229602
+MedTermIDRangeFacets: region +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=229561
+MedTermIDRangeFacets: here +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=229505
+MedTermIDRangeFacets: me +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=229204
+MedTermIDRangeFacets: caption +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=229172
+MedTermIDRangeFacets: must +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=228491
+MedTermIDRangeFacets: army +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=228105
+MedTermIDRangeFacets: l +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=227974
+MedTermIDRangeFacets: side +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=227747
+MedTermIDRangeFacets: society +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=226742
+MedTermIDRangeFacets: full +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=226457
+MedTermIDRangeFacets: few +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=226422
+MedTermIDRangeFacets: records +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=225886
+MedTermIDRangeFacets: below +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=225843
+MedTermIDRangeFacets: community +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=225571
+MedTermIDRangeFacets: office +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=225338
+MedTermIDRangeFacets: 1992 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=225200
+MedTermIDRangeFacets: road +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=225050
+MedTermIDRangeFacets: research +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=224925
+MedTermIDRangeFacets: various +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=224593
+MedTermIDRangeFacets: take +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=224260
+MedTermIDRangeFacets: wikipedia:persondata +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=222385
+MedTermIDRangeFacets: 1990 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=222154
+MedTermIDRangeFacets: 40 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=221687
+MedTermIDRangeFacets: created +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=220831
+MedTermIDRangeFacets: 1993 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=220776
+MedTermIDRangeFacets: france +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=220058
+MedTermIDRangeFacets: science +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=219988
+MedTermIDRangeFacets: every +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=219884
+MedTermIDRangeFacets: become +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=219753
+MedTermIDRangeFacets: modern +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=218831
+MedTermIDRangeFacets: post +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=218570
+MedTermIDRangeFacets: games +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=218434
+MedTermIDRangeFacets: michael +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=217311
+MedTermIDRangeFacets: current +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=217174
+MedTermIDRangeFacets: included +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=216978
+MedTermIDRangeFacets: ja +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=216549
+MedTermIDRangeFacets: magazine +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=215725
+MedTermIDRangeFacets: position +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=215493
+MedTermIDRangeFacets: australia +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=215391
+MedTermIDRangeFacets: archive +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=215381
+MedTermIDRangeFacets: union +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=214164
+MedTermIDRangeFacets: having +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=213416
+MedTermIDRangeFacets: g +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=212936
+MedTermIDRangeFacets: popular +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=212493
+MedTermIDRangeFacets: royal +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=211710
+MedTermIDRangeFacets: period +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=211690
+MedTermIDRangeFacets: little +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=211124
+MedTermIDRangeFacets: wikitable +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=210990
+MedTermIDRangeFacets: rock +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=210815
+MedTermIDRangeFacets: artist +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=210591
+MedTermIDRangeFacets: play +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=210199
+MedTermIDRangeFacets: led +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=210033
+MedTermIDRangeFacets: notes +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=210029
+MedTermIDRangeFacets: water +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=209444
+MedTermIDRangeFacets: business +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=209353
+MedTermIDRangeFacets: art +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=209322
+MedTermIDRangeFacets: common +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=209310
+MedTermIDRangeFacets: co +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=209086
+MedTermIDRangeFacets: education +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=208909
+MedTermIDRangeFacets: role +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=208579
+MedTermIDRangeFacets: 1991 +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=207589
+MedTermIDRangeFacets: case +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=207307
+MedTermIDRangeFacets: paul +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=207229
+MedTermIDRangeFacets: media +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=206574
+MedTermIDRangeFacets: div +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=206057
+MedTermIDRangeFacets: census +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=205166
+MedTermIDRangeFacets: charles +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=204987
+MedTermIDRangeFacets: written +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=204891
+MedTermIDRangeFacets: pp +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=204742
+MedTermIDRangeFacets: green +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=203371
+MedTermIDRangeFacets: island +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=203023
+MedTermIDRangeFacets: never +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=203017
+MedTermIDRangeFacets: making +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=203003
+MedTermIDRangeFacets: term +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=202691
+MedTermIDRangeFacets: video +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=202380
+MedTermIDRangeFacets: son +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=202340
+MedTermIDRangeFacets: discussion +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=202145
+MedTermIDRangeFacets: died +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=202125
+MedTermIDRangeFacets: view +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=201593
+MedTermIDRangeFacets: street +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=200985
+MedTermIDRangeFacets: council +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=200706
+MedTermIDRangeFacets: re +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=199632
+MedTermIDRangeFacets: award +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=199318
+MedTermIDRangeFacets: works +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=199177
+MedTermIDRangeFacets: special +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=198917
+MedTermIDRangeFacets: force +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=198556
+MedTermIDRangeFacets: six +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=197970
+MedTermIDRangeFacets: came +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=197126
+MedTermIDRangeFacets: building +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=196508
+MedTermIDRangeFacets: young +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=196428
+MedTermIDRangeFacets: together +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=195949
+MedTermIDRangeFacets: important +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=195851
+MedTermIDRangeFacets: star +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=195768
+MedTermIDRangeFacets: similar +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=195171
+MedTermIDRangeFacets: received +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=194983
+MedTermIDRangeFacets: sup +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=194723
+MedTermIDRangeFacets: head +facets:range:long|id|0-2000000,3000000-6000000,7000000-9500000 # freq=194682
+
+MedTermIDOvlpRangeFacets: most +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=819634
+MedTermIDOvlpRangeFacets: up +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=818546
+MedTermIDOvlpRangeFacets: world +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=808563
+MedTermIDOvlpRangeFacets: 2007 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=801586
+MedTermIDOvlpRangeFacets: during +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=798114
+MedTermIDOvlpRangeFacets: people +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=790960
+MedTermIDOvlpRangeFacets: years +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=789628
+MedTermIDOvlpRangeFacets: such +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=787877
+MedTermIDOvlpRangeFacets: 12 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=774572
+MedTermIDOvlpRangeFacets: over +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=774312
+MedTermIDOvlpRangeFacets: can +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=765163
+MedTermIDOvlpRangeFacets: references +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=760306
+MedTermIDOvlpRangeFacets: city +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=760272
+MedTermIDOvlpRangeFacets: 6 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=759234
+MedTermIDOvlpRangeFacets: american +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=758337
+MedTermIDOvlpRangeFacets: news +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=756063
+MedTermIDOvlpRangeFacets: history +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=755471
+MedTermIDOvlpRangeFacets: 0 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=754451
+MedTermIDOvlpRangeFacets: made +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=742313
+MedTermIDOvlpRangeFacets: out +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=733775
+MedTermIDOvlpRangeFacets: 11 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=730505
+MedTermIDOvlpRangeFacets: used +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=708455
+MedTermIDOvlpRangeFacets: links +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=703350
+MedTermIDOvlpRangeFacets: state +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=702598
+MedTermIDOvlpRangeFacets: many +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=694439
+MedTermIDOvlpRangeFacets: would +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=690480
+MedTermIDOvlpRangeFacets: page +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=681036
+MedTermIDOvlpRangeFacets: national +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=677281
+MedTermIDOvlpRangeFacets: than +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=676864
+MedTermIDOvlpRangeFacets: thumb +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=672667
+MedTermIDOvlpRangeFacets: 7 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=660220
+MedTermIDOvlpRangeFacets: place +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=654158
+MedTermIDOvlpRangeFacets: de +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=652242
+MedTermIDOvlpRangeFacets: if +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=640551
+MedTermIDOvlpRangeFacets: university +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=636959
+MedTermIDOvlpRangeFacets: 8 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=635822
+MedTermIDOvlpRangeFacets: external +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=635450
+MedTermIDOvlpRangeFacets: between +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=630650
+MedTermIDOvlpRangeFacets: where +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=630647
+MedTermIDOvlpRangeFacets: right +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=630423
+MedTermIDOvlpRangeFacets: 20 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=624967
+MedTermIDOvlpRangeFacets: under +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=623872
+MedTermIDOvlpRangeFacets: these +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=623267
+MedTermIDOvlpRangeFacets: march +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=620393
+MedTermIDOvlpRangeFacets: br +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=617824
+MedTermIDOvlpRangeFacets: book +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=617297
+MedTermIDOvlpRangeFacets: p +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=616159
+MedTermIDOvlpRangeFacets: article +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=610650
+MedTermIDOvlpRangeFacets: known +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=607158
+MedTermIDOvlpRangeFacets: then +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=606159
+MedTermIDOvlpRangeFacets: style +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=606000
+MedTermIDOvlpRangeFacets: later +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=604921
+MedTermIDOvlpRangeFacets: three +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=598349
+MedTermIDOvlpRangeFacets: use +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=597053
+MedTermIDOvlpRangeFacets: category +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=595446
+MedTermIDOvlpRangeFacets: john +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=594461
+MedTermIDOvlpRangeFacets: part +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=594224
+MedTermIDOvlpRangeFacets: left +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=593967
+MedTermIDOvlpRangeFacets: 2004 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=593934
+MedTermIDOvlpRangeFacets: 15 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=592407
+MedTermIDOvlpRangeFacets: december +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=590171
+MedTermIDOvlpRangeFacets: april +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=587542
+MedTermIDOvlpRangeFacets: list +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=585922
+MedTermIDOvlpRangeFacets: 18 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=585631
+MedTermIDOvlpRangeFacets: small +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=581643
+MedTermIDOvlpRangeFacets: january +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=581309
+MedTermIDOvlpRangeFacets: before +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=580481
+MedTermIDOvlpRangeFacets: being +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=580185
+MedTermIDOvlpRangeFacets: well +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=580011
+MedTermIDOvlpRangeFacets: id +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=579566
+MedTermIDOvlpRangeFacets: while +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=579117
+MedTermIDOvlpRangeFacets: 9 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=574434
+MedTermIDOvlpRangeFacets: death +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=568895
+MedTermIDOvlpRangeFacets: author +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=567768
+MedTermIDOvlpRangeFacets: however +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=566494
+MedTermIDOvlpRangeFacets: october +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=566229
+MedTermIDOvlpRangeFacets: north +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=564195
+MedTermIDOvlpRangeFacets: so +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=562598
+MedTermIDOvlpRangeFacets: reflist +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=561253
+MedTermIDOvlpRangeFacets: south +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=560468
+MedTermIDOvlpRangeFacets: area +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=559023
+MedTermIDOvlpRangeFacets: class +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=556838
+MedTermIDOvlpRangeFacets: september +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=553409
+MedTermIDOvlpRangeFacets: war +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=547417
+MedTermIDOvlpRangeFacets: image +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=541747
+MedTermIDOvlpRangeFacets: 16 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=540539
+MedTermIDOvlpRangeFacets: both +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=534900
+MedTermIDOvlpRangeFacets: 14 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=534005
+MedTermIDOvlpRangeFacets: 13 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=530419
+MedTermIDOvlpRangeFacets: july +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=529655
+MedTermIDOvlpRangeFacets: august +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=527806
+MedTermIDOvlpRangeFacets: november +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=527131
+MedTermIDOvlpRangeFacets: end +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=526636
+MedTermIDOvlpRangeFacets: february +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=524886
+MedTermIDOvlpRangeFacets: infobox +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=524810
+MedTermIDOvlpRangeFacets: june +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=522519
+MedTermIDOvlpRangeFacets: series +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=521861
+MedTermIDOvlpRangeFacets: york +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=521383
+MedTermIDOvlpRangeFacets: including +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=521324
+MedTermIDOvlpRangeFacets: county +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=521126
+MedTermIDOvlpRangeFacets: them +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=520298
+MedTermIDOvlpRangeFacets: her +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=518717
+MedTermIDOvlpRangeFacets: through +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=514966
+MedTermIDOvlpRangeFacets: do +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=511178
+MedTermIDOvlpRangeFacets: 17 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=507396
+MedTermIDOvlpRangeFacets: him +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=507350
+MedTermIDOvlpRangeFacets: nbsp +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=506054
+MedTermIDOvlpRangeFacets: second +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=505575
+MedTermIDOvlpRangeFacets: 22 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=502778
+MedTermIDOvlpRangeFacets: html +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=500198
+MedTermIDOvlpRangeFacets: 2000 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=499639
+MedTermIDOvlpRangeFacets: 25 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=491957
+MedTermIDOvlpRangeFacets: location +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=489791
+MedTermIDOvlpRangeFacets: will +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=489711
+MedTermIDOvlpRangeFacets: center +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=489673
+MedTermIDOvlpRangeFacets: 30 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=488930
+MedTermIDOvlpRangeFacets: since +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=485325
+MedTermIDOvlpRangeFacets: 19 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=484187
+MedTermIDOvlpRangeFacets: now +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=484114
+MedTermIDOvlpRangeFacets: any +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=483514
+MedTermIDOvlpRangeFacets: early +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=482793
+MedTermIDOvlpRangeFacets: 21 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=482314
+MedTermIDOvlpRangeFacets: high +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=482152
+MedTermIDOvlpRangeFacets: like +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=479390
+MedTermIDOvlpRangeFacets: life +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=477007
+MedTermIDOvlpRangeFacets: general +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=476690
+MedTermIDOvlpRangeFacets: music +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=473240
+MedTermIDOvlpRangeFacets: number +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=473154
+MedTermIDOvlpRangeFacets: 24 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=470708
+MedTermIDOvlpRangeFacets: main +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=470429
+MedTermIDOvlpRangeFacets: isbn +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=467574
+MedTermIDOvlpRangeFacets: pages +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=466290
+MedTermIDOvlpRangeFacets: became +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=465594
+MedTermIDOvlpRangeFacets: short +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=465205
+MedTermIDOvlpRangeFacets: school +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=462166
+MedTermIDOvlpRangeFacets: you +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=461587
+MedTermIDOvlpRangeFacets: 23 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=457097
+MedTermIDOvlpRangeFacets: 2003 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=456990
+MedTermIDOvlpRangeFacets: called +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=454580
+MedTermIDOvlpRangeFacets: utc +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=450225
+MedTermIDOvlpRangeFacets: n +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=449994
+MedTermIDOvlpRangeFacets: c +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=444247
+MedTermIDOvlpRangeFacets: group +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=442503
+MedTermIDOvlpRangeFacets: m +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=441232
+MedTermIDOvlpRangeFacets: several +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=436129
+MedTermIDOvlpRangeFacets: website +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=435941
+MedTermIDOvlpRangeFacets: film +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=432758
+MedTermIDOvlpRangeFacets: west +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=431006
+MedTermIDOvlpRangeFacets: u.s +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=428534
+MedTermIDOvlpRangeFacets: she +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=426267
+MedTermIDOvlpRangeFacets: until +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=425389
+MedTermIDOvlpRangeFacets: birth +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=425138
+MedTermIDOvlpRangeFacets: us +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=421210
+MedTermIDOvlpRangeFacets: same +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=420741
+MedTermIDOvlpRangeFacets: country +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=420052
+MedTermIDOvlpRangeFacets: international +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=418261
+MedTermIDOvlpRangeFacets: british +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=417307
+MedTermIDOvlpRangeFacets: language +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=416771
+MedTermIDOvlpRangeFacets: following +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=416515
+MedTermIDOvlpRangeFacets: because +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=413003
+MedTermIDOvlpRangeFacets: system +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=412862
+MedTermIDOvlpRangeFacets: english +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=412061
+MedTermIDOvlpRangeFacets: 2001 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=410364
+MedTermIDOvlpRangeFacets: e +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=408741
+MedTermIDOvlpRangeFacets: times +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=407155
+MedTermIDOvlpRangeFacets: 2002 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=406953
+MedTermIDOvlpRangeFacets: names +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=404796
+MedTermIDOvlpRangeFacets: w +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=404764
+MedTermIDOvlpRangeFacets: day +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=402096
+MedTermIDOvlpRangeFacets: should +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=401379
+MedTermIDOvlpRangeFacets: against +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=399228
+MedTermIDOvlpRangeFacets: press +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=398988
+MedTermIDOvlpRangeFacets: based +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=398415
+MedTermIDOvlpRangeFacets: age +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=395368
+MedTermIDOvlpRangeFacets: what +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=394675
+MedTermIDOvlpRangeFacets: party +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=394410
+MedTermIDOvlpRangeFacets: company +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=391520
+MedTermIDOvlpRangeFacets: four +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=389818
+MedTermIDOvlpRangeFacets: 28 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=389552
+MedTermIDOvlpRangeFacets: 26 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=389026
+MedTermIDOvlpRangeFacets: family +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=387175
+MedTermIDOvlpRangeFacets: long +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=385787
+MedTermIDOvlpRangeFacets: century +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=385541
+MedTermIDOvlpRangeFacets: government +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=384004
+MedTermIDOvlpRangeFacets: 27 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=383042
+MedTermIDOvlpRangeFacets: old +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=381809
+MedTermIDOvlpRangeFacets: team +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=379028
+MedTermIDOvlpRangeFacets: house +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=377336
+MedTermIDOvlpRangeFacets: population +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=374481
+MedTermIDOvlpRangeFacets: 29 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=372091
+MedTermIDOvlpRangeFacets: b +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=369454
+MedTermIDOvlpRangeFacets: public +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=368868
+MedTermIDOvlpRangeFacets: home +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=367819
+MedTermIDOvlpRangeFacets: top +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=364628
+MedTermIDOvlpRangeFacets: east +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=364582
+MedTermIDOvlpRangeFacets: talk +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=364194
+MedTermIDOvlpRangeFacets: order +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=360915
+MedTermIDOvlpRangeFacets: line +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=360442
+MedTermIDOvlpRangeFacets: could +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=356679
+MedTermIDOvlpRangeFacets: 2012 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=355641
+MedTermIDOvlpRangeFacets: description +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=355070
+MedTermIDOvlpRangeFacets: very +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=354898
+MedTermIDOvlpRangeFacets: each +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=354583
+MedTermIDOvlpRangeFacets: information +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=353153
+MedTermIDOvlpRangeFacets: another +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=352496
+MedTermIDOvlpRangeFacets: born +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=352196
+MedTermIDOvlpRangeFacets: back +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=349276
+MedTermIDOvlpRangeFacets: london +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=348918
+MedTermIDOvlpRangeFacets: just +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=348911
+MedTermIDOvlpRangeFacets: town +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=348598
+MedTermIDOvlpRangeFacets: journal +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=348162
+MedTermIDOvlpRangeFacets: non +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=348142
+MedTermIDOvlpRangeFacets: color +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=347941
+MedTermIDOvlpRangeFacets: 01 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=347922
+MedTermIDOvlpRangeFacets: great +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=347499
+MedTermIDOvlpRangeFacets: although +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=341432
+MedTermIDOvlpRangeFacets: books +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=341376
+MedTermIDOvlpRangeFacets: ii +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=340800
+MedTermIDOvlpRangeFacets: major +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=340345
+MedTermIDOvlpRangeFacets: further +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=339350
+MedTermIDOvlpRangeFacets: 1999 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=334887
+MedTermIDOvlpRangeFacets: around +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=334840
+MedTermIDOvlpRangeFacets: best +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=334550
+MedTermIDOvlpRangeFacets: former +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=332750
+MedTermIDOvlpRangeFacets: still +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=332543
+MedTermIDOvlpRangeFacets: album +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=331360
+MedTermIDOvlpRangeFacets: stub +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=329768
+MedTermIDOvlpRangeFacets: did +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=328303
+MedTermIDOvlpRangeFacets: j +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=327713
+MedTermIDOvlpRangeFacets: even +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=326231
+MedTermIDOvlpRangeFacets: official +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=326177
+MedTermIDOvlpRangeFacets: original +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=323521
+MedTermIDOvlpRangeFacets: user +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=323242
+MedTermIDOvlpRangeFacets: alternative +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=322536
+MedTermIDOvlpRangeFacets: released +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=322473
+MedTermIDOvlpRangeFacets: jpg +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=322278
+MedTermIDOvlpRangeFacets: issue +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=322106
+MedTermIDOvlpRangeFacets: own +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=321703
+MedTermIDOvlpRangeFacets: season +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=320228
+MedTermIDOvlpRangeFacets: those +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=320013
+MedTermIDOvlpRangeFacets: 02 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=319783
+MedTermIDOvlpRangeFacets: uk +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=319211
+MedTermIDOvlpRangeFacets: way +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=318344
+MedTermIDOvlpRangeFacets: type +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=318210
+MedTermIDOvlpRangeFacets: 03 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=318112
+MedTermIDOvlpRangeFacets: england +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=317884
+MedTermIDOvlpRangeFacets: much +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=317670
+MedTermIDOvlpRangeFacets: off +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=315473
+MedTermIDOvlpRangeFacets: game +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=315157
+MedTermIDOvlpRangeFacets: background +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=314229
+MedTermIDOvlpRangeFacets: 04 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=313827
+MedTermIDOvlpRangeFacets: found +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=313247
+MedTermIDOvlpRangeFacets: volume +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=312846
+MedTermIDOvlpRangeFacets: named +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=310150
+MedTermIDOvlpRangeFacets: service +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=309976
+MedTermIDOvlpRangeFacets: d +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=309729
+MedTermIDOvlpRangeFacets: st +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=309092
+MedTermIDOvlpRangeFacets: large +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=308888
+MedTermIDOvlpRangeFacets: often +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=307684
+MedTermIDOvlpRangeFacets: 06 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=305698
+MedTermIDOvlpRangeFacets: 05 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=302860
+MedTermIDOvlpRangeFacets: 1998 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=300506
+MedTermIDOvlpRangeFacets: align +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=300455
+MedTermIDOvlpRangeFacets: kingdom +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=299825
+MedTermIDOvlpRangeFacets: using +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=299474
+MedTermIDOvlpRangeFacets: white +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=299411
+MedTermIDOvlpRangeFacets: 07 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=299351
+MedTermIDOvlpRangeFacets: district +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=299108
+MedTermIDOvlpRangeFacets: local +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=299012
+MedTermIDOvlpRangeFacets: metadata +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=298533
+MedTermIDOvlpRangeFacets: 31 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=298349
+MedTermIDOvlpRangeFacets: 08 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=297258
+MedTermIDOvlpRangeFacets: 09 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=296300
+MedTermIDOvlpRangeFacets: r +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=296283
+MedTermIDOvlpRangeFacets: set +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=294255
+MedTermIDOvlpRangeFacets: show +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=293934
+MedTermIDOvlpRangeFacets: david +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=292847
+MedTermIDOvlpRangeFacets: make +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=292607
+MedTermIDOvlpRangeFacets: story +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=292404
+MedTermIDOvlpRangeFacets: citation +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=291478
+MedTermIDOvlpRangeFacets: within +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=291049
+MedTermIDOvlpRangeFacets: due +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=290531
+MedTermIDOvlpRangeFacets: link +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=287552
+MedTermIDOvlpRangeFacets: 1997 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=286789
+MedTermIDOvlpRangeFacets: members +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=286028
+MedTermIDOvlpRangeFacets: william +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=284592
+MedTermIDOvlpRangeFacets: along +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=284442
+MedTermIDOvlpRangeFacets: v +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=284318
+MedTermIDOvlpRangeFacets: located +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=283899
+MedTermIDOvlpRangeFacets: single +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=283824
+MedTermIDOvlpRangeFacets: per +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=283568
+MedTermIDOvlpRangeFacets: established +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=282471
+MedTermIDOvlpRangeFacets: james +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=281597
+MedTermIDOvlpRangeFacets: needed +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=281051
+MedTermIDOvlpRangeFacets: down +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=280662
+MedTermIDOvlpRangeFacets: present +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=278449
+MedTermIDOvlpRangeFacets: man +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=278112
+MedTermIDOvlpRangeFacets: college +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=278094
+MedTermIDOvlpRangeFacets: f +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=278015
+MedTermIDOvlpRangeFacets: site +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=277788
+MedTermIDOvlpRangeFacets: football +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=277738
+MedTermIDOvlpRangeFacets: en +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=277463
+MedTermIDOvlpRangeFacets: result +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=276803
+MedTermIDOvlpRangeFacets: include +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=276466
+MedTermIDOvlpRangeFacets: began +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=276036
+MedTermIDOvlpRangeFacets: my +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=274256
+MedTermIDOvlpRangeFacets: x +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=272695
+MedTermIDOvlpRangeFacets: central +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=272531
+MedTermIDOvlpRangeFacets: band +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=272207
+MedTermIDOvlpRangeFacets: 1996 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=271980
+MedTermIDOvlpRangeFacets: form +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=271966
+MedTermIDOvlpRangeFacets: member +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=271607
+MedTermIDOvlpRangeFacets: television +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=271426
+MedTermIDOvlpRangeFacets: league +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=270223
+MedTermIDOvlpRangeFacets: free +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=270199
+MedTermIDOvlpRangeFacets: political +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=269665
+MedTermIDOvlpRangeFacets: font +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=269439
+MedTermIDOvlpRangeFacets: 100 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=268978
+MedTermIDOvlpRangeFacets: convert +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=267974
+MedTermIDOvlpRangeFacets: red +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=266177
+MedTermIDOvlpRangeFacets: president +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=263341
+MedTermIDOvlpRangeFacets: five +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=262923
+MedTermIDOvlpRangeFacets: t +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=262832
+MedTermIDOvlpRangeFacets: power +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=262586
+MedTermIDOvlpRangeFacets: river +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=262231
+MedTermIDOvlpRangeFacets: we +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=261001
+MedTermIDOvlpRangeFacets: song +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=260741
+MedTermIDOvlpRangeFacets: next +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=259039
+MedTermIDOvlpRangeFacets: articles +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=258949
+MedTermIDOvlpRangeFacets: point +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=258471
+MedTermIDOvlpRangeFacets: text +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=257803
+MedTermIDOvlpRangeFacets: according +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=256949
+MedTermIDOvlpRangeFacets: black +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=256526
+MedTermIDOvlpRangeFacets: george +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=256196
+MedTermIDOvlpRangeFacets: different +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=255951
+MedTermIDOvlpRangeFacets: ndash +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=255747
+MedTermIDOvlpRangeFacets: third +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=255690
+MedTermIDOvlpRangeFacets: tv +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=255429
+MedTermIDOvlpRangeFacets: law +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=255248
+MedTermIDOvlpRangeFacets: canada +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=254867
+MedTermIDOvlpRangeFacets: near +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=254492
+MedTermIDOvlpRangeFacets: built +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=254491
+MedTermIDOvlpRangeFacets: 1995 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=252837
+MedTermIDOvlpRangeFacets: how +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=252284
+MedTermIDOvlpRangeFacets: record +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=250484
+MedTermIDOvlpRangeFacets: french +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=250453
+MedTermIDOvlpRangeFacets: air +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=250411
+MedTermIDOvlpRangeFacets: king +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=250321
+MedTermIDOvlpRangeFacets: without +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=249926
+MedTermIDOvlpRangeFacets: though +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=248968
+MedTermIDOvlpRangeFacets: played +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=248191
+MedTermIDOvlpRangeFacets: park +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=247801
+MedTermIDOvlpRangeFacets: took +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=247388
+MedTermIDOvlpRangeFacets: association +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=247156
+MedTermIDOvlpRangeFacets: military +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=246727
+MedTermIDOvlpRangeFacets: robert +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=246405
+MedTermIDOvlpRangeFacets: above +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=246135
+MedTermIDOvlpRangeFacets: persondata +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=246119
+MedTermIDOvlpRangeFacets: career +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=245439
+MedTermIDOvlpRangeFacets: version +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=244541
+MedTermIDOvlpRangeFacets: again +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=244255
+MedTermIDOvlpRangeFacets: late +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=243636
+MedTermIDOvlpRangeFacets: published +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=243548
+MedTermIDOvlpRangeFacets: live +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=242147
+MedTermIDOvlpRangeFacets: h +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=241946
+MedTermIDOvlpRangeFacets: good +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=241649
+MedTermIDOvlpRangeFacets: player +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=241451
+MedTermIDOvlpRangeFacets: others +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=240487
+MedTermIDOvlpRangeFacets: america +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=240374
+MedTermIDOvlpRangeFacets: review +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=240157
+MedTermIDOvlpRangeFacets: station +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=239572
+MedTermIDOvlpRangeFacets: among +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=238986
+MedTermIDOvlpRangeFacets: section +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=238874
+MedTermIDOvlpRangeFacets: border +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=238540
+MedTermIDOvlpRangeFacets: your +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=237723
+MedTermIDOvlpRangeFacets: size +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=237662
+MedTermIDOvlpRangeFacets: births +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=237033
+MedTermIDOvlpRangeFacets: support +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=236989
+MedTermIDOvlpRangeFacets: german +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=236721
+MedTermIDOvlpRangeFacets: california +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=236086
+MedTermIDOvlpRangeFacets: given +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=235719
+MedTermIDOvlpRangeFacets: commons +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=235235
+MedTermIDOvlpRangeFacets: 1994 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=235100
+MedTermIDOvlpRangeFacets: start +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=233925
+MedTermIDOvlpRangeFacets: km +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=233831
+MedTermIDOvlpRangeFacets: said +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=233066
+MedTermIDOvlpRangeFacets: western +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=232781
+MedTermIDOvlpRangeFacets: won +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=232751
+MedTermIDOvlpRangeFacets: la +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=232610
+MedTermIDOvlpRangeFacets: held +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=232354
+MedTermIDOvlpRangeFacets: children +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=232342
+MedTermIDOvlpRangeFacets: does +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=232202
+MedTermIDOvlpRangeFacets: club +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=232173
+MedTermIDOvlpRangeFacets: source +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=231838
+MedTermIDOvlpRangeFacets: church +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=231667
+MedTermIDOvlpRangeFacets: format +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=231300
+MedTermIDOvlpRangeFacets: example +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=230457
+MedTermIDOvlpRangeFacets: development +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=230286
+MedTermIDOvlpRangeFacets: land +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=230284
+MedTermIDOvlpRangeFacets: total +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=230013
+MedTermIDOvlpRangeFacets: final +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=230006
+MedTermIDOvlpRangeFacets: 50 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=229614
+MedTermIDOvlpRangeFacets: please +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=229602
+MedTermIDOvlpRangeFacets: region +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=229561
+MedTermIDOvlpRangeFacets: here +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=229505
+MedTermIDOvlpRangeFacets: me +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=229204
+MedTermIDOvlpRangeFacets: caption +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=229172
+MedTermIDOvlpRangeFacets: must +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=228491
+MedTermIDOvlpRangeFacets: army +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=228105
+MedTermIDOvlpRangeFacets: l +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=227974
+MedTermIDOvlpRangeFacets: side +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=227747
+MedTermIDOvlpRangeFacets: society +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=226742
+MedTermIDOvlpRangeFacets: full +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=226457
+MedTermIDOvlpRangeFacets: few +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=226422
+MedTermIDOvlpRangeFacets: records +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=225886
+MedTermIDOvlpRangeFacets: below +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=225843
+MedTermIDOvlpRangeFacets: community +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=225571
+MedTermIDOvlpRangeFacets: office +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=225338
+MedTermIDOvlpRangeFacets: 1992 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=225200
+MedTermIDOvlpRangeFacets: road +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=225050
+MedTermIDOvlpRangeFacets: research +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=224925
+MedTermIDOvlpRangeFacets: various +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=224593
+MedTermIDOvlpRangeFacets: take +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=224260
+MedTermIDOvlpRangeFacets: wikipedia:persondata +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=222385
+MedTermIDOvlpRangeFacets: 1990 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=222154
+MedTermIDOvlpRangeFacets: 40 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=221687
+MedTermIDOvlpRangeFacets: created +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=220831
+MedTermIDOvlpRangeFacets: 1993 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=220776
+MedTermIDOvlpRangeFacets: france +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=220058
+MedTermIDOvlpRangeFacets: science +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=219988
+MedTermIDOvlpRangeFacets: every +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=219884
+MedTermIDOvlpRangeFacets: become +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=219753
+MedTermIDOvlpRangeFacets: modern +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=218831
+MedTermIDOvlpRangeFacets: post +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=218570
+MedTermIDOvlpRangeFacets: games +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=218434
+MedTermIDOvlpRangeFacets: michael +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=217311
+MedTermIDOvlpRangeFacets: current +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=217174
+MedTermIDOvlpRangeFacets: included +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=216978
+MedTermIDOvlpRangeFacets: ja +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=216549
+MedTermIDOvlpRangeFacets: magazine +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=215725
+MedTermIDOvlpRangeFacets: position +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=215493
+MedTermIDOvlpRangeFacets: australia +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=215391
+MedTermIDOvlpRangeFacets: archive +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=215381
+MedTermIDOvlpRangeFacets: union +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=214164
+MedTermIDOvlpRangeFacets: having +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=213416
+MedTermIDOvlpRangeFacets: g +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=212936
+MedTermIDOvlpRangeFacets: popular +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=212493
+MedTermIDOvlpRangeFacets: royal +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=211710
+MedTermIDOvlpRangeFacets: period +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=211690
+MedTermIDOvlpRangeFacets: little +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=211124
+MedTermIDOvlpRangeFacets: wikitable +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=210990
+MedTermIDOvlpRangeFacets: rock +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=210815
+MedTermIDOvlpRangeFacets: artist +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=210591
+MedTermIDOvlpRangeFacets: play +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=210199
+MedTermIDOvlpRangeFacets: led +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=210033
+MedTermIDOvlpRangeFacets: notes +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=210029
+MedTermIDOvlpRangeFacets: water +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=209444
+MedTermIDOvlpRangeFacets: business +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=209353
+MedTermIDOvlpRangeFacets: art +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=209322
+MedTermIDOvlpRangeFacets: common +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=209310
+MedTermIDOvlpRangeFacets: co +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=209086
+MedTermIDOvlpRangeFacets: education +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=208909
+MedTermIDOvlpRangeFacets: role +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=208579
+MedTermIDOvlpRangeFacets: 1991 +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=207589
+MedTermIDOvlpRangeFacets: case +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=207307
+MedTermIDOvlpRangeFacets: paul +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=207229
+MedTermIDOvlpRangeFacets: media +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=206574
+MedTermIDOvlpRangeFacets: div +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=206057
+MedTermIDOvlpRangeFacets: census +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=205166
+MedTermIDOvlpRangeFacets: charles +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=204987
+MedTermIDOvlpRangeFacets: written +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=204891
+MedTermIDOvlpRangeFacets: pp +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=204742
+MedTermIDOvlpRangeFacets: green +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=203371
+MedTermIDOvlpRangeFacets: island +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=203023
+MedTermIDOvlpRangeFacets: never +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=203017
+MedTermIDOvlpRangeFacets: making +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=203003
+MedTermIDOvlpRangeFacets: term +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=202691
+MedTermIDOvlpRangeFacets: video +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=202380
+MedTermIDOvlpRangeFacets: son +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=202340
+MedTermIDOvlpRangeFacets: discussion +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=202145
+MedTermIDOvlpRangeFacets: died +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=202125
+MedTermIDOvlpRangeFacets: view +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=201593
+MedTermIDOvlpRangeFacets: street +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=200985
+MedTermIDOvlpRangeFacets: council +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=200706
+MedTermIDOvlpRangeFacets: re +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=199632
+MedTermIDOvlpRangeFacets: award +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=199318
+MedTermIDOvlpRangeFacets: works +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=199177
+MedTermIDOvlpRangeFacets: special +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=198917
+MedTermIDOvlpRangeFacets: force +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=198556
+MedTermIDOvlpRangeFacets: six +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=197970
+MedTermIDOvlpRangeFacets: came +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=197126
+MedTermIDOvlpRangeFacets: building +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=196508
+MedTermIDOvlpRangeFacets: young +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=196428
+MedTermIDOvlpRangeFacets: together +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=195949
+MedTermIDOvlpRangeFacets: important +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=195851
+MedTermIDOvlpRangeFacets: star +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=195768
+MedTermIDOvlpRangeFacets: similar +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=195171
+MedTermIDOvlpRangeFacets: received +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=194983
+MedTermIDOvlpRangeFacets: sup +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=194723
+MedTermIDOvlpRangeFacets: head +facets:range:long|id|0-4999999,2500000-7499999,5000000-9999999 # freq=194682

--- a/tasks/wikimedium.10M.nostopwords.tasks
+++ b/tasks/wikimedium.10M.nostopwords.tasks
@@ -14403,14 +14403,14 @@ OrNotHighLow: -do necessities # freq=511178 freq=1195
 OrHighNotLow: do -necessities # freq=511178 freq=1195
 OrNotHighLow: -had halfback # freq=1246743 freq=1205
 OrHighNotLow: had -halfback # freq=1246743 freq=1205
-BrowseDateTaxoFacets: *:* +facets:Date.taxonomy
-BrowseMonthTaxoFacets: *:* +facets:Month.taxonomy
-BrowseDayOfYearTaxoFacets: *:* +facets:DayOfYear.taxonomy
-BrowseDateSSDVFacets: *:* +facets:Date.sortedset
-BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
-BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
-BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
-BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
+BrowseDateTaxoFacets: *:* +facets:taxonomy:Date
+BrowseMonthTaxoFacets: *:* +facets:taxonomy:Month
+BrowseDayOfYearTaxoFacets: *:* +facets:taxonomy:DayOfYear
+BrowseDateSSDVFacets: *:* +facets:sortedset:Date
+BrowseMonthSSDVFacets: *:* +facets:sortedset:Month
+BrowseDayOfYearSSDVFacets: *:* +facets:sortedset:DayOfYear
+BrowseRandomLabelTaxoFacets: *:* +facets:taxonomy:RandomLabel
+BrowseRandomLabelSSDVFacets: *:* +facets:sortedset:RandomLabel
 range:dayOfYear:0-50,50-100,100-150,150-200,200-250,250-300,300-350,350-400
 range:dayOfYear:0-100,50-150,100-200,150-250,200-300,250-350,300-400
 range:dayOfYear:0-10,10-20,20-30,30-40,40-50,50-60,60-70,70-80,80-90,90-100,100-110,110-120,120-130,130-140,140-150,150-160,160-170,170-180,180-190,190-200,200-210,210-220,220-230,230-240,240-250,250-260,260-270,270-280,280-290,290-300,300-310,310-320,320-330,330-340,340-350,350-360,360-370,370-380,380-390
@@ -15133,2006 +15133,2006 @@ HighTermTitleBDVSort: titlebdvsort//century # freq=385541
 HighTermTitleBDVSort: titlebdvsort//government # freq=384004
 HighTermTitleBDVSort: titlebdvsort//27 # freq=383042
 HighTermTitleBDVSort: titlebdvsort//old # freq=381809
-MedTermDayTaxoFacets: most +facets:DayOfYear.taxonomy # freq=819634
-MedTermDayTaxoFacets: up +facets:DayOfYear.taxonomy # freq=818546
-MedTermDayTaxoFacets: world +facets:DayOfYear.taxonomy # freq=808563
-MedTermDayTaxoFacets: 2007 +facets:DayOfYear.taxonomy # freq=801586
-MedTermDayTaxoFacets: during +facets:DayOfYear.taxonomy # freq=798114
-MedTermDayTaxoFacets: people +facets:DayOfYear.taxonomy # freq=790960
-MedTermDayTaxoFacets: years +facets:DayOfYear.taxonomy # freq=789628
-MedTermDayTaxoFacets: such +facets:DayOfYear.taxonomy # freq=787877
-MedTermDayTaxoFacets: 12 +facets:DayOfYear.taxonomy # freq=774572
-MedTermDayTaxoFacets: over +facets:DayOfYear.taxonomy # freq=774312
-MedTermDayTaxoFacets: can +facets:DayOfYear.taxonomy # freq=765163
-MedTermDayTaxoFacets: references +facets:DayOfYear.taxonomy # freq=760306
-MedTermDayTaxoFacets: city +facets:DayOfYear.taxonomy # freq=760272
-MedTermDayTaxoFacets: 6 +facets:DayOfYear.taxonomy # freq=759234
-MedTermDayTaxoFacets: american +facets:DayOfYear.taxonomy # freq=758337
-MedTermDayTaxoFacets: news +facets:DayOfYear.taxonomy # freq=756063
-MedTermDayTaxoFacets: history +facets:DayOfYear.taxonomy # freq=755471
-MedTermDayTaxoFacets: 0 +facets:DayOfYear.taxonomy # freq=754451
-MedTermDayTaxoFacets: made +facets:DayOfYear.taxonomy # freq=742313
-MedTermDayTaxoFacets: out +facets:DayOfYear.taxonomy # freq=733775
-MedTermDayTaxoFacets: 11 +facets:DayOfYear.taxonomy # freq=730505
-MedTermDayTaxoFacets: used +facets:DayOfYear.taxonomy # freq=708455
-MedTermDayTaxoFacets: links +facets:DayOfYear.taxonomy # freq=703350
-MedTermDayTaxoFacets: state +facets:DayOfYear.taxonomy # freq=702598
-MedTermDayTaxoFacets: many +facets:DayOfYear.taxonomy # freq=694439
-MedTermDayTaxoFacets: would +facets:DayOfYear.taxonomy # freq=690480
-MedTermDayTaxoFacets: page +facets:DayOfYear.taxonomy # freq=681036
-MedTermDayTaxoFacets: national +facets:DayOfYear.taxonomy # freq=677281
-MedTermDayTaxoFacets: than +facets:DayOfYear.taxonomy # freq=676864
-MedTermDayTaxoFacets: thumb +facets:DayOfYear.taxonomy # freq=672667
-MedTermDayTaxoFacets: 7 +facets:DayOfYear.taxonomy # freq=660220
-MedTermDayTaxoFacets: place +facets:DayOfYear.taxonomy # freq=654158
-MedTermDayTaxoFacets: de +facets:DayOfYear.taxonomy # freq=652242
-MedTermDayTaxoFacets: if +facets:DayOfYear.taxonomy # freq=640551
-MedTermDayTaxoFacets: university +facets:DayOfYear.taxonomy # freq=636959
-MedTermDayTaxoFacets: 8 +facets:DayOfYear.taxonomy # freq=635822
-MedTermDayTaxoFacets: external +facets:DayOfYear.taxonomy # freq=635450
-MedTermDayTaxoFacets: between +facets:DayOfYear.taxonomy # freq=630650
-MedTermDayTaxoFacets: where +facets:DayOfYear.taxonomy # freq=630647
-MedTermDayTaxoFacets: right +facets:DayOfYear.taxonomy # freq=630423
-MedTermDayTaxoFacets: 20 +facets:DayOfYear.taxonomy # freq=624967
-MedTermDayTaxoFacets: under +facets:DayOfYear.taxonomy # freq=623872
-MedTermDayTaxoFacets: these +facets:DayOfYear.taxonomy # freq=623267
-MedTermDayTaxoFacets: march +facets:DayOfYear.taxonomy # freq=620393
-MedTermDayTaxoFacets: br +facets:DayOfYear.taxonomy # freq=617824
-MedTermDayTaxoFacets: book +facets:DayOfYear.taxonomy # freq=617297
-MedTermDayTaxoFacets: p +facets:DayOfYear.taxonomy # freq=616159
-MedTermDayTaxoFacets: article +facets:DayOfYear.taxonomy # freq=610650
-MedTermDayTaxoFacets: known +facets:DayOfYear.taxonomy # freq=607158
-MedTermDayTaxoFacets: then +facets:DayOfYear.taxonomy # freq=606159
-MedTermDayTaxoFacets: style +facets:DayOfYear.taxonomy # freq=606000
-MedTermDayTaxoFacets: later +facets:DayOfYear.taxonomy # freq=604921
-MedTermDayTaxoFacets: three +facets:DayOfYear.taxonomy # freq=598349
-MedTermDayTaxoFacets: use +facets:DayOfYear.taxonomy # freq=597053
-MedTermDayTaxoFacets: category +facets:DayOfYear.taxonomy # freq=595446
-MedTermDayTaxoFacets: john +facets:DayOfYear.taxonomy # freq=594461
-MedTermDayTaxoFacets: part +facets:DayOfYear.taxonomy # freq=594224
-MedTermDayTaxoFacets: left +facets:DayOfYear.taxonomy # freq=593967
-MedTermDayTaxoFacets: 2004 +facets:DayOfYear.taxonomy # freq=593934
-MedTermDayTaxoFacets: 15 +facets:DayOfYear.taxonomy # freq=592407
-MedTermDayTaxoFacets: december +facets:DayOfYear.taxonomy # freq=590171
-MedTermDayTaxoFacets: april +facets:DayOfYear.taxonomy # freq=587542
-MedTermDayTaxoFacets: list +facets:DayOfYear.taxonomy # freq=585922
-MedTermDayTaxoFacets: 18 +facets:DayOfYear.taxonomy # freq=585631
-MedTermDayTaxoFacets: small +facets:DayOfYear.taxonomy # freq=581643
-MedTermDayTaxoFacets: january +facets:DayOfYear.taxonomy # freq=581309
-MedTermDayTaxoFacets: before +facets:DayOfYear.taxonomy # freq=580481
-MedTermDayTaxoFacets: being +facets:DayOfYear.taxonomy # freq=580185
-MedTermDayTaxoFacets: well +facets:DayOfYear.taxonomy # freq=580011
-MedTermDayTaxoFacets: id +facets:DayOfYear.taxonomy # freq=579566
-MedTermDayTaxoFacets: while +facets:DayOfYear.taxonomy # freq=579117
-MedTermDayTaxoFacets: 9 +facets:DayOfYear.taxonomy # freq=574434
-MedTermDayTaxoFacets: death +facets:DayOfYear.taxonomy # freq=568895
-MedTermDayTaxoFacets: author +facets:DayOfYear.taxonomy # freq=567768
-MedTermDayTaxoFacets: however +facets:DayOfYear.taxonomy # freq=566494
-MedTermDayTaxoFacets: october +facets:DayOfYear.taxonomy # freq=566229
-MedTermDayTaxoFacets: north +facets:DayOfYear.taxonomy # freq=564195
-MedTermDayTaxoFacets: so +facets:DayOfYear.taxonomy # freq=562598
-MedTermDayTaxoFacets: reflist +facets:DayOfYear.taxonomy # freq=561253
-MedTermDayTaxoFacets: south +facets:DayOfYear.taxonomy # freq=560468
-MedTermDayTaxoFacets: area +facets:DayOfYear.taxonomy # freq=559023
-MedTermDayTaxoFacets: class +facets:DayOfYear.taxonomy # freq=556838
-MedTermDayTaxoFacets: september +facets:DayOfYear.taxonomy # freq=553409
-MedTermDayTaxoFacets: war +facets:DayOfYear.taxonomy # freq=547417
-MedTermDayTaxoFacets: image +facets:DayOfYear.taxonomy # freq=541747
-MedTermDayTaxoFacets: 16 +facets:DayOfYear.taxonomy # freq=540539
-MedTermDayTaxoFacets: both +facets:DayOfYear.taxonomy # freq=534900
-MedTermDayTaxoFacets: 14 +facets:DayOfYear.taxonomy # freq=534005
-MedTermDayTaxoFacets: 13 +facets:DayOfYear.taxonomy # freq=530419
-MedTermDayTaxoFacets: july +facets:DayOfYear.taxonomy # freq=529655
-MedTermDayTaxoFacets: august +facets:DayOfYear.taxonomy # freq=527806
-MedTermDayTaxoFacets: november +facets:DayOfYear.taxonomy # freq=527131
-MedTermDayTaxoFacets: end +facets:DayOfYear.taxonomy # freq=526636
-MedTermDayTaxoFacets: february +facets:DayOfYear.taxonomy # freq=524886
-MedTermDayTaxoFacets: infobox +facets:DayOfYear.taxonomy # freq=524810
-MedTermDayTaxoFacets: june +facets:DayOfYear.taxonomy # freq=522519
-MedTermDayTaxoFacets: series +facets:DayOfYear.taxonomy # freq=521861
-MedTermDayTaxoFacets: york +facets:DayOfYear.taxonomy # freq=521383
-MedTermDayTaxoFacets: including +facets:DayOfYear.taxonomy # freq=521324
-MedTermDayTaxoFacets: county +facets:DayOfYear.taxonomy # freq=521126
-MedTermDayTaxoFacets: them +facets:DayOfYear.taxonomy # freq=520298
-MedTermDayTaxoFacets: her +facets:DayOfYear.taxonomy # freq=518717
-MedTermDayTaxoFacets: through +facets:DayOfYear.taxonomy # freq=514966
-MedTermDayTaxoFacets: do +facets:DayOfYear.taxonomy # freq=511178
-MedTermDayTaxoFacets: 17 +facets:DayOfYear.taxonomy # freq=507396
-MedTermDayTaxoFacets: him +facets:DayOfYear.taxonomy # freq=507350
-MedTermDayTaxoFacets: nbsp +facets:DayOfYear.taxonomy # freq=506054
-MedTermDayTaxoFacets: second +facets:DayOfYear.taxonomy # freq=505575
-MedTermDayTaxoFacets: 22 +facets:DayOfYear.taxonomy # freq=502778
-MedTermDayTaxoFacets: html +facets:DayOfYear.taxonomy # freq=500198
-MedTermDayTaxoFacets: 2000 +facets:DayOfYear.taxonomy # freq=499639
-MedTermDayTaxoFacets: 25 +facets:DayOfYear.taxonomy # freq=491957
-MedTermDayTaxoFacets: location +facets:DayOfYear.taxonomy # freq=489791
-MedTermDayTaxoFacets: will +facets:DayOfYear.taxonomy # freq=489711
-MedTermDayTaxoFacets: center +facets:DayOfYear.taxonomy # freq=489673
-MedTermDayTaxoFacets: 30 +facets:DayOfYear.taxonomy # freq=488930
-MedTermDayTaxoFacets: since +facets:DayOfYear.taxonomy # freq=485325
-MedTermDayTaxoFacets: 19 +facets:DayOfYear.taxonomy # freq=484187
-MedTermDayTaxoFacets: now +facets:DayOfYear.taxonomy # freq=484114
-MedTermDayTaxoFacets: any +facets:DayOfYear.taxonomy # freq=483514
-MedTermDayTaxoFacets: early +facets:DayOfYear.taxonomy # freq=482793
-MedTermDayTaxoFacets: 21 +facets:DayOfYear.taxonomy # freq=482314
-MedTermDayTaxoFacets: high +facets:DayOfYear.taxonomy # freq=482152
-MedTermDayTaxoFacets: like +facets:DayOfYear.taxonomy # freq=479390
-MedTermDayTaxoFacets: life +facets:DayOfYear.taxonomy # freq=477007
-MedTermDayTaxoFacets: general +facets:DayOfYear.taxonomy # freq=476690
-MedTermDayTaxoFacets: music +facets:DayOfYear.taxonomy # freq=473240
-MedTermDayTaxoFacets: number +facets:DayOfYear.taxonomy # freq=473154
-MedTermDayTaxoFacets: 24 +facets:DayOfYear.taxonomy # freq=470708
-MedTermDayTaxoFacets: main +facets:DayOfYear.taxonomy # freq=470429
-MedTermDayTaxoFacets: isbn +facets:DayOfYear.taxonomy # freq=467574
-MedTermDayTaxoFacets: pages +facets:DayOfYear.taxonomy # freq=466290
-MedTermDayTaxoFacets: became +facets:DayOfYear.taxonomy # freq=465594
-MedTermDayTaxoFacets: short +facets:DayOfYear.taxonomy # freq=465205
-MedTermDayTaxoFacets: school +facets:DayOfYear.taxonomy # freq=462166
-MedTermDayTaxoFacets: you +facets:DayOfYear.taxonomy # freq=461587
-MedTermDayTaxoFacets: 23 +facets:DayOfYear.taxonomy # freq=457097
-MedTermDayTaxoFacets: 2003 +facets:DayOfYear.taxonomy # freq=456990
-MedTermDayTaxoFacets: called +facets:DayOfYear.taxonomy # freq=454580
-MedTermDayTaxoFacets: utc +facets:DayOfYear.taxonomy # freq=450225
-MedTermDayTaxoFacets: n +facets:DayOfYear.taxonomy # freq=449994
-MedTermDayTaxoFacets: c +facets:DayOfYear.taxonomy # freq=444247
-MedTermDayTaxoFacets: group +facets:DayOfYear.taxonomy # freq=442503
-MedTermDayTaxoFacets: m +facets:DayOfYear.taxonomy # freq=441232
-MedTermDayTaxoFacets: several +facets:DayOfYear.taxonomy # freq=436129
-MedTermDayTaxoFacets: website +facets:DayOfYear.taxonomy # freq=435941
-MedTermDayTaxoFacets: film +facets:DayOfYear.taxonomy # freq=432758
-MedTermDayTaxoFacets: west +facets:DayOfYear.taxonomy # freq=431006
-MedTermDayTaxoFacets: u.s +facets:DayOfYear.taxonomy # freq=428534
-MedTermDayTaxoFacets: she +facets:DayOfYear.taxonomy # freq=426267
-MedTermDayTaxoFacets: until +facets:DayOfYear.taxonomy # freq=425389
-MedTermDayTaxoFacets: birth +facets:DayOfYear.taxonomy # freq=425138
-MedTermDayTaxoFacets: us +facets:DayOfYear.taxonomy # freq=421210
-MedTermDayTaxoFacets: same +facets:DayOfYear.taxonomy # freq=420741
-MedTermDayTaxoFacets: country +facets:DayOfYear.taxonomy # freq=420052
-MedTermDayTaxoFacets: international +facets:DayOfYear.taxonomy # freq=418261
-MedTermDayTaxoFacets: british +facets:DayOfYear.taxonomy # freq=417307
-MedTermDayTaxoFacets: language +facets:DayOfYear.taxonomy # freq=416771
-MedTermDayTaxoFacets: following +facets:DayOfYear.taxonomy # freq=416515
-MedTermDayTaxoFacets: because +facets:DayOfYear.taxonomy # freq=413003
-MedTermDayTaxoFacets: system +facets:DayOfYear.taxonomy # freq=412862
-MedTermDayTaxoFacets: english +facets:DayOfYear.taxonomy # freq=412061
-MedTermDayTaxoFacets: 2001 +facets:DayOfYear.taxonomy # freq=410364
-MedTermDayTaxoFacets: e +facets:DayOfYear.taxonomy # freq=408741
-MedTermDayTaxoFacets: times +facets:DayOfYear.taxonomy # freq=407155
-MedTermDayTaxoFacets: 2002 +facets:DayOfYear.taxonomy # freq=406953
-MedTermDayTaxoFacets: names +facets:DayOfYear.taxonomy # freq=404796
-MedTermDayTaxoFacets: w +facets:DayOfYear.taxonomy # freq=404764
-MedTermDayTaxoFacets: day +facets:DayOfYear.taxonomy # freq=402096
-MedTermDayTaxoFacets: should +facets:DayOfYear.taxonomy # freq=401379
-MedTermDayTaxoFacets: against +facets:DayOfYear.taxonomy # freq=399228
-MedTermDayTaxoFacets: press +facets:DayOfYear.taxonomy # freq=398988
-MedTermDayTaxoFacets: based +facets:DayOfYear.taxonomy # freq=398415
-MedTermDayTaxoFacets: age +facets:DayOfYear.taxonomy # freq=395368
-MedTermDayTaxoFacets: what +facets:DayOfYear.taxonomy # freq=394675
-MedTermDayTaxoFacets: party +facets:DayOfYear.taxonomy # freq=394410
-MedTermDayTaxoFacets: company +facets:DayOfYear.taxonomy # freq=391520
-MedTermDayTaxoFacets: four +facets:DayOfYear.taxonomy # freq=389818
-MedTermDayTaxoFacets: 28 +facets:DayOfYear.taxonomy # freq=389552
-MedTermDayTaxoFacets: 26 +facets:DayOfYear.taxonomy # freq=389026
-MedTermDayTaxoFacets: family +facets:DayOfYear.taxonomy # freq=387175
-MedTermDayTaxoFacets: long +facets:DayOfYear.taxonomy # freq=385787
-MedTermDayTaxoFacets: century +facets:DayOfYear.taxonomy # freq=385541
-MedTermDayTaxoFacets: government +facets:DayOfYear.taxonomy # freq=384004
-MedTermDayTaxoFacets: 27 +facets:DayOfYear.taxonomy # freq=383042
-MedTermDayTaxoFacets: old +facets:DayOfYear.taxonomy # freq=381809
-MedTermDayTaxoFacets: team +facets:DayOfYear.taxonomy # freq=379028
-MedTermDayTaxoFacets: house +facets:DayOfYear.taxonomy # freq=377336
-MedTermDayTaxoFacets: population +facets:DayOfYear.taxonomy # freq=374481
-MedTermDayTaxoFacets: 29 +facets:DayOfYear.taxonomy # freq=372091
-MedTermDayTaxoFacets: b +facets:DayOfYear.taxonomy # freq=369454
-MedTermDayTaxoFacets: public +facets:DayOfYear.taxonomy # freq=368868
-MedTermDayTaxoFacets: home +facets:DayOfYear.taxonomy # freq=367819
-MedTermDayTaxoFacets: top +facets:DayOfYear.taxonomy # freq=364628
-MedTermDayTaxoFacets: east +facets:DayOfYear.taxonomy # freq=364582
-MedTermDayTaxoFacets: talk +facets:DayOfYear.taxonomy # freq=364194
-MedTermDayTaxoFacets: order +facets:DayOfYear.taxonomy # freq=360915
-MedTermDayTaxoFacets: line +facets:DayOfYear.taxonomy # freq=360442
-MedTermDayTaxoFacets: could +facets:DayOfYear.taxonomy # freq=356679
-MedTermDayTaxoFacets: 2012 +facets:DayOfYear.taxonomy # freq=355641
-MedTermDayTaxoFacets: description +facets:DayOfYear.taxonomy # freq=355070
-MedTermDayTaxoFacets: very +facets:DayOfYear.taxonomy # freq=354898
-MedTermDayTaxoFacets: each +facets:DayOfYear.taxonomy # freq=354583
-MedTermDayTaxoFacets: information +facets:DayOfYear.taxonomy # freq=353153
-MedTermDayTaxoFacets: another +facets:DayOfYear.taxonomy # freq=352496
-MedTermDayTaxoFacets: born +facets:DayOfYear.taxonomy # freq=352196
-MedTermDayTaxoFacets: back +facets:DayOfYear.taxonomy # freq=349276
-MedTermDayTaxoFacets: london +facets:DayOfYear.taxonomy # freq=348918
-MedTermDayTaxoFacets: just +facets:DayOfYear.taxonomy # freq=348911
-MedTermDayTaxoFacets: town +facets:DayOfYear.taxonomy # freq=348598
-MedTermDayTaxoFacets: journal +facets:DayOfYear.taxonomy # freq=348162
-MedTermDayTaxoFacets: non +facets:DayOfYear.taxonomy # freq=348142
-MedTermDayTaxoFacets: color +facets:DayOfYear.taxonomy # freq=347941
-MedTermDayTaxoFacets: 01 +facets:DayOfYear.taxonomy # freq=347922
-MedTermDayTaxoFacets: great +facets:DayOfYear.taxonomy # freq=347499
-MedTermDayTaxoFacets: although +facets:DayOfYear.taxonomy # freq=341432
-MedTermDayTaxoFacets: books +facets:DayOfYear.taxonomy # freq=341376
-MedTermDayTaxoFacets: ii +facets:DayOfYear.taxonomy # freq=340800
-MedTermDayTaxoFacets: major +facets:DayOfYear.taxonomy # freq=340345
-MedTermDayTaxoFacets: further +facets:DayOfYear.taxonomy # freq=339350
-MedTermDayTaxoFacets: 1999 +facets:DayOfYear.taxonomy # freq=334887
-MedTermDayTaxoFacets: around +facets:DayOfYear.taxonomy # freq=334840
-MedTermDayTaxoFacets: best +facets:DayOfYear.taxonomy # freq=334550
-MedTermDayTaxoFacets: former +facets:DayOfYear.taxonomy # freq=332750
-MedTermDayTaxoFacets: still +facets:DayOfYear.taxonomy # freq=332543
-MedTermDayTaxoFacets: album +facets:DayOfYear.taxonomy # freq=331360
-MedTermDayTaxoFacets: stub +facets:DayOfYear.taxonomy # freq=329768
-MedTermDayTaxoFacets: did +facets:DayOfYear.taxonomy # freq=328303
-MedTermDayTaxoFacets: j +facets:DayOfYear.taxonomy # freq=327713
-MedTermDayTaxoFacets: even +facets:DayOfYear.taxonomy # freq=326231
-MedTermDayTaxoFacets: official +facets:DayOfYear.taxonomy # freq=326177
-MedTermDayTaxoFacets: original +facets:DayOfYear.taxonomy # freq=323521
-MedTermDayTaxoFacets: user +facets:DayOfYear.taxonomy # freq=323242
-MedTermDayTaxoFacets: alternative +facets:DayOfYear.taxonomy # freq=322536
-MedTermDayTaxoFacets: released +facets:DayOfYear.taxonomy # freq=322473
-MedTermDayTaxoFacets: jpg +facets:DayOfYear.taxonomy # freq=322278
-MedTermDayTaxoFacets: issue +facets:DayOfYear.taxonomy # freq=322106
-MedTermDayTaxoFacets: own +facets:DayOfYear.taxonomy # freq=321703
-MedTermDayTaxoFacets: season +facets:DayOfYear.taxonomy # freq=320228
-MedTermDayTaxoFacets: those +facets:DayOfYear.taxonomy # freq=320013
-MedTermDayTaxoFacets: 02 +facets:DayOfYear.taxonomy # freq=319783
-MedTermDayTaxoFacets: uk +facets:DayOfYear.taxonomy # freq=319211
-MedTermDayTaxoFacets: way +facets:DayOfYear.taxonomy # freq=318344
-MedTermDayTaxoFacets: type +facets:DayOfYear.taxonomy # freq=318210
-MedTermDayTaxoFacets: 03 +facets:DayOfYear.taxonomy # freq=318112
-MedTermDayTaxoFacets: england +facets:DayOfYear.taxonomy # freq=317884
-MedTermDayTaxoFacets: much +facets:DayOfYear.taxonomy # freq=317670
-MedTermDayTaxoFacets: off +facets:DayOfYear.taxonomy # freq=315473
-MedTermDayTaxoFacets: game +facets:DayOfYear.taxonomy # freq=315157
-MedTermDayTaxoFacets: background +facets:DayOfYear.taxonomy # freq=314229
-MedTermDayTaxoFacets: 04 +facets:DayOfYear.taxonomy # freq=313827
-MedTermDayTaxoFacets: found +facets:DayOfYear.taxonomy # freq=313247
-MedTermDayTaxoFacets: volume +facets:DayOfYear.taxonomy # freq=312846
-MedTermDayTaxoFacets: named +facets:DayOfYear.taxonomy # freq=310150
-MedTermDayTaxoFacets: service +facets:DayOfYear.taxonomy # freq=309976
-MedTermDayTaxoFacets: d +facets:DayOfYear.taxonomy # freq=309729
-MedTermDayTaxoFacets: st +facets:DayOfYear.taxonomy # freq=309092
-MedTermDayTaxoFacets: large +facets:DayOfYear.taxonomy # freq=308888
-MedTermDayTaxoFacets: often +facets:DayOfYear.taxonomy # freq=307684
-MedTermDayTaxoFacets: 06 +facets:DayOfYear.taxonomy # freq=305698
-MedTermDayTaxoFacets: 05 +facets:DayOfYear.taxonomy # freq=302860
-MedTermDayTaxoFacets: 1998 +facets:DayOfYear.taxonomy # freq=300506
-MedTermDayTaxoFacets: align +facets:DayOfYear.taxonomy # freq=300455
-MedTermDayTaxoFacets: kingdom +facets:DayOfYear.taxonomy # freq=299825
-MedTermDayTaxoFacets: using +facets:DayOfYear.taxonomy # freq=299474
-MedTermDayTaxoFacets: white +facets:DayOfYear.taxonomy # freq=299411
-MedTermDayTaxoFacets: 07 +facets:DayOfYear.taxonomy # freq=299351
-MedTermDayTaxoFacets: district +facets:DayOfYear.taxonomy # freq=299108
-MedTermDayTaxoFacets: local +facets:DayOfYear.taxonomy # freq=299012
-MedTermDayTaxoFacets: metadata +facets:DayOfYear.taxonomy # freq=298533
-MedTermDayTaxoFacets: 31 +facets:DayOfYear.taxonomy # freq=298349
-MedTermDayTaxoFacets: 08 +facets:DayOfYear.taxonomy # freq=297258
-MedTermDayTaxoFacets: 09 +facets:DayOfYear.taxonomy # freq=296300
-MedTermDayTaxoFacets: r +facets:DayOfYear.taxonomy # freq=296283
-MedTermDayTaxoFacets: set +facets:DayOfYear.taxonomy # freq=294255
-MedTermDayTaxoFacets: show +facets:DayOfYear.taxonomy # freq=293934
-MedTermDayTaxoFacets: david +facets:DayOfYear.taxonomy # freq=292847
-MedTermDayTaxoFacets: make +facets:DayOfYear.taxonomy # freq=292607
-MedTermDayTaxoFacets: story +facets:DayOfYear.taxonomy # freq=292404
-MedTermDayTaxoFacets: citation +facets:DayOfYear.taxonomy # freq=291478
-MedTermDayTaxoFacets: within +facets:DayOfYear.taxonomy # freq=291049
-MedTermDayTaxoFacets: due +facets:DayOfYear.taxonomy # freq=290531
-MedTermDayTaxoFacets: link +facets:DayOfYear.taxonomy # freq=287552
-MedTermDayTaxoFacets: 1997 +facets:DayOfYear.taxonomy # freq=286789
-MedTermDayTaxoFacets: members +facets:DayOfYear.taxonomy # freq=286028
-MedTermDayTaxoFacets: william +facets:DayOfYear.taxonomy # freq=284592
-MedTermDayTaxoFacets: along +facets:DayOfYear.taxonomy # freq=284442
-MedTermDayTaxoFacets: v +facets:DayOfYear.taxonomy # freq=284318
-MedTermDayTaxoFacets: located +facets:DayOfYear.taxonomy # freq=283899
-MedTermDayTaxoFacets: single +facets:DayOfYear.taxonomy # freq=283824
-MedTermDayTaxoFacets: per +facets:DayOfYear.taxonomy # freq=283568
-MedTermDayTaxoFacets: established +facets:DayOfYear.taxonomy # freq=282471
-MedTermDayTaxoFacets: james +facets:DayOfYear.taxonomy # freq=281597
-MedTermDayTaxoFacets: needed +facets:DayOfYear.taxonomy # freq=281051
-MedTermDayTaxoFacets: down +facets:DayOfYear.taxonomy # freq=280662
-MedTermDayTaxoFacets: present +facets:DayOfYear.taxonomy # freq=278449
-MedTermDayTaxoFacets: man +facets:DayOfYear.taxonomy # freq=278112
-MedTermDayTaxoFacets: college +facets:DayOfYear.taxonomy # freq=278094
-MedTermDayTaxoFacets: f +facets:DayOfYear.taxonomy # freq=278015
-MedTermDayTaxoFacets: site +facets:DayOfYear.taxonomy # freq=277788
-MedTermDayTaxoFacets: football +facets:DayOfYear.taxonomy # freq=277738
-MedTermDayTaxoFacets: en +facets:DayOfYear.taxonomy # freq=277463
-MedTermDayTaxoFacets: result +facets:DayOfYear.taxonomy # freq=276803
-MedTermDayTaxoFacets: include +facets:DayOfYear.taxonomy # freq=276466
-MedTermDayTaxoFacets: began +facets:DayOfYear.taxonomy # freq=276036
-MedTermDayTaxoFacets: my +facets:DayOfYear.taxonomy # freq=274256
-MedTermDayTaxoFacets: x +facets:DayOfYear.taxonomy # freq=272695
-MedTermDayTaxoFacets: central +facets:DayOfYear.taxonomy # freq=272531
-MedTermDayTaxoFacets: band +facets:DayOfYear.taxonomy # freq=272207
-MedTermDayTaxoFacets: 1996 +facets:DayOfYear.taxonomy # freq=271980
-MedTermDayTaxoFacets: form +facets:DayOfYear.taxonomy # freq=271966
-MedTermDayTaxoFacets: member +facets:DayOfYear.taxonomy # freq=271607
-MedTermDayTaxoFacets: television +facets:DayOfYear.taxonomy # freq=271426
-MedTermDayTaxoFacets: league +facets:DayOfYear.taxonomy # freq=270223
-MedTermDayTaxoFacets: free +facets:DayOfYear.taxonomy # freq=270199
-MedTermDayTaxoFacets: political +facets:DayOfYear.taxonomy # freq=269665
-MedTermDayTaxoFacets: font +facets:DayOfYear.taxonomy # freq=269439
-MedTermDayTaxoFacets: 100 +facets:DayOfYear.taxonomy # freq=268978
-MedTermDayTaxoFacets: convert +facets:DayOfYear.taxonomy # freq=267974
-MedTermDayTaxoFacets: red +facets:DayOfYear.taxonomy # freq=266177
-MedTermDayTaxoFacets: president +facets:DayOfYear.taxonomy # freq=263341
-MedTermDayTaxoFacets: five +facets:DayOfYear.taxonomy # freq=262923
-MedTermDayTaxoFacets: t +facets:DayOfYear.taxonomy # freq=262832
-MedTermDayTaxoFacets: power +facets:DayOfYear.taxonomy # freq=262586
-MedTermDayTaxoFacets: river +facets:DayOfYear.taxonomy # freq=262231
-MedTermDayTaxoFacets: we +facets:DayOfYear.taxonomy # freq=261001
-MedTermDayTaxoFacets: song +facets:DayOfYear.taxonomy # freq=260741
-MedTermDayTaxoFacets: next +facets:DayOfYear.taxonomy # freq=259039
-MedTermDayTaxoFacets: articles +facets:DayOfYear.taxonomy # freq=258949
-MedTermDayTaxoFacets: point +facets:DayOfYear.taxonomy # freq=258471
-MedTermDayTaxoFacets: text +facets:DayOfYear.taxonomy # freq=257803
-MedTermDayTaxoFacets: according +facets:DayOfYear.taxonomy # freq=256949
-MedTermDayTaxoFacets: black +facets:DayOfYear.taxonomy # freq=256526
-MedTermDayTaxoFacets: george +facets:DayOfYear.taxonomy # freq=256196
-MedTermDayTaxoFacets: different +facets:DayOfYear.taxonomy # freq=255951
-MedTermDayTaxoFacets: ndash +facets:DayOfYear.taxonomy # freq=255747
-MedTermDayTaxoFacets: third +facets:DayOfYear.taxonomy # freq=255690
-MedTermDayTaxoFacets: tv +facets:DayOfYear.taxonomy # freq=255429
-MedTermDayTaxoFacets: law +facets:DayOfYear.taxonomy # freq=255248
-MedTermDayTaxoFacets: canada +facets:DayOfYear.taxonomy # freq=254867
-MedTermDayTaxoFacets: near +facets:DayOfYear.taxonomy # freq=254492
-MedTermDayTaxoFacets: built +facets:DayOfYear.taxonomy # freq=254491
-MedTermDayTaxoFacets: 1995 +facets:DayOfYear.taxonomy # freq=252837
-MedTermDayTaxoFacets: how +facets:DayOfYear.taxonomy # freq=252284
-MedTermDayTaxoFacets: record +facets:DayOfYear.taxonomy # freq=250484
-MedTermDayTaxoFacets: french +facets:DayOfYear.taxonomy # freq=250453
-MedTermDayTaxoFacets: air +facets:DayOfYear.taxonomy # freq=250411
-MedTermDayTaxoFacets: king +facets:DayOfYear.taxonomy # freq=250321
-MedTermDayTaxoFacets: without +facets:DayOfYear.taxonomy # freq=249926
-MedTermDayTaxoFacets: though +facets:DayOfYear.taxonomy # freq=248968
-MedTermDayTaxoFacets: played +facets:DayOfYear.taxonomy # freq=248191
-MedTermDayTaxoFacets: park +facets:DayOfYear.taxonomy # freq=247801
-MedTermDayTaxoFacets: took +facets:DayOfYear.taxonomy # freq=247388
-MedTermDayTaxoFacets: association +facets:DayOfYear.taxonomy # freq=247156
-MedTermDayTaxoFacets: military +facets:DayOfYear.taxonomy # freq=246727
-MedTermDayTaxoFacets: robert +facets:DayOfYear.taxonomy # freq=246405
-MedTermDayTaxoFacets: above +facets:DayOfYear.taxonomy # freq=246135
-MedTermDayTaxoFacets: persondata +facets:DayOfYear.taxonomy # freq=246119
-MedTermDayTaxoFacets: career +facets:DayOfYear.taxonomy # freq=245439
-MedTermDayTaxoFacets: version +facets:DayOfYear.taxonomy # freq=244541
-MedTermDayTaxoFacets: again +facets:DayOfYear.taxonomy # freq=244255
-MedTermDayTaxoFacets: late +facets:DayOfYear.taxonomy # freq=243636
-MedTermDayTaxoFacets: published +facets:DayOfYear.taxonomy # freq=243548
-MedTermDayTaxoFacets: live +facets:DayOfYear.taxonomy # freq=242147
-MedTermDayTaxoFacets: h +facets:DayOfYear.taxonomy # freq=241946
-MedTermDayTaxoFacets: good +facets:DayOfYear.taxonomy # freq=241649
-MedTermDayTaxoFacets: player +facets:DayOfYear.taxonomy # freq=241451
-MedTermDayTaxoFacets: others +facets:DayOfYear.taxonomy # freq=240487
-MedTermDayTaxoFacets: america +facets:DayOfYear.taxonomy # freq=240374
-MedTermDayTaxoFacets: review +facets:DayOfYear.taxonomy # freq=240157
-MedTermDayTaxoFacets: station +facets:DayOfYear.taxonomy # freq=239572
-MedTermDayTaxoFacets: among +facets:DayOfYear.taxonomy # freq=238986
-MedTermDayTaxoFacets: section +facets:DayOfYear.taxonomy # freq=238874
-MedTermDayTaxoFacets: border +facets:DayOfYear.taxonomy # freq=238540
-MedTermDayTaxoFacets: your +facets:DayOfYear.taxonomy # freq=237723
-MedTermDayTaxoFacets: size +facets:DayOfYear.taxonomy # freq=237662
-MedTermDayTaxoFacets: births +facets:DayOfYear.taxonomy # freq=237033
-MedTermDayTaxoFacets: support +facets:DayOfYear.taxonomy # freq=236989
-MedTermDayTaxoFacets: german +facets:DayOfYear.taxonomy # freq=236721
-MedTermDayTaxoFacets: california +facets:DayOfYear.taxonomy # freq=236086
-MedTermDayTaxoFacets: given +facets:DayOfYear.taxonomy # freq=235719
-MedTermDayTaxoFacets: commons +facets:DayOfYear.taxonomy # freq=235235
-MedTermDayTaxoFacets: 1994 +facets:DayOfYear.taxonomy # freq=235100
-MedTermDayTaxoFacets: start +facets:DayOfYear.taxonomy # freq=233925
-MedTermDayTaxoFacets: km +facets:DayOfYear.taxonomy # freq=233831
-MedTermDayTaxoFacets: said +facets:DayOfYear.taxonomy # freq=233066
-MedTermDayTaxoFacets: western +facets:DayOfYear.taxonomy # freq=232781
-MedTermDayTaxoFacets: won +facets:DayOfYear.taxonomy # freq=232751
-MedTermDayTaxoFacets: la +facets:DayOfYear.taxonomy # freq=232610
-MedTermDayTaxoFacets: held +facets:DayOfYear.taxonomy # freq=232354
-MedTermDayTaxoFacets: children +facets:DayOfYear.taxonomy # freq=232342
-MedTermDayTaxoFacets: does +facets:DayOfYear.taxonomy # freq=232202
-MedTermDayTaxoFacets: club +facets:DayOfYear.taxonomy # freq=232173
-MedTermDayTaxoFacets: source +facets:DayOfYear.taxonomy # freq=231838
-MedTermDayTaxoFacets: church +facets:DayOfYear.taxonomy # freq=231667
-MedTermDayTaxoFacets: format +facets:DayOfYear.taxonomy # freq=231300
-MedTermDayTaxoFacets: example +facets:DayOfYear.taxonomy # freq=230457
-MedTermDayTaxoFacets: development +facets:DayOfYear.taxonomy # freq=230286
-MedTermDayTaxoFacets: land +facets:DayOfYear.taxonomy # freq=230284
-MedTermDayTaxoFacets: total +facets:DayOfYear.taxonomy # freq=230013
-MedTermDayTaxoFacets: final +facets:DayOfYear.taxonomy # freq=230006
-MedTermDayTaxoFacets: 50 +facets:DayOfYear.taxonomy # freq=229614
-MedTermDayTaxoFacets: please +facets:DayOfYear.taxonomy # freq=229602
-MedTermDayTaxoFacets: region +facets:DayOfYear.taxonomy # freq=229561
-MedTermDayTaxoFacets: here +facets:DayOfYear.taxonomy # freq=229505
-MedTermDayTaxoFacets: me +facets:DayOfYear.taxonomy # freq=229204
-MedTermDayTaxoFacets: caption +facets:DayOfYear.taxonomy # freq=229172
-MedTermDayTaxoFacets: must +facets:DayOfYear.taxonomy # freq=228491
-MedTermDayTaxoFacets: army +facets:DayOfYear.taxonomy # freq=228105
-MedTermDayTaxoFacets: l +facets:DayOfYear.taxonomy # freq=227974
-MedTermDayTaxoFacets: side +facets:DayOfYear.taxonomy # freq=227747
-MedTermDayTaxoFacets: society +facets:DayOfYear.taxonomy # freq=226742
-MedTermDayTaxoFacets: full +facets:DayOfYear.taxonomy # freq=226457
-MedTermDayTaxoFacets: few +facets:DayOfYear.taxonomy # freq=226422
-MedTermDayTaxoFacets: records +facets:DayOfYear.taxonomy # freq=225886
-MedTermDayTaxoFacets: below +facets:DayOfYear.taxonomy # freq=225843
-MedTermDayTaxoFacets: community +facets:DayOfYear.taxonomy # freq=225571
-MedTermDayTaxoFacets: office +facets:DayOfYear.taxonomy # freq=225338
-MedTermDayTaxoFacets: 1992 +facets:DayOfYear.taxonomy # freq=225200
-MedTermDayTaxoFacets: road +facets:DayOfYear.taxonomy # freq=225050
-MedTermDayTaxoFacets: research +facets:DayOfYear.taxonomy # freq=224925
-MedTermDayTaxoFacets: various +facets:DayOfYear.taxonomy # freq=224593
-MedTermDayTaxoFacets: take +facets:DayOfYear.taxonomy # freq=224260
-MedTermDayTaxoFacets: wikipedia:persondata +facets:DayOfYear.taxonomy # freq=222385
-MedTermDayTaxoFacets: 1990 +facets:DayOfYear.taxonomy # freq=222154
-MedTermDayTaxoFacets: 40 +facets:DayOfYear.taxonomy # freq=221687
-MedTermDayTaxoFacets: created +facets:DayOfYear.taxonomy # freq=220831
-MedTermDayTaxoFacets: 1993 +facets:DayOfYear.taxonomy # freq=220776
-MedTermDayTaxoFacets: france +facets:DayOfYear.taxonomy # freq=220058
-MedTermDayTaxoFacets: science +facets:DayOfYear.taxonomy # freq=219988
-MedTermDayTaxoFacets: every +facets:DayOfYear.taxonomy # freq=219884
-MedTermDayTaxoFacets: become +facets:DayOfYear.taxonomy # freq=219753
-MedTermDayTaxoFacets: modern +facets:DayOfYear.taxonomy # freq=218831
-MedTermDayTaxoFacets: post +facets:DayOfYear.taxonomy # freq=218570
-MedTermDayTaxoFacets: games +facets:DayOfYear.taxonomy # freq=218434
-MedTermDayTaxoFacets: michael +facets:DayOfYear.taxonomy # freq=217311
-MedTermDayTaxoFacets: current +facets:DayOfYear.taxonomy # freq=217174
-MedTermDayTaxoFacets: included +facets:DayOfYear.taxonomy # freq=216978
-MedTermDayTaxoFacets: ja +facets:DayOfYear.taxonomy # freq=216549
-MedTermDayTaxoFacets: magazine +facets:DayOfYear.taxonomy # freq=215725
-MedTermDayTaxoFacets: position +facets:DayOfYear.taxonomy # freq=215493
-MedTermDayTaxoFacets: australia +facets:DayOfYear.taxonomy # freq=215391
-MedTermDayTaxoFacets: archive +facets:DayOfYear.taxonomy # freq=215381
-MedTermDayTaxoFacets: union +facets:DayOfYear.taxonomy # freq=214164
-MedTermDayTaxoFacets: having +facets:DayOfYear.taxonomy # freq=213416
-MedTermDayTaxoFacets: g +facets:DayOfYear.taxonomy # freq=212936
-MedTermDayTaxoFacets: popular +facets:DayOfYear.taxonomy # freq=212493
-MedTermDayTaxoFacets: royal +facets:DayOfYear.taxonomy # freq=211710
-MedTermDayTaxoFacets: period +facets:DayOfYear.taxonomy # freq=211690
-MedTermDayTaxoFacets: little +facets:DayOfYear.taxonomy # freq=211124
-MedTermDayTaxoFacets: wikitable +facets:DayOfYear.taxonomy # freq=210990
-MedTermDayTaxoFacets: rock +facets:DayOfYear.taxonomy # freq=210815
-MedTermDayTaxoFacets: artist +facets:DayOfYear.taxonomy # freq=210591
-MedTermDayTaxoFacets: play +facets:DayOfYear.taxonomy # freq=210199
-MedTermDayTaxoFacets: led +facets:DayOfYear.taxonomy # freq=210033
-MedTermDayTaxoFacets: notes +facets:DayOfYear.taxonomy # freq=210029
-MedTermDayTaxoFacets: water +facets:DayOfYear.taxonomy # freq=209444
-MedTermDayTaxoFacets: business +facets:DayOfYear.taxonomy # freq=209353
-MedTermDayTaxoFacets: art +facets:DayOfYear.taxonomy # freq=209322
-MedTermDayTaxoFacets: common +facets:DayOfYear.taxonomy # freq=209310
-MedTermDayTaxoFacets: co +facets:DayOfYear.taxonomy # freq=209086
-MedTermDayTaxoFacets: education +facets:DayOfYear.taxonomy # freq=208909
-MedTermDayTaxoFacets: role +facets:DayOfYear.taxonomy # freq=208579
-MedTermDayTaxoFacets: 1991 +facets:DayOfYear.taxonomy # freq=207589
-MedTermDayTaxoFacets: case +facets:DayOfYear.taxonomy # freq=207307
-MedTermDayTaxoFacets: paul +facets:DayOfYear.taxonomy # freq=207229
-MedTermDayTaxoFacets: media +facets:DayOfYear.taxonomy # freq=206574
-MedTermDayTaxoFacets: div +facets:DayOfYear.taxonomy # freq=206057
-MedTermDayTaxoFacets: census +facets:DayOfYear.taxonomy # freq=205166
-MedTermDayTaxoFacets: charles +facets:DayOfYear.taxonomy # freq=204987
-MedTermDayTaxoFacets: written +facets:DayOfYear.taxonomy # freq=204891
-MedTermDayTaxoFacets: pp +facets:DayOfYear.taxonomy # freq=204742
-MedTermDayTaxoFacets: green +facets:DayOfYear.taxonomy # freq=203371
-MedTermDayTaxoFacets: island +facets:DayOfYear.taxonomy # freq=203023
-MedTermDayTaxoFacets: never +facets:DayOfYear.taxonomy # freq=203017
-MedTermDayTaxoFacets: making +facets:DayOfYear.taxonomy # freq=203003
-MedTermDayTaxoFacets: term +facets:DayOfYear.taxonomy # freq=202691
-MedTermDayTaxoFacets: video +facets:DayOfYear.taxonomy # freq=202380
-MedTermDayTaxoFacets: son +facets:DayOfYear.taxonomy # freq=202340
-MedTermDayTaxoFacets: discussion +facets:DayOfYear.taxonomy # freq=202145
-MedTermDayTaxoFacets: died +facets:DayOfYear.taxonomy # freq=202125
-MedTermDayTaxoFacets: view +facets:DayOfYear.taxonomy # freq=201593
-MedTermDayTaxoFacets: street +facets:DayOfYear.taxonomy # freq=200985
-MedTermDayTaxoFacets: council +facets:DayOfYear.taxonomy # freq=200706
-MedTermDayTaxoFacets: re +facets:DayOfYear.taxonomy # freq=199632
-MedTermDayTaxoFacets: award +facets:DayOfYear.taxonomy # freq=199318
-MedTermDayTaxoFacets: works +facets:DayOfYear.taxonomy # freq=199177
-MedTermDayTaxoFacets: special +facets:DayOfYear.taxonomy # freq=198917
-MedTermDayTaxoFacets: force +facets:DayOfYear.taxonomy # freq=198556
-MedTermDayTaxoFacets: six +facets:DayOfYear.taxonomy # freq=197970
-MedTermDayTaxoFacets: came +facets:DayOfYear.taxonomy # freq=197126
-MedTermDayTaxoFacets: building +facets:DayOfYear.taxonomy # freq=196508
-MedTermDayTaxoFacets: young +facets:DayOfYear.taxonomy # freq=196428
-MedTermDayTaxoFacets: together +facets:DayOfYear.taxonomy # freq=195949
-MedTermDayTaxoFacets: important +facets:DayOfYear.taxonomy # freq=195851
-MedTermDayTaxoFacets: star +facets:DayOfYear.taxonomy # freq=195768
-MedTermDayTaxoFacets: similar +facets:DayOfYear.taxonomy # freq=195171
-MedTermDayTaxoFacets: received +facets:DayOfYear.taxonomy # freq=194983
-MedTermDayTaxoFacets: sup +facets:DayOfYear.taxonomy # freq=194723
-MedTermDayTaxoFacets: head +facets:DayOfYear.taxonomy # freq=194682
-AndHighHighDayTaxoFacets: +of +s +facets:DayOfYear.taxonomy # freq=8184358 freq=1581243
-AndHighHighDayTaxoFacets: +date +he +facets:DayOfYear.taxonomy # freq=2020626 freq=1659434
-AndHighHighDayTaxoFacets: +cite +2005 +facets:DayOfYear.taxonomy # freq=1741194 freq=835460
-AndHighHighDayTaxoFacets: +i +10 +facets:DayOfYear.taxonomy # freq=956148 freq=918339
-AndHighHighDayTaxoFacets: +date +2009 +facets:DayOfYear.taxonomy # freq=2020626 freq=887702
-AndHighHighDayTaxoFacets: +for +cite +facets:DayOfYear.taxonomy # freq=4380011 freq=1741194
-AndHighHighDayTaxoFacets: +as +its +facets:DayOfYear.taxonomy # freq=3925535 freq=1173450
-AndHighHighDayTaxoFacets: +which +2011 +facets:DayOfYear.taxonomy # freq=1963428 freq=871410
-AndHighHighDayTaxoFacets: +have +see +facets:DayOfYear.taxonomy # freq=1297121 freq=1044180
-AndHighHighDayTaxoFacets: +first +accessdate +facets:DayOfYear.taxonomy # freq=1933372 freq=1228887
-AndHighHighDayTaxoFacets: +also +no +facets:DayOfYear.taxonomy # freq=1959419 freq=1045000
-AndHighHighDayTaxoFacets: +first +new +facets:DayOfYear.taxonomy # freq=1933372 freq=1657293
-AndHighHighDayTaxoFacets: +publisher +web +facets:DayOfYear.taxonomy # freq=1289029 freq=1118334
-AndHighHighDayTaxoFacets: +states +work +facets:DayOfYear.taxonomy # freq=1034872 freq=853422
-AndHighHighDayTaxoFacets: +more +work +facets:DayOfYear.taxonomy # freq=963533 freq=853422
-AndHighHighDayTaxoFacets: +1 +their +facets:DayOfYear.taxonomy # freq=1641090 freq=1158682
-AndHighHighDayTaxoFacets: +http +an +facets:DayOfYear.taxonomy # freq=3493581 freq=2628056
-AndHighHighDayTaxoFacets: +year +5 +facets:DayOfYear.taxonomy # freq=1235231 freq=891361
-AndHighHighDayTaxoFacets: +4 +there +facets:DayOfYear.taxonomy # freq=986452 freq=956153
-AndHighHighDayTaxoFacets: +s +who +facets:DayOfYear.taxonomy # freq=1581243 freq=1196171
-AndHighHighDayTaxoFacets: +who +may +facets:DayOfYear.taxonomy # freq=1196171 freq=1071932
-AndHighHighDayTaxoFacets: +united +time +facets:DayOfYear.taxonomy # freq=1196944 freq=1032071
-AndHighHighDayTaxoFacets: +other +no +facets:DayOfYear.taxonomy # freq=1269961 freq=1045000
-AndHighHighDayTaxoFacets: +time +when +facets:DayOfYear.taxonomy # freq=1032071 freq=1027487
-AndHighHighDayTaxoFacets: +that +cite +facets:DayOfYear.taxonomy # freq=2931020 freq=1741194
-AndHighHighDayTaxoFacets: +to +its +facets:DayOfYear.taxonomy # freq=6155577 freq=1173450
-AndHighHighDayTaxoFacets: +2011 +2008 +facets:DayOfYear.taxonomy # freq=871410 freq=831253
-AndHighHighDayTaxoFacets: +been +2005 +facets:DayOfYear.taxonomy # freq=1041183 freq=835460
-AndHighHighDayTaxoFacets: +1 +year +facets:DayOfYear.taxonomy # freq=1641090 freq=1235231
-AndHighHighDayTaxoFacets: +was +more +facets:DayOfYear.taxonomy # freq=3763623 freq=963533
-AndHighHighDayTaxoFacets: +3 +2005 +facets:DayOfYear.taxonomy # freq=1148799 freq=835460
-AndHighHighDayTaxoFacets: +a +they +facets:DayOfYear.taxonomy # freq=6560531 freq=1021945
-AndHighHighDayTaxoFacets: +s +time +facets:DayOfYear.taxonomy # freq=1581243 freq=1032071
-AndHighHighDayTaxoFacets: +in +2011 +facets:DayOfYear.taxonomy # freq=7320987 freq=871410
-AndHighHighDayTaxoFacets: +a +work +facets:DayOfYear.taxonomy # freq=6560531 freq=853422
-AndHighHighDayTaxoFacets: +they +4 +facets:DayOfYear.taxonomy # freq=1021945 freq=986452
-AndHighHighDayTaxoFacets: +and +2 +facets:DayOfYear.taxonomy # freq=7318061 freq=1549245
-AndHighHighDayTaxoFacets: +to +an +facets:DayOfYear.taxonomy # freq=6155577 freq=2628056
-AndHighHighDayTaxoFacets: +an +which +facets:DayOfYear.taxonomy # freq=2628056 freq=1963428
-AndHighHighDayTaxoFacets: +was +also +facets:DayOfYear.taxonomy # freq=3763623 freq=1959419
-AndHighHighDayTaxoFacets: +this +see +facets:DayOfYear.taxonomy # freq=2224932 freq=1044180
-AndHighHighDayTaxoFacets: +all +2010 +facets:DayOfYear.taxonomy # freq=1203572 freq=950573
-AndHighHighDayTaxoFacets: +2 +2010 +facets:DayOfYear.taxonomy # freq=1549245 freq=950573
-AndHighHighDayTaxoFacets: +first +work +facets:DayOfYear.taxonomy # freq=1933372 freq=853422
-AndHighHighDayTaxoFacets: +he +10 +facets:DayOfYear.taxonomy # freq=1659434 freq=918339
-AndHighHighDayTaxoFacets: +http +that +facets:DayOfYear.taxonomy # freq=3493581 freq=2931020
-AndHighHighDayTaxoFacets: +new +2011 +facets:DayOfYear.taxonomy # freq=1657293 freq=871410
-AndHighHighDayTaxoFacets: +as +by +facets:DayOfYear.taxonomy # freq=3925535 freq=3826691
-AndHighHighDayTaxoFacets: +there +2008 +facets:DayOfYear.taxonomy # freq=956153 freq=831253
-AndHighHighDayTaxoFacets: +is +they +facets:DayOfYear.taxonomy # freq=4074455 freq=1021945
-AndHighHighDayTaxoFacets: +2010 +2011 +facets:DayOfYear.taxonomy # freq=950573 freq=871410
-AndHighHighDayTaxoFacets: +accessdate +2005 +facets:DayOfYear.taxonomy # freq=1228887 freq=835460
-AndHighHighDayTaxoFacets: +at +this +facets:DayOfYear.taxonomy # freq=2857534 freq=2224932
-AndHighHighDayTaxoFacets: +as +some +facets:DayOfYear.taxonomy # freq=3925535 freq=839919
-AndHighHighDayTaxoFacets: +after +all +facets:DayOfYear.taxonomy # freq=1247398 freq=1203572
-AndHighHighDayTaxoFacets: +year +they +facets:DayOfYear.taxonomy # freq=1235231 freq=1021945
-AndHighHighDayTaxoFacets: +1 +accessdate +facets:DayOfYear.taxonomy # freq=1641090 freq=1228887
-AndHighHighDayTaxoFacets: +on +web +facets:DayOfYear.taxonomy # freq=4074624 freq=1118334
-AndHighHighDayTaxoFacets: +first +5 +facets:DayOfYear.taxonomy # freq=1933372 freq=891361
-AndHighHighDayTaxoFacets: +he +but +facets:DayOfYear.taxonomy # freq=1659434 freq=1456553
-AndHighHighDayTaxoFacets: +title +when +facets:DayOfYear.taxonomy # freq=2397378 freq=1027487
-AndHighHighDayTaxoFacets: +who +two +facets:DayOfYear.taxonomy # freq=1196171 freq=1104053
-AndHighHighDayTaxoFacets: +last +2006 +facets:DayOfYear.taxonomy # freq=958437 freq=889954
-AndHighHighDayTaxoFacets: +from +name +facets:DayOfYear.taxonomy # freq=3224339 freq=2827713
-AndHighHighDayTaxoFacets: +new +i +facets:DayOfYear.taxonomy # freq=1657293 freq=956148
-AndHighHighDayTaxoFacets: +was +publisher +facets:DayOfYear.taxonomy # freq=3763623 freq=1289029
-AndHighHighDayTaxoFacets: +and +not +facets:DayOfYear.taxonomy # freq=7318061 freq=1713264
-AndHighHighDayTaxoFacets: +is +their +facets:DayOfYear.taxonomy # freq=4074455 freq=1158682
-AndHighHighDayTaxoFacets: +ref +that +facets:DayOfYear.taxonomy # freq=3793973 freq=2931020
-AndHighHighDayTaxoFacets: +of +for +facets:DayOfYear.taxonomy # freq=8184358 freq=4380011
-AndHighHighDayTaxoFacets: +name +which +facets:DayOfYear.taxonomy # freq=2827713 freq=1963428
-AndHighHighDayTaxoFacets: +after +2008 +facets:DayOfYear.taxonomy # freq=1247398 freq=831253
-AndHighHighDayTaxoFacets: +that +an +facets:DayOfYear.taxonomy # freq=2931020 freq=2628056
-AndHighHighDayTaxoFacets: +by +2006 +facets:DayOfYear.taxonomy # freq=3826691 freq=889954
-AndHighHighDayTaxoFacets: +that +or +facets:DayOfYear.taxonomy # freq=2931020 freq=1858841
-AndHighHighDayTaxoFacets: +be +which +facets:DayOfYear.taxonomy # freq=2051702 freq=1963428
-AndHighHighDayTaxoFacets: +with +2010 +facets:DayOfYear.taxonomy # freq=3709421 freq=950573
-AndHighHighDayTaxoFacets: +by +with +facets:DayOfYear.taxonomy # freq=3826691 freq=3709421
-AndHighHighDayTaxoFacets: +by +4 +facets:DayOfYear.taxonomy # freq=3826691 freq=986452
-AndHighHighDayTaxoFacets: +was +cite +facets:DayOfYear.taxonomy # freq=3763623 freq=1741194
-AndHighHighDayTaxoFacets: +was +they +facets:DayOfYear.taxonomy # freq=3763623 freq=1021945
-AndHighHighDayTaxoFacets: +on +was +facets:DayOfYear.taxonomy # freq=4074624 freq=3763623
-AndHighHighDayTaxoFacets: +is +time +facets:DayOfYear.taxonomy # freq=4074455 freq=1032071
-AndHighHighDayTaxoFacets: +the +be +facets:DayOfYear.taxonomy # freq=8217362 freq=2051702
-AndHighHighDayTaxoFacets: +were +2010 +facets:DayOfYear.taxonomy # freq=1524630 freq=950573
-AndHighHighDayTaxoFacets: +they +2006 +facets:DayOfYear.taxonomy # freq=1021945 freq=889954
-AndHighHighDayTaxoFacets: +he +may +facets:DayOfYear.taxonomy # freq=1659434 freq=1071932
-AndHighHighDayTaxoFacets: +an +title +facets:DayOfYear.taxonomy # freq=2628056 freq=2397378
-AndHighHighDayTaxoFacets: +into +some +facets:DayOfYear.taxonomy # freq=888684 freq=839919
-AndHighHighDayTaxoFacets: +first +some +facets:DayOfYear.taxonomy # freq=1933372 freq=839919
-AndHighHighDayTaxoFacets: +name +new +facets:DayOfYear.taxonomy # freq=2827713 freq=1657293
-AndHighHighDayTaxoFacets: +cite +3 +facets:DayOfYear.taxonomy # freq=1741194 freq=1148799
-AndHighHighDayTaxoFacets: +to +web +facets:DayOfYear.taxonomy # freq=6155577 freq=1118334
-AndHighHighDayTaxoFacets: +for +it +facets:DayOfYear.taxonomy # freq=4380011 freq=2675552
-AndHighHighDayTaxoFacets: +year +there +facets:DayOfYear.taxonomy # freq=1235231 freq=956153
-AndHighHighDayTaxoFacets: +but +been +facets:DayOfYear.taxonomy # freq=1456553 freq=1041183
-AndHighHighDayTaxoFacets: +this +who +facets:DayOfYear.taxonomy # freq=2224932 freq=1196171
-AndHighHighDayTaxoFacets: +ref +web +facets:DayOfYear.taxonomy # freq=3793973 freq=1118334
-AndHighHighDayTaxoFacets: +cite +2011 +facets:DayOfYear.taxonomy # freq=1741194 freq=871410
-AndHighHighDayTaxoFacets: +by +he +facets:DayOfYear.taxonomy # freq=3826691 freq=1659434
-AndHighHighDayTaxoFacets: +name +first +facets:DayOfYear.taxonomy # freq=2827713 freq=1933372
-AndHighHighDayTaxoFacets: +has +about +facets:DayOfYear.taxonomy # freq=1502961 freq=850283
-AndHighHighDayTaxoFacets: +were +two +facets:DayOfYear.taxonomy # freq=1524630 freq=1104053
-AndHighHighDayTaxoFacets: +two +work +facets:DayOfYear.taxonomy # freq=1104053 freq=853422
-AndHighHighDayTaxoFacets: +he +been +facets:DayOfYear.taxonomy # freq=1659434 freq=1041183
-AndHighHighDayTaxoFacets: +from +2 +facets:DayOfYear.taxonomy # freq=3224339 freq=1549245
-AndHighHighDayTaxoFacets: +all +some +facets:DayOfYear.taxonomy # freq=1203572 freq=839919
-AndHighHighDayTaxoFacets: +on +only +facets:DayOfYear.taxonomy # freq=4074624 freq=875561
-AndHighHighDayTaxoFacets: +was +no +facets:DayOfYear.taxonomy # freq=3763623 freq=1045000
-AndHighHighDayTaxoFacets: +name +see +facets:DayOfYear.taxonomy # freq=2827713 freq=1044180
-AndHighHighDayTaxoFacets: +of +as +facets:DayOfYear.taxonomy # freq=8184358 freq=3925535
-AndHighHighDayTaxoFacets: +be +has +facets:DayOfYear.taxonomy # freq=2051702 freq=1502961
-AndHighHighDayTaxoFacets: +url +into +facets:DayOfYear.taxonomy # freq=1513595 freq=888684
-AndHighHighDayTaxoFacets: +of +2006 +facets:DayOfYear.taxonomy # freq=8184358 freq=889954
-AndHighHighDayTaxoFacets: +ref +or +facets:DayOfYear.taxonomy # freq=3793973 freq=1858841
-AndHighHighDayTaxoFacets: +by +url +facets:DayOfYear.taxonomy # freq=3826691 freq=1513595
-AndHighHighDayTaxoFacets: +3 +into +facets:DayOfYear.taxonomy # freq=1148799 freq=888684
-AndHighHighDayTaxoFacets: +which +year +facets:DayOfYear.taxonomy # freq=1963428 freq=1235231
-AndHighHighDayTaxoFacets: +at +only +facets:DayOfYear.taxonomy # freq=2857534 freq=875561
-AndHighHighDayTaxoFacets: +http +publisher +facets:DayOfYear.taxonomy # freq=3493581 freq=1289029
-AndHighHighDayTaxoFacets: +with +accessdate +facets:DayOfYear.taxonomy # freq=3709421 freq=1228887
-AndHighHighDayTaxoFacets: +had +work +facets:DayOfYear.taxonomy # freq=1246743 freq=853422
-AndHighHighDayTaxoFacets: +as +they +facets:DayOfYear.taxonomy # freq=3925535 freq=1021945
-AndHighHighDayTaxoFacets: +the +2009 +facets:DayOfYear.taxonomy # freq=8217362 freq=887702
-AndHighHighDayTaxoFacets: +are +but +facets:DayOfYear.taxonomy # freq=1877802 freq=1456553
-AndHighHighDayTaxoFacets: +other +10 +facets:DayOfYear.taxonomy # freq=1269961 freq=918339
-AndHighHighDayTaxoFacets: +two +they +facets:DayOfYear.taxonomy # freq=1104053 freq=1021945
-AndHighHighDayTaxoFacets: +all +they +facets:DayOfYear.taxonomy # freq=1203572 freq=1021945
-AndHighHighDayTaxoFacets: +2011 +about +facets:DayOfYear.taxonomy # freq=871410 freq=850283
-AndHighHighDayTaxoFacets: +name +states +facets:DayOfYear.taxonomy # freq=2827713 freq=1034872
-AndHighHighDayTaxoFacets: +were +may +facets:DayOfYear.taxonomy # freq=1524630 freq=1071932
-AndHighHighDayTaxoFacets: +the +into +facets:DayOfYear.taxonomy # freq=8217362 freq=888684
-AndHighHighDayTaxoFacets: +new +united +facets:DayOfYear.taxonomy # freq=1657293 freq=1196944
-AndHighHighDayTaxoFacets: +their +only +facets:DayOfYear.taxonomy # freq=1158682 freq=875561
-AndHighHighDayTaxoFacets: +be +10 +facets:DayOfYear.taxonomy # freq=2051702 freq=918339
-AndHighHighDayTaxoFacets: +that +not +facets:DayOfYear.taxonomy # freq=2931020 freq=1713264
-AndHighHighDayTaxoFacets: +title +all +facets:DayOfYear.taxonomy # freq=2397378 freq=1203572
-AndHighHighDayTaxoFacets: +with +have +facets:DayOfYear.taxonomy # freq=3709421 freq=1297121
-AndHighHighDayTaxoFacets: +as +been +facets:DayOfYear.taxonomy # freq=3925535 freq=1041183
-AndHighHighDayTaxoFacets: +it +more +facets:DayOfYear.taxonomy # freq=2675552 freq=963533
-AndHighHighDayTaxoFacets: +all +united +facets:DayOfYear.taxonomy # freq=1203572 freq=1196944
-AndHighHighDayTaxoFacets: +other +two +facets:DayOfYear.taxonomy # freq=1269961 freq=1104053
-AndHighHighDayTaxoFacets: +he +url +facets:DayOfYear.taxonomy # freq=1659434 freq=1513595
-AndHighHighDayTaxoFacets: +to +3 +facets:DayOfYear.taxonomy # freq=6155577 freq=1148799
-AndHighHighDayTaxoFacets: +in +from +facets:DayOfYear.taxonomy # freq=7320987 freq=3224339
-AndHighHighDayTaxoFacets: +not +there +facets:DayOfYear.taxonomy # freq=1713264 freq=956153
-AndHighHighDayTaxoFacets: +other +see +facets:DayOfYear.taxonomy # freq=1269961 freq=1044180
-AndHighHighDayTaxoFacets: +its +i +facets:DayOfYear.taxonomy # freq=1173450 freq=956148
-AndHighHighDayTaxoFacets: +as +2008 +facets:DayOfYear.taxonomy # freq=3925535 freq=831253
-AndHighHighDayTaxoFacets: +http +s +facets:DayOfYear.taxonomy # freq=3493581 freq=1581243
-AndHighHighDayTaxoFacets: +or +web +facets:DayOfYear.taxonomy # freq=1858841 freq=1118334
-AndHighHighDayTaxoFacets: +new +publisher +facets:DayOfYear.taxonomy # freq=1657293 freq=1289029
-AndHighHighDayTaxoFacets: +of +who +facets:DayOfYear.taxonomy # freq=8184358 freq=1196171
-AndHighHighDayTaxoFacets: +10 +2009 +facets:DayOfYear.taxonomy # freq=918339 freq=887702
-AndHighHighDayTaxoFacets: +that +he +facets:DayOfYear.taxonomy # freq=2931020 freq=1659434
-AndHighHighDayTaxoFacets: +url +2005 +facets:DayOfYear.taxonomy # freq=1513595 freq=835460
-AndHighHighDayTaxoFacets: +the +a +facets:DayOfYear.taxonomy # freq=8217362 freq=6560531
-AndHighHighDayTaxoFacets: +more +there +facets:DayOfYear.taxonomy # freq=963533 freq=956153
-AndHighHighDayTaxoFacets: +and +an +facets:DayOfYear.taxonomy # freq=7318061 freq=2628056
-AndHighHighDayTaxoFacets: +with +they +facets:DayOfYear.taxonomy # freq=3709421 freq=1021945
-AndHighHighDayTaxoFacets: +title +time +facets:DayOfYear.taxonomy # freq=2397378 freq=1032071
-AndHighHighDayTaxoFacets: +states +4 +facets:DayOfYear.taxonomy # freq=1034872 freq=986452
-AndHighHighDayTaxoFacets: +united +when +facets:DayOfYear.taxonomy # freq=1196944 freq=1027487
-AndHighHighDayTaxoFacets: +is +title +facets:DayOfYear.taxonomy # freq=4074455 freq=2397378
-AndHighHighDayTaxoFacets: +from +who +facets:DayOfYear.taxonomy # freq=3224339 freq=1196171
-AndHighHighDayTaxoFacets: +more +some +facets:DayOfYear.taxonomy # freq=963533 freq=839919
-AndHighHighDayTaxoFacets: +title +year +facets:DayOfYear.taxonomy # freq=2397378 freq=1235231
-AndHighHighDayTaxoFacets: +one +after +facets:DayOfYear.taxonomy # freq=1527689 freq=1247398
-AndHighHighDayTaxoFacets: +with +title +facets:DayOfYear.taxonomy # freq=3709421 freq=2397378
-AndHighHighDayTaxoFacets: +in +first +facets:DayOfYear.taxonomy # freq=7320987 freq=1933372
-AndHighHighDayTaxoFacets: +are +i +facets:DayOfYear.taxonomy # freq=1877802 freq=956148
-AndHighHighDayTaxoFacets: +the +two +facets:DayOfYear.taxonomy # freq=8217362 freq=1104053
-AndHighHighDayTaxoFacets: +but +there +facets:DayOfYear.taxonomy # freq=1456553 freq=956153
-AndHighHighDayTaxoFacets: +from +all +facets:DayOfYear.taxonomy # freq=3224339 freq=1203572
-AndHighHighDayTaxoFacets: +2 +more +facets:DayOfYear.taxonomy # freq=1549245 freq=963533
-AndHighHighDayTaxoFacets: +had +its +facets:DayOfYear.taxonomy # freq=1246743 freq=1173450
-AndHighHighDayTaxoFacets: +in +no +facets:DayOfYear.taxonomy # freq=7320987 freq=1045000
-AndHighHighDayTaxoFacets: +other +more +facets:DayOfYear.taxonomy # freq=1269961 freq=963533
-AndHighHighDayTaxoFacets: +his +united +facets:DayOfYear.taxonomy # freq=1777780 freq=1196944
-AndHighHighDayTaxoFacets: +more +last +facets:DayOfYear.taxonomy # freq=963533 freq=958437
-AndHighHighDayTaxoFacets: +ref +more +facets:DayOfYear.taxonomy # freq=3793973 freq=963533
-AndHighHighDayTaxoFacets: +ref +been +facets:DayOfYear.taxonomy # freq=3793973 freq=1041183
-AndHighHighDayTaxoFacets: +cite +time +facets:DayOfYear.taxonomy # freq=1741194 freq=1032071
-AndHighHighDayTaxoFacets: +http +3 +facets:DayOfYear.taxonomy # freq=3493581 freq=1148799
-AndHighHighDayTaxoFacets: +has +they +facets:DayOfYear.taxonomy # freq=1502961 freq=1021945
-AndHighHighDayTaxoFacets: +and +2011 +facets:DayOfYear.taxonomy # freq=7318061 freq=871410
-AndHighHighDayTaxoFacets: +be +accessdate +facets:DayOfYear.taxonomy # freq=2051702 freq=1228887
-AndHighHighDayTaxoFacets: +are +2010 +facets:DayOfYear.taxonomy # freq=1877802 freq=950573
-AndHighHighDayTaxoFacets: +at +2009 +facets:DayOfYear.taxonomy # freq=2857534 freq=887702
-AndHighHighDayTaxoFacets: +also +united +facets:DayOfYear.taxonomy # freq=1959419 freq=1196944
-AndHighHighDayTaxoFacets: +united +been +facets:DayOfYear.taxonomy # freq=1196944 freq=1041183
-AndHighHighDayTaxoFacets: +also +1 +facets:DayOfYear.taxonomy # freq=1959419 freq=1641090
-AndHighHighDayTaxoFacets: +he +last +facets:DayOfYear.taxonomy # freq=1659434 freq=958437
-AndHighHighDayTaxoFacets: +was +from +facets:DayOfYear.taxonomy # freq=3763623 freq=3224339
-AndHighHighDayTaxoFacets: +ref +when +facets:DayOfYear.taxonomy # freq=3793973 freq=1027487
-AndHighHighDayTaxoFacets: +not +they +facets:DayOfYear.taxonomy # freq=1713264 freq=1021945
-AndHighHighDayTaxoFacets: +the +other +facets:DayOfYear.taxonomy # freq=8217362 freq=1269961
-AndHighHighDayTaxoFacets: +cite +work +facets:DayOfYear.taxonomy # freq=1741194 freq=853422
-AndHighHighDayTaxoFacets: +was +were +facets:DayOfYear.taxonomy # freq=3763623 freq=1524630
-AndHighHighDayTaxoFacets: +in +after +facets:DayOfYear.taxonomy # freq=7320987 freq=1247398
-AndHighHighDayTaxoFacets: +and +first +facets:DayOfYear.taxonomy # freq=7318061 freq=1933372
-AndHighHighDayTaxoFacets: +have +their +facets:DayOfYear.taxonomy # freq=1297121 freq=1158682
-AndHighHighDayTaxoFacets: +also +4 +facets:DayOfYear.taxonomy # freq=1959419 freq=986452
-AndHighHighDayTaxoFacets: +he +2006 +facets:DayOfYear.taxonomy # freq=1659434 freq=889954
-AndHighHighDayTaxoFacets: +may +time +facets:DayOfYear.taxonomy # freq=1071932 freq=1032071
-AndHighHighDayTaxoFacets: +is +url +facets:DayOfYear.taxonomy # freq=4074455 freq=1513595
-AndHighHighDayTaxoFacets: +for +has +facets:DayOfYear.taxonomy # freq=4380011 freq=1502961
-AndHighHighDayTaxoFacets: +and +be +facets:DayOfYear.taxonomy # freq=7318061 freq=2051702
-AndHighHighDayTaxoFacets: +url +had +facets:DayOfYear.taxonomy # freq=1513595 freq=1246743
-AndHighHighDayTaxoFacets: +his +5 +facets:DayOfYear.taxonomy # freq=1777780 freq=891361
-AndHighHighDayTaxoFacets: +on +he +facets:DayOfYear.taxonomy # freq=4074624 freq=1659434
-AndHighHighDayTaxoFacets: +this +first +facets:DayOfYear.taxonomy # freq=2224932 freq=1933372
-AndHighHighDayTaxoFacets: +new +its +facets:DayOfYear.taxonomy # freq=1657293 freq=1173450
-AndHighHighDayTaxoFacets: +s +2009 +facets:DayOfYear.taxonomy # freq=1581243 freq=887702
-AndHighHighDayTaxoFacets: +see +2010 +facets:DayOfYear.taxonomy # freq=1044180 freq=950573
-AndHighHighDayTaxoFacets: +or +but +facets:DayOfYear.taxonomy # freq=1858841 freq=1456553
-AndHighHighDayTaxoFacets: +its +into +facets:DayOfYear.taxonomy # freq=1173450 freq=888684
-AndHighHighDayTaxoFacets: +on +accessdate +facets:DayOfYear.taxonomy # freq=4074624 freq=1228887
-AndHighHighDayTaxoFacets: +are +accessdate +facets:DayOfYear.taxonomy # freq=1877802 freq=1228887
-AndHighHighDayTaxoFacets: +2 +there +facets:DayOfYear.taxonomy # freq=1549245 freq=956153
-AndHighHighDayTaxoFacets: +united +3 +facets:DayOfYear.taxonomy # freq=1196944 freq=1148799
-AndHighHighDayTaxoFacets: +which +no +facets:DayOfYear.taxonomy # freq=1963428 freq=1045000
-AndHighHighDayTaxoFacets: +s +2006 +facets:DayOfYear.taxonomy # freq=1581243 freq=889954
-AndHighHighDayTaxoFacets: +ref +there +facets:DayOfYear.taxonomy # freq=3793973 freq=956153
-AndHighHighDayTaxoFacets: +he +more +facets:DayOfYear.taxonomy # freq=1659434 freq=963533
-AndHighHighDayTaxoFacets: +had +two +facets:DayOfYear.taxonomy # freq=1246743 freq=1104053
-AndHighHighDayTaxoFacets: +the +only +facets:DayOfYear.taxonomy # freq=8217362 freq=875561
-AndHighHighDayTaxoFacets: +be +about +facets:DayOfYear.taxonomy # freq=2051702 freq=850283
-AndHighHighDayTaxoFacets: +in +has +facets:DayOfYear.taxonomy # freq=7320987 freq=1502961
-AndHighHighDayTaxoFacets: +2009 +work +facets:DayOfYear.taxonomy # freq=887702 freq=853422
-AndHighHighDayTaxoFacets: +on +10 +facets:DayOfYear.taxonomy # freq=4074624 freq=918339
-AndHighHighDayTaxoFacets: +ref +2010 +facets:DayOfYear.taxonomy # freq=3793973 freq=950573
-AndHighHighDayTaxoFacets: +other +2006 +facets:DayOfYear.taxonomy # freq=1269961 freq=889954
-AndHighHighDayTaxoFacets: +with +all +facets:DayOfYear.taxonomy # freq=3709421 freq=1203572
-AndHighHighDayTaxoFacets: +in +work +facets:DayOfYear.taxonomy # freq=7320987 freq=853422
-AndHighHighDayTaxoFacets: +url +about +facets:DayOfYear.taxonomy # freq=1513595 freq=850283
-AndHighHighDayTaxoFacets: +after +some +facets:DayOfYear.taxonomy # freq=1247398 freq=839919
-AndHighHighDayTaxoFacets: +this +when +facets:DayOfYear.taxonomy # freq=2224932 freq=1027487
-AndHighHighDayTaxoFacets: +not +1 +facets:DayOfYear.taxonomy # freq=1713264 freq=1641090
-AndHighHighDayTaxoFacets: +1 +more +facets:DayOfYear.taxonomy # freq=1641090 freq=963533
-AndHighHighDayTaxoFacets: +not +2 +facets:DayOfYear.taxonomy # freq=1713264 freq=1549245
-AndHighHighDayTaxoFacets: +publisher +2005 +facets:DayOfYear.taxonomy # freq=1289029 freq=835460
-AndHighHighDayTaxoFacets: +in +at +facets:DayOfYear.taxonomy # freq=7320987 freq=2857534
-AndHighHighDayTaxoFacets: +1 +some +facets:DayOfYear.taxonomy # freq=1641090 freq=839919
-AndHighHighDayTaxoFacets: +s +its +facets:DayOfYear.taxonomy # freq=1581243 freq=1173450
-AndHighHighDayTaxoFacets: +date +more +facets:DayOfYear.taxonomy # freq=2020626 freq=963533
-AndHighHighDayTaxoFacets: +from +his +facets:DayOfYear.taxonomy # freq=3224339 freq=1777780
-AndHighHighDayTaxoFacets: +was +when +facets:DayOfYear.taxonomy # freq=3763623 freq=1027487
-AndHighHighDayTaxoFacets: +time +2010 +facets:DayOfYear.taxonomy # freq=1032071 freq=950573
-AndHighHighDayTaxoFacets: +it +2 +facets:DayOfYear.taxonomy # freq=2675552 freq=1549245
-AndHighHighDayTaxoFacets: +of +http +facets:DayOfYear.taxonomy # freq=8184358 freq=3493581
-AndHighHighDayTaxoFacets: +2 +2011 +facets:DayOfYear.taxonomy # freq=1549245 freq=871410
-AndHighHighDayTaxoFacets: +who +2009 +facets:DayOfYear.taxonomy # freq=1196171 freq=887702
-AndHighHighDayTaxoFacets: +in +2009 +facets:DayOfYear.taxonomy # freq=7320987 freq=887702
-AndHighHighDayTaxoFacets: +by +3 +facets:DayOfYear.taxonomy # freq=3826691 freq=1148799
-AndHighHighDayTaxoFacets: +when +2011 +facets:DayOfYear.taxonomy # freq=1027487 freq=871410
-AndHighHighDayTaxoFacets: +not +have +facets:DayOfYear.taxonomy # freq=1713264 freq=1297121
-AndHighHighDayTaxoFacets: +all +their +facets:DayOfYear.taxonomy # freq=1203572 freq=1158682
-AndHighHighDayTaxoFacets: +an +2005 +facets:DayOfYear.taxonomy # freq=2628056 freq=835460
-AndHighHighDayTaxoFacets: +of +is +facets:DayOfYear.taxonomy # freq=8184358 freq=4074455
-AndHighHighDayTaxoFacets: +of +url +facets:DayOfYear.taxonomy # freq=8184358 freq=1513595
-AndHighHighDayTaxoFacets: +also +year +facets:DayOfYear.taxonomy # freq=1959419 freq=1235231
-AndHighHighDayTaxoFacets: +is +new +facets:DayOfYear.taxonomy # freq=4074455 freq=1657293
-AndHighHighDayTaxoFacets: +http +name +facets:DayOfYear.taxonomy # freq=3493581 freq=2827713
-AndHighHighDayTaxoFacets: +i +into +facets:DayOfYear.taxonomy # freq=956148 freq=888684
-AndHighHighDayTaxoFacets: +are +united +facets:DayOfYear.taxonomy # freq=1877802 freq=1196944
-AndHighHighDayTaxoFacets: +or +only +facets:DayOfYear.taxonomy # freq=1858841 freq=875561
-AndHighHighDayTaxoFacets: +who +their +facets:DayOfYear.taxonomy # freq=1196171 freq=1158682
-AndHighHighDayTaxoFacets: +name +been +facets:DayOfYear.taxonomy # freq=2827713 freq=1041183
-AndHighHighDayTaxoFacets: +last +2009 +facets:DayOfYear.taxonomy # freq=958437 freq=887702
-AndHighHighDayTaxoFacets: +they +2005 +facets:DayOfYear.taxonomy # freq=1021945 freq=835460
-AndHighHighDayTaxoFacets: +new +1 +facets:DayOfYear.taxonomy # freq=1657293 freq=1641090
-AndHighHighDayTaxoFacets: +title +some +facets:DayOfYear.taxonomy # freq=2397378 freq=839919
-AndHighHighDayTaxoFacets: +name +5 +facets:DayOfYear.taxonomy # freq=2827713 freq=891361
-AndHighHighDayTaxoFacets: +and +or +facets:DayOfYear.taxonomy # freq=7318061 freq=1858841
-AndHighHighDayTaxoFacets: +3 +2006 +facets:DayOfYear.taxonomy # freq=1148799 freq=889954
-AndHighHighDayTaxoFacets: +of +has +facets:DayOfYear.taxonomy # freq=8184358 freq=1502961
-AndHighHighDayTaxoFacets: +which +i +facets:DayOfYear.taxonomy # freq=1963428 freq=956148
-AndHighHighDayTaxoFacets: +see +5 +facets:DayOfYear.taxonomy # freq=1044180 freq=891361
-AndHighHighDayTaxoFacets: +has +2011 +facets:DayOfYear.taxonomy # freq=1502961 freq=871410
-AndHighHighDayTaxoFacets: +new +accessdate +facets:DayOfYear.taxonomy # freq=1657293 freq=1228887
-AndHighHighDayTaxoFacets: +united +i +facets:DayOfYear.taxonomy # freq=1196944 freq=956148
-AndHighHighDayTaxoFacets: +are +10 +facets:DayOfYear.taxonomy # freq=1877802 freq=918339
-AndHighHighDayTaxoFacets: +the +is +facets:DayOfYear.taxonomy # freq=8217362 freq=4074455
-AndHighHighDayTaxoFacets: +other +web +facets:DayOfYear.taxonomy # freq=1269961 freq=1118334
-AndHighHighDayTaxoFacets: +i +2006 +facets:DayOfYear.taxonomy # freq=956148 freq=889954
-AndHighHighDayTaxoFacets: +were +publisher +facets:DayOfYear.taxonomy # freq=1524630 freq=1289029
-AndHighHighDayTaxoFacets: +be +when +facets:DayOfYear.taxonomy # freq=2051702 freq=1027487
-AndHighHighDayTaxoFacets: +to +date +facets:DayOfYear.taxonomy # freq=6155577 freq=2020626
-AndHighHighDayTaxoFacets: +for +2006 +facets:DayOfYear.taxonomy # freq=4380011 freq=889954
-AndHighHighDayTaxoFacets: +for +at +facets:DayOfYear.taxonomy # freq=4380011 freq=2857534
-AndHighHighDayTaxoFacets: +his +s +facets:DayOfYear.taxonomy # freq=1777780 freq=1581243
-AndHighHighDayTaxoFacets: +from +or +facets:DayOfYear.taxonomy # freq=3224339 freq=1858841
-AndHighHighDayTaxoFacets: +ref +an +facets:DayOfYear.taxonomy # freq=3793973 freq=2628056
-AndHighHighDayTaxoFacets: +which +had +facets:DayOfYear.taxonomy # freq=1963428 freq=1246743
-AndHighHighDayTaxoFacets: +an +were +facets:DayOfYear.taxonomy # freq=2628056 freq=1524630
-AndHighHighDayTaxoFacets: +web +only +facets:DayOfYear.taxonomy # freq=1118334 freq=875561
-AndHighHighDayTaxoFacets: +ref +one +facets:DayOfYear.taxonomy # freq=3793973 freq=1527689
-AndHighHighDayTaxoFacets: +a +one +facets:DayOfYear.taxonomy # freq=6560531 freq=1527689
-AndHighHighDayTaxoFacets: +they +into +facets:DayOfYear.taxonomy # freq=1021945 freq=888684
-AndHighHighDayTaxoFacets: +of +2008 +facets:DayOfYear.taxonomy # freq=8184358 freq=831253
-AndHighHighDayTaxoFacets: +in +which +facets:DayOfYear.taxonomy # freq=7320987 freq=1963428
-AndHighHighDayTaxoFacets: +united +2010 +facets:DayOfYear.taxonomy # freq=1196944 freq=950573
-AndHighHighDayTaxoFacets: +after +i +facets:DayOfYear.taxonomy # freq=1247398 freq=956148
-AndHighHighDayTaxoFacets: +he +web +facets:DayOfYear.taxonomy # freq=1659434 freq=1118334
-AndHighHighDayTaxoFacets: +are +states +facets:DayOfYear.taxonomy # freq=1877802 freq=1034872
-AndHighHighDayTaxoFacets: +after +time +facets:DayOfYear.taxonomy # freq=1247398 freq=1032071
-AndHighHighDayTaxoFacets: +its +web +facets:DayOfYear.taxonomy # freq=1173450 freq=1118334
-AndHighHighDayTaxoFacets: +for +when +facets:DayOfYear.taxonomy # freq=4380011 freq=1027487
-AndHighHighDayTaxoFacets: +has +states +facets:DayOfYear.taxonomy # freq=1502961 freq=1034872
-AndHighHighDayTaxoFacets: +the +no +facets:DayOfYear.taxonomy # freq=8217362 freq=1045000
-AndHighHighDayTaxoFacets: +title +one +facets:DayOfYear.taxonomy # freq=2397378 freq=1527689
-AndHighHighDayTaxoFacets: +i +2009 +facets:DayOfYear.taxonomy # freq=956148 freq=887702
-AndHighHighDayTaxoFacets: +1 +states +facets:DayOfYear.taxonomy # freq=1641090 freq=1034872
-AndHighHighDayTaxoFacets: +other +only +facets:DayOfYear.taxonomy # freq=1269961 freq=875561
-AndHighHighDayTaxoFacets: +by +they +facets:DayOfYear.taxonomy # freq=3826691 freq=1021945
-AndHighHighDayTaxoFacets: +http +its +facets:DayOfYear.taxonomy # freq=3493581 freq=1173450
-AndHighHighDayTaxoFacets: +for +two +facets:DayOfYear.taxonomy # freq=4380011 freq=1104053
-AndHighHighDayTaxoFacets: +all +may +facets:DayOfYear.taxonomy # freq=1203572 freq=1071932
-AndHighHighDayTaxoFacets: +after +last +facets:DayOfYear.taxonomy # freq=1247398 freq=958437
-AndHighHighDayTaxoFacets: +there +only +facets:DayOfYear.taxonomy # freq=956153 freq=875561
-AndHighHighDayTaxoFacets: +2 +no +facets:DayOfYear.taxonomy # freq=1549245 freq=1045000
-AndHighHighDayTaxoFacets: +an +he +facets:DayOfYear.taxonomy # freq=2628056 freq=1659434
-AndHighHighDayTaxoFacets: +his +i +facets:DayOfYear.taxonomy # freq=1777780 freq=956148
-AndHighHighDayTaxoFacets: +first +not +facets:DayOfYear.taxonomy # freq=1933372 freq=1713264
-AndHighHighDayTaxoFacets: +a +5 +facets:DayOfYear.taxonomy # freq=6560531 freq=891361
-AndHighHighDayTaxoFacets: +from +2005 +facets:DayOfYear.taxonomy # freq=3224339 freq=835460
-AndHighHighDayTaxoFacets: +after +web +facets:DayOfYear.taxonomy # freq=1247398 freq=1118334
-AndHighHighDayTaxoFacets: +to +which +facets:DayOfYear.taxonomy # freq=6155577 freq=1963428
-AndHighHighDayTaxoFacets: +this +into +facets:DayOfYear.taxonomy # freq=2224932 freq=888684
-AndHighHighDayTaxoFacets: +its +last +facets:DayOfYear.taxonomy # freq=1173450 freq=958437
-AndHighHighDayTaxoFacets: +it +there +facets:DayOfYear.taxonomy # freq=2675552 freq=956153
-AndHighHighDayTaxoFacets: +name +are +facets:DayOfYear.taxonomy # freq=2827713 freq=1877802
-AndHighHighDayTaxoFacets: +are +4 +facets:DayOfYear.taxonomy # freq=1877802 freq=986452
-AndHighHighDayTaxoFacets: +name +cite +facets:DayOfYear.taxonomy # freq=2827713 freq=1741194
-AndHighHighDayTaxoFacets: +more +2008 +facets:DayOfYear.taxonomy # freq=963533 freq=831253
-AndHighHighDayTaxoFacets: +of +that +facets:DayOfYear.taxonomy # freq=8184358 freq=2931020
-AndHighHighDayTaxoFacets: +ref +at +facets:DayOfYear.taxonomy # freq=3793973 freq=2857534
-AndHighHighDayTaxoFacets: +new +web +facets:DayOfYear.taxonomy # freq=1657293 freq=1118334
-AndHighHighDayTaxoFacets: +the +2 +facets:DayOfYear.taxonomy # freq=8217362 freq=1549245
-AndHighHighDayTaxoFacets: +for +1 +facets:DayOfYear.taxonomy # freq=4380011 freq=1641090
-AndHighHighDayTaxoFacets: +by +no +facets:DayOfYear.taxonomy # freq=3826691 freq=1045000
-AndHighHighDayTaxoFacets: +all +i +facets:DayOfYear.taxonomy # freq=1203572 freq=956148
-AndHighHighDayTaxoFacets: +5 +2006 +facets:DayOfYear.taxonomy # freq=891361 freq=889954
-AndHighHighDayTaxoFacets: +4 +work +facets:DayOfYear.taxonomy # freq=986452 freq=853422
-AndHighHighDayTaxoFacets: +was +new +facets:DayOfYear.taxonomy # freq=3763623 freq=1657293
-AndHighHighDayTaxoFacets: +year +see +facets:DayOfYear.taxonomy # freq=1235231 freq=1044180
-AndHighHighDayTaxoFacets: +s +had +facets:DayOfYear.taxonomy # freq=1581243 freq=1246743
-AndHighHighDayTaxoFacets: +an +last +facets:DayOfYear.taxonomy # freq=2628056 freq=958437
-AndHighHighDayTaxoFacets: +had +4 +facets:DayOfYear.taxonomy # freq=1246743 freq=986452
-AndHighHighDayTaxoFacets: +from +publisher +facets:DayOfYear.taxonomy # freq=3224339 freq=1289029
-AndHighHighDayTaxoFacets: +new +url +facets:DayOfYear.taxonomy # freq=1657293 freq=1513595
-AndHighHighDayTaxoFacets: +4 +5 +facets:DayOfYear.taxonomy # freq=986452 freq=891361
-AndHighHighDayTaxoFacets: +by +cite +facets:DayOfYear.taxonomy # freq=3826691 freq=1741194
-AndHighHighDayTaxoFacets: +2010 +2009 +facets:DayOfYear.taxonomy # freq=950573 freq=887702
-AndHighHighDayTaxoFacets: +their +4 +facets:DayOfYear.taxonomy # freq=1158682 freq=986452
-AndHighHighDayTaxoFacets: +publisher +who +facets:DayOfYear.taxonomy # freq=1289029 freq=1196171
-AndHighHighDayTaxoFacets: +that +more +facets:DayOfYear.taxonomy # freq=2931020 freq=963533
-AndHighHighDayTaxoFacets: +ref +see +facets:DayOfYear.taxonomy # freq=3793973 freq=1044180
-AndHighHighDayTaxoFacets: +publisher +last +facets:DayOfYear.taxonomy # freq=1289029 freq=958437
-AndHighHighDayTaxoFacets: +but +their +facets:DayOfYear.taxonomy # freq=1456553 freq=1158682
-AndHighHighDayTaxoFacets: +is +1 +facets:DayOfYear.taxonomy # freq=4074455 freq=1641090
-AndHighHighDayTaxoFacets: +new +have +facets:DayOfYear.taxonomy # freq=1657293 freq=1297121
-AndHighHighDayTaxoFacets: +title +also +facets:DayOfYear.taxonomy # freq=2397378 freq=1959419
-AndHighHighDayTaxoFacets: +also +i +facets:DayOfYear.taxonomy # freq=1959419 freq=956148
-AndHighHighDayTaxoFacets: +had +into +facets:DayOfYear.taxonomy # freq=1246743 freq=888684
-AndHighHighDayTaxoFacets: +first +when +facets:DayOfYear.taxonomy # freq=1933372 freq=1027487
-AndHighHighDayTaxoFacets: +in +be +facets:DayOfYear.taxonomy # freq=7320987 freq=2051702
-AndHighHighDayTaxoFacets: +are +2008 +facets:DayOfYear.taxonomy # freq=1877802 freq=831253
-AndHighHighDayTaxoFacets: +two +2006 +facets:DayOfYear.taxonomy # freq=1104053 freq=889954
-AndHighHighDayTaxoFacets: +date +about +facets:DayOfYear.taxonomy # freq=2020626 freq=850283
-AndHighHighDayTaxoFacets: +its +only +facets:DayOfYear.taxonomy # freq=1173450 freq=875561
-AndHighHighDayTaxoFacets: +title +new +facets:DayOfYear.taxonomy # freq=2397378 freq=1657293
-AndHighHighDayTaxoFacets: +2 +10 +facets:DayOfYear.taxonomy # freq=1549245 freq=918339
-AndHighHighDayTaxoFacets: +2 +one +facets:DayOfYear.taxonomy # freq=1549245 freq=1527689
-AndHighHighDayTaxoFacets: +is +an +facets:DayOfYear.taxonomy # freq=4074455 freq=2628056
-AndHighHighDayTaxoFacets: +at +no +facets:DayOfYear.taxonomy # freq=2857534 freq=1045000
-AndHighHighDayTaxoFacets: +has +its +facets:DayOfYear.taxonomy # freq=1502961 freq=1173450
-AndHighHighDayTaxoFacets: +were +there +facets:DayOfYear.taxonomy # freq=1524630 freq=956153
-AndHighHighDayTaxoFacets: +with +were +facets:DayOfYear.taxonomy # freq=3709421 freq=1524630
-AndHighHighDayTaxoFacets: +on +i +facets:DayOfYear.taxonomy # freq=4074624 freq=956148
-AndHighHighDayTaxoFacets: +as +was +facets:DayOfYear.taxonomy # freq=3925535 freq=3763623
-AndHighHighDayTaxoFacets: +date +cite +facets:DayOfYear.taxonomy # freq=2020626 freq=1741194
-AndHighHighDayTaxoFacets: +or +united +facets:DayOfYear.taxonomy # freq=1858841 freq=1196944
-AndHighHighDayTaxoFacets: +to +http +facets:DayOfYear.taxonomy # freq=6155577 freq=3493581
-AndHighHighDayTaxoFacets: +he +have +facets:DayOfYear.taxonomy # freq=1659434 freq=1297121
-AndHighHighDayTaxoFacets: +s +about +facets:DayOfYear.taxonomy # freq=1581243 freq=850283
-AndHighHighDayTaxoFacets: +this +s +facets:DayOfYear.taxonomy # freq=2224932 freq=1581243
-AndHighHighDayTaxoFacets: +is +but +facets:DayOfYear.taxonomy # freq=4074455 freq=1456553
-AndHighHighDayTaxoFacets: +web +2010 +facets:DayOfYear.taxonomy # freq=1118334 freq=950573
-AndHighHighDayTaxoFacets: +first +are +facets:DayOfYear.taxonomy # freq=1933372 freq=1877802
-AndHighHighDayTaxoFacets: +have +2008 +facets:DayOfYear.taxonomy # freq=1297121 freq=831253
-AndHighHighDayTaxoFacets: +to +no +facets:DayOfYear.taxonomy # freq=6155577 freq=1045000
-AndHighHighDayTaxoFacets: +or +2 +facets:DayOfYear.taxonomy # freq=1858841 freq=1549245
-AndHighHighDayTaxoFacets: +was +about +facets:DayOfYear.taxonomy # freq=3763623 freq=850283
-AndHighHighDayTaxoFacets: +cite +more +facets:DayOfYear.taxonomy # freq=1741194 freq=963533
-AndHighHighDayTaxoFacets: +date +their +facets:DayOfYear.taxonomy # freq=2020626 freq=1158682
-AndHighHighDayTaxoFacets: +from +work +facets:DayOfYear.taxonomy # freq=3224339 freq=853422
-AndHighHighDayTaxoFacets: +at +2010 +facets:DayOfYear.taxonomy # freq=2857534 freq=950573
-AndHighHighDayTaxoFacets: +other +last +facets:DayOfYear.taxonomy # freq=1269961 freq=958437
-AndHighHighDayTaxoFacets: +date +into +facets:DayOfYear.taxonomy # freq=2020626 freq=888684
-AndHighHighDayTaxoFacets: +they +more +facets:DayOfYear.taxonomy # freq=1021945 freq=963533
-AndHighHighDayTaxoFacets: +to +ref +facets:DayOfYear.taxonomy # freq=6155577 freq=3793973
-AndHighHighDayTaxoFacets: +be +but +facets:DayOfYear.taxonomy # freq=2051702 freq=1456553
-AndHighHighDayTaxoFacets: +or +into +facets:DayOfYear.taxonomy # freq=1858841 freq=888684
-AndHighHighDayTaxoFacets: +has +last +facets:DayOfYear.taxonomy # freq=1502961 freq=958437
-AndHighHighDayTaxoFacets: +to +time +facets:DayOfYear.taxonomy # freq=6155577 freq=1032071
-AndHighHighDayTaxoFacets: +the +some +facets:DayOfYear.taxonomy # freq=8217362 freq=839919
-AndHighHighDayTaxoFacets: +ref +united +facets:DayOfYear.taxonomy # freq=3793973 freq=1196944
-AndHighHighDayTaxoFacets: +all +last +facets:DayOfYear.taxonomy # freq=1203572 freq=958437
-AndHighHighDayTaxoFacets: +url +all +facets:DayOfYear.taxonomy # freq=1513595 freq=1203572
-AndHighHighDayTaxoFacets: +other +some +facets:DayOfYear.taxonomy # freq=1269961 freq=839919
-AndHighHighDayTaxoFacets: +cite +new +facets:DayOfYear.taxonomy # freq=1741194 freq=1657293
-AndHighHighDayTaxoFacets: +and +by +facets:DayOfYear.taxonomy # freq=7318061 freq=3826691
-AndHighHighDayTaxoFacets: +publisher +i +facets:DayOfYear.taxonomy # freq=1289029 freq=956148
-AndHighHighDayTaxoFacets: +to +publisher +facets:DayOfYear.taxonomy # freq=6155577 freq=1289029
-AndHighHighDayTaxoFacets: +the +about +facets:DayOfYear.taxonomy # freq=8217362 freq=850283
-AndHighHighDayTaxoFacets: +as +are +facets:DayOfYear.taxonomy # freq=3925535 freq=1877802
-AndHighHighDayTaxoFacets: +it +title +facets:DayOfYear.taxonomy # freq=2675552 freq=2397378
-AndHighHighDayTaxoFacets: +by +are +facets:DayOfYear.taxonomy # freq=3826691 freq=1877802
-AndHighHighDayTaxoFacets: +has +have +facets:DayOfYear.taxonomy # freq=1502961 freq=1297121
-AndHighHighDayTaxoFacets: +one +2011 +facets:DayOfYear.taxonomy # freq=1527689 freq=871410
-AndHighHighDayTaxoFacets: +are +2005 +facets:DayOfYear.taxonomy # freq=1877802 freq=835460
-AndHighHighDayTaxoFacets: +had +some +facets:DayOfYear.taxonomy # freq=1246743 freq=839919
-AndHighHighDayTaxoFacets: +by +when +facets:DayOfYear.taxonomy # freq=3826691 freq=1027487
-AndHighHighDayTaxoFacets: +it +2011 +facets:DayOfYear.taxonomy # freq=2675552 freq=871410
-AndHighHighDayTaxoFacets: +1 +they +facets:DayOfYear.taxonomy # freq=1641090 freq=1021945
-AndHighHighDayTaxoFacets: +on +their +facets:DayOfYear.taxonomy # freq=4074624 freq=1158682
-AndHighHighDayTaxoFacets: +been +10 +facets:DayOfYear.taxonomy # freq=1041183 freq=918339
-AndHighHighDayTaxoFacets: +was +only +facets:DayOfYear.taxonomy # freq=3763623 freq=875561
-AndHighHighDayTaxoFacets: +also +other +facets:DayOfYear.taxonomy # freq=1959419 freq=1269961
-AndHighHighDayTaxoFacets: +who +its +facets:DayOfYear.taxonomy # freq=1196171 freq=1173450
-AndHighHighDayTaxoFacets: +3 +may +facets:DayOfYear.taxonomy # freq=1148799 freq=1071932
-AndHighHighDayTaxoFacets: +with +2006 +facets:DayOfYear.taxonomy # freq=3709421 freq=889954
-AndHighHighDayTaxoFacets: +from +but +facets:DayOfYear.taxonomy # freq=3224339 freq=1456553
-AndHighHighDayTaxoFacets: +was +work +facets:DayOfYear.taxonomy # freq=3763623 freq=853422
-AndHighHighDayTaxoFacets: +as +also +facets:DayOfYear.taxonomy # freq=3925535 freq=1959419
-AndHighHighDayTaxoFacets: +which +into +facets:DayOfYear.taxonomy # freq=1963428 freq=888684
-AndHighHighDayTaxoFacets: +see +i +facets:DayOfYear.taxonomy # freq=1044180 freq=956148
-AndHighHighDayTaxoFacets: +have +more +facets:DayOfYear.taxonomy # freq=1297121 freq=963533
-AndHighHighDayTaxoFacets: +were +after +facets:DayOfYear.taxonomy # freq=1524630 freq=1247398
-AndHighHighDayTaxoFacets: +on +2010 +facets:DayOfYear.taxonomy # freq=4074624 freq=950573
-AndHighHighDayTaxoFacets: +is +had +facets:DayOfYear.taxonomy # freq=4074455 freq=1246743
-AndHighHighDayTaxoFacets: +he +5 +facets:DayOfYear.taxonomy # freq=1659434 freq=891361
-AndHighHighDayTaxoFacets: +first +year +facets:DayOfYear.taxonomy # freq=1933372 freq=1235231
-AndHighHighDayTaxoFacets: +not +url +facets:DayOfYear.taxonomy # freq=1713264 freq=1513595
-AndHighHighDayTaxoFacets: +first +his +facets:DayOfYear.taxonomy # freq=1933372 freq=1777780
-AndHighHighDayTaxoFacets: +date +10 +facets:DayOfYear.taxonomy # freq=2020626 freq=918339
-AndHighHighDayTaxoFacets: +was +not +facets:DayOfYear.taxonomy # freq=3763623 freq=1713264
-AndHighHighDayTaxoFacets: +and +may +facets:DayOfYear.taxonomy # freq=7318061 freq=1071932
-AndHighHighDayTaxoFacets: +no +more +facets:DayOfYear.taxonomy # freq=1045000 freq=963533
-AndHighHighDayTaxoFacets: +it +url +facets:DayOfYear.taxonomy # freq=2675552 freq=1513595
-AndHighHighDayTaxoFacets: +as +no +facets:DayOfYear.taxonomy # freq=3925535 freq=1045000
-AndHighHighDayTaxoFacets: +other +all +facets:DayOfYear.taxonomy # freq=1269961 freq=1203572
-AndHighHighDayTaxoFacets: +as +2 +facets:DayOfYear.taxonomy # freq=3925535 freq=1549245
-AndHighHighDayTaxoFacets: +for +as +facets:DayOfYear.taxonomy # freq=4380011 freq=3925535
-AndHighHighDayTaxoFacets: +for +there +facets:DayOfYear.taxonomy # freq=4380011 freq=956153
-AndHighHighDayTaxoFacets: +the +new +facets:DayOfYear.taxonomy # freq=8217362 freq=1657293
-AndHighHighDayTaxoFacets: +is +no +facets:DayOfYear.taxonomy # freq=4074455 freq=1045000
-AndHighHighDayTaxoFacets: +also +their +facets:DayOfYear.taxonomy # freq=1959419 freq=1158682
-AndHighHighDayTaxoFacets: +that +2010 +facets:DayOfYear.taxonomy # freq=2931020 freq=950573
-AndHighHighDayTaxoFacets: +s +2008 +facets:DayOfYear.taxonomy # freq=1581243 freq=831253
-AndHighHighDayTaxoFacets: +were +2009 +facets:DayOfYear.taxonomy # freq=1524630 freq=887702
-AndHighHighDayTaxoFacets: +of +after +facets:DayOfYear.taxonomy # freq=8184358 freq=1247398
-AndHighHighDayTaxoFacets: +of +an +facets:DayOfYear.taxonomy # freq=8184358 freq=2628056
-AndHighHighDayTaxoFacets: +the +10 +facets:DayOfYear.taxonomy # freq=8217362 freq=918339
-AndHighHighDayTaxoFacets: +title +web +facets:DayOfYear.taxonomy # freq=2397378 freq=1118334
-AndHighHighDayTaxoFacets: +on +they +facets:DayOfYear.taxonomy # freq=4074624 freq=1021945
-AndHighHighDayTaxoFacets: +to +have +facets:DayOfYear.taxonomy # freq=6155577 freq=1297121
-AndHighHighDayTaxoFacets: +was +its +facets:DayOfYear.taxonomy # freq=3763623 freq=1173450
-AndHighHighDayTaxoFacets: +at +time +facets:DayOfYear.taxonomy # freq=2857534 freq=1032071
-AndHighHighDayTaxoFacets: +2 +accessdate +facets:DayOfYear.taxonomy # freq=1549245 freq=1228887
-AndHighHighDayTaxoFacets: +with +united +facets:DayOfYear.taxonomy # freq=3709421 freq=1196944
-AndHighHighDayTaxoFacets: +in +about +facets:DayOfYear.taxonomy # freq=7320987 freq=850283
-AndHighHighDayTaxoFacets: +in +2005 +facets:DayOfYear.taxonomy # freq=7320987 freq=835460
-AndHighHighDayTaxoFacets: +for +last +facets:DayOfYear.taxonomy # freq=4380011 freq=958437
-AndHighHighDayTaxoFacets: +and +when +facets:DayOfYear.taxonomy # freq=7318061 freq=1027487
-AndHighHighDayTaxoFacets: +an +their +facets:DayOfYear.taxonomy # freq=2628056 freq=1158682
-AndHighHighDayTaxoFacets: +2010 +into +facets:DayOfYear.taxonomy # freq=950573 freq=888684
-AndHighHighDayTaxoFacets: +web +two +facets:DayOfYear.taxonomy # freq=1118334 freq=1104053
-AndHighHighDayTaxoFacets: +two +4 +facets:DayOfYear.taxonomy # freq=1104053 freq=986452
-AndHighHighDayTaxoFacets: +1 +there +facets:DayOfYear.taxonomy # freq=1641090 freq=956153
-AndHighHighDayTaxoFacets: +name +url +facets:DayOfYear.taxonomy # freq=2827713 freq=1513595
-AndHighHighDayTaxoFacets: +united +who +facets:DayOfYear.taxonomy # freq=1196944 freq=1196171
-AndHighHighDayTaxoFacets: +they +there +facets:DayOfYear.taxonomy # freq=1021945 freq=956153
-AndHighHighDayTaxoFacets: +http +5 +facets:DayOfYear.taxonomy # freq=3493581 freq=891361
-AndHighHighDayTaxoFacets: +not +2008 +facets:DayOfYear.taxonomy # freq=1713264 freq=831253
-AndHighHighDayTaxoFacets: +are +2009 +facets:DayOfYear.taxonomy # freq=1877802 freq=887702
-AndHighHighDayTaxoFacets: +on +may +facets:DayOfYear.taxonomy # freq=4074624 freq=1071932
-AndHighHighDayTaxoFacets: +is +are +facets:DayOfYear.taxonomy # freq=4074455 freq=1877802
-AndHighHighDayTaxoFacets: +been +there +facets:DayOfYear.taxonomy # freq=1041183 freq=956153
-AndHighHighDayTaxoFacets: +other +into +facets:DayOfYear.taxonomy # freq=1269961 freq=888684
-AndHighHighDayTaxoFacets: +be +their +facets:DayOfYear.taxonomy # freq=2051702 freq=1158682
-AndHighHighDayTaxoFacets: +new +other +facets:DayOfYear.taxonomy # freq=1657293 freq=1269961
-AndHighHighDayTaxoFacets: +its +2011 +facets:DayOfYear.taxonomy # freq=1173450 freq=871410
-AndHighHighDayTaxoFacets: +ref +3 +facets:DayOfYear.taxonomy # freq=3793973 freq=1148799
-AndHighHighDayTaxoFacets: +name +be +facets:DayOfYear.taxonomy # freq=2827713 freq=2051702
-AndHighHighDayTaxoFacets: +had +see +facets:DayOfYear.taxonomy # freq=1246743 freq=1044180
-AndHighHighDayTaxoFacets: +also +or +facets:DayOfYear.taxonomy # freq=1959419 freq=1858841
-AndHighHighDayTaxoFacets: +but +4 +facets:DayOfYear.taxonomy # freq=1456553 freq=986452
-AndHighMedDayTaxoFacets: +has +please +facets:DayOfYear.taxonomy # freq=1502961 freq=229602
-AndHighMedDayTaxoFacets: +he +battle +facets:DayOfYear.taxonomy # freq=1659434 freq=192357
-AndHighMedDayTaxoFacets: +be +century +facets:DayOfYear.taxonomy # freq=2051702 freq=385541
-AndHighMedDayTaxoFacets: +may +studio +facets:DayOfYear.taxonomy # freq=1071932 freq=101979
-AndHighMedDayTaxoFacets: +have +level +facets:DayOfYear.taxonomy # freq=1297121 freq=175382
-AndHighMedDayTaxoFacets: +web +place +facets:DayOfYear.taxonomy # freq=1118334 freq=654158
-AndHighMedDayTaxoFacets: +all +close +facets:DayOfYear.taxonomy # freq=1203572 freq=136706
-AndHighMedDayTaxoFacets: +as +chart +facets:DayOfYear.taxonomy # freq=3925535 freq=84194
-AndHighMedDayTaxoFacets: +ref +appropriate +facets:DayOfYear.taxonomy # freq=3793973 freq=135343
-AndHighMedDayTaxoFacets: +be +put +facets:DayOfYear.taxonomy # freq=2051702 freq=139882
-AndHighMedDayTaxoFacets: +and +called +facets:DayOfYear.taxonomy # freq=7318061 freq=454580
-AndHighMedDayTaxoFacets: +been +four +facets:DayOfYear.taxonomy # freq=1041183 freq=389818
-AndHighMedDayTaxoFacets: +url +whether +facets:DayOfYear.taxonomy # freq=1513595 freq=93965
-AndHighMedDayTaxoFacets: +with +day +facets:DayOfYear.taxonomy # freq=3709421 freq=402096
-AndHighMedDayTaxoFacets: +a +famous +facets:DayOfYear.taxonomy # freq=6560531 freq=139092
-AndHighMedDayTaxoFacets: +it +nature +facets:DayOfYear.taxonomy # freq=2675552 freq=107428
-AndHighMedDayTaxoFacets: +his +although +facets:DayOfYear.taxonomy # freq=1777780 freq=341432
-AndHighMedDayTaxoFacets: +1 +artists +facets:DayOfYear.taxonomy # freq=1641090 freq=107145
-AndHighMedDayTaxoFacets: +title +digital +facets:DayOfYear.taxonomy # freq=2397378 freq=82650
-AndHighMedDayTaxoFacets: +that +37 +facets:DayOfYear.taxonomy # freq=2931020 freq=126429
-AndHighMedDayTaxoFacets: +was +free +facets:DayOfYear.taxonomy # freq=3763623 freq=270199
-AndHighMedDayTaxoFacets: +5 +west +facets:DayOfYear.taxonomy # freq=891361 freq=431006
-AndHighMedDayTaxoFacets: +had +reference +facets:DayOfYear.taxonomy # freq=1246743 freq=111493
-AndHighMedDayTaxoFacets: +in +sports +facets:DayOfYear.taxonomy # freq=7320987 freq=178542
-AndHighMedDayTaxoFacets: +its +interview +facets:DayOfYear.taxonomy # freq=1173450 freq=98846
-AndHighMedDayTaxoFacets: +url +took +facets:DayOfYear.taxonomy # freq=1513595 freq=247388
-AndHighMedDayTaxoFacets: +and +los +facets:DayOfYear.taxonomy # freq=7318061 freq=145404
-AndHighMedDayTaxoFacets: +last +english +facets:DayOfYear.taxonomy # freq=958437 freq=412061
-AndHighMedDayTaxoFacets: +not +lee +facets:DayOfYear.taxonomy # freq=1713264 freq=90461
-AndHighMedDayTaxoFacets: +their +few +facets:DayOfYear.taxonomy # freq=1158682 freq=226422
-AndHighMedDayTaxoFacets: +they +round +facets:DayOfYear.taxonomy # freq=1021945 freq=122499
-AndHighMedDayTaxoFacets: +cite +area +facets:DayOfYear.taxonomy # freq=1741194 freq=559023
-AndHighMedDayTaxoFacets: +two +lake +facets:DayOfYear.taxonomy # freq=1104053 freq=131603
-AndHighMedDayTaxoFacets: +time +8 +facets:DayOfYear.taxonomy # freq=1032071 freq=635822
-AndHighMedDayTaxoFacets: +this +winning +facets:DayOfYear.taxonomy # freq=2224932 freq=95704
-AndHighMedDayTaxoFacets: +only +performed +facets:DayOfYear.taxonomy # freq=875561 freq=104044
-AndHighMedDayTaxoFacets: +when +books.google.com +facets:DayOfYear.taxonomy # freq=1027487 freq=119391
-AndHighMedDayTaxoFacets: +who +legal +facets:DayOfYear.taxonomy # freq=1196171 freq=90645
-AndHighMedDayTaxoFacets: +2009 +keep +facets:DayOfYear.taxonomy # freq=887702 freq=177996
-AndHighMedDayTaxoFacets: +http +running +facets:DayOfYear.taxonomy # freq=3493581 freq=101764
-AndHighMedDayTaxoFacets: +5 +grand +facets:DayOfYear.taxonomy # freq=891361 freq=139202
-AndHighMedDayTaxoFacets: +it +man +facets:DayOfYear.taxonomy # freq=2675552 freq=278112
-AndHighMedDayTaxoFacets: +had +entertainment +facets:DayOfYear.taxonomy # freq=1246743 freq=117931
-AndHighMedDayTaxoFacets: +with +200px +facets:DayOfYear.taxonomy # freq=3709421 freq=102661
-AndHighMedDayTaxoFacets: +had +van +facets:DayOfYear.taxonomy # freq=1246743 freq=116920
-AndHighMedDayTaxoFacets: +was +track +facets:DayOfYear.taxonomy # freq=3763623 freq=148840
-AndHighMedDayTaxoFacets: +10 +corporation +facets:DayOfYear.taxonomy # freq=918339 freq=107425
-AndHighMedDayTaxoFacets: +other +make +facets:DayOfYear.taxonomy # freq=1269961 freq=292607
-AndHighMedDayTaxoFacets: +first +results +facets:DayOfYear.taxonomy # freq=1933372 freq=137248
-AndHighMedDayTaxoFacets: +2010 +unreferenced +facets:DayOfYear.taxonomy # freq=950573 freq=107803
-AndHighMedDayTaxoFacets: +first +top +facets:DayOfYear.taxonomy # freq=1933372 freq=364628
-AndHighMedDayTaxoFacets: +his +en +facets:DayOfYear.taxonomy # freq=1777780 freq=277463
-AndHighMedDayTaxoFacets: +other +airport +facets:DayOfYear.taxonomy # freq=1269961 freq=88205
-AndHighMedDayTaxoFacets: +10 +march +facets:DayOfYear.taxonomy # freq=918339 freq=620393
-AndHighMedDayTaxoFacets: +all +recently +facets:DayOfYear.taxonomy # freq=1203572 freq=90249
-AndHighMedDayTaxoFacets: +were +genre +facets:DayOfYear.taxonomy # freq=1524630 freq=121233
-AndHighMedDayTaxoFacets: +and +program +facets:DayOfYear.taxonomy # freq=7318061 freq=173553
-AndHighMedDayTaxoFacets: +i +09 +facets:DayOfYear.taxonomy # freq=956148 freq=296300
-AndHighMedDayTaxoFacets: +to +ended +facets:DayOfYear.taxonomy # freq=6155577 freq=84664
-AndHighMedDayTaxoFacets: +not +playing +facets:DayOfYear.taxonomy # freq=1713264 freq=133330
-AndHighMedDayTaxoFacets: +time +companies +facets:DayOfYear.taxonomy # freq=1032071 freq=98905
-AndHighMedDayTaxoFacets: +to +living +facets:DayOfYear.taxonomy # freq=6155577 freq=181427
-AndHighMedDayTaxoFacets: +of +silver +facets:DayOfYear.taxonomy # freq=8184358 freq=85967
-AndHighMedDayTaxoFacets: +in +images +facets:DayOfYear.taxonomy # freq=7320987 freq=125154
-AndHighMedDayTaxoFacets: +2008 +debate +facets:DayOfYear.taxonomy # freq=831253 freq=177827
-AndHighMedDayTaxoFacets: +some +los +facets:DayOfYear.taxonomy # freq=839919 freq=145404
-AndHighMedDayTaxoFacets: +2008 +simply +facets:DayOfYear.taxonomy # freq=831253 freq=84090
-AndHighMedDayTaxoFacets: +first +producer +facets:DayOfYear.taxonomy # freq=1933372 freq=137098
-AndHighMedDayTaxoFacets: +last +seven +facets:DayOfYear.taxonomy # freq=958437 freq=134402
-AndHighMedDayTaxoFacets: +more +soon +facets:DayOfYear.taxonomy # freq=963533 freq=123657
-AndHighMedDayTaxoFacets: +date +talk +facets:DayOfYear.taxonomy # freq=2020626 freq=364194
-AndHighMedDayTaxoFacets: +its +49 +facets:DayOfYear.taxonomy # freq=1173450 freq=103612
-AndHighMedDayTaxoFacets: +publisher +car +facets:DayOfYear.taxonomy # freq=1289029 freq=121250
-AndHighMedDayTaxoFacets: +were +v +facets:DayOfYear.taxonomy # freq=1524630 freq=284318
-AndHighMedDayTaxoFacets: +more +says +facets:DayOfYear.taxonomy # freq=963533 freq=84589
-AndHighMedDayTaxoFacets: +3 +man +facets:DayOfYear.taxonomy # freq=1148799 freq=278112
-AndHighMedDayTaxoFacets: +but +1974 +facets:DayOfYear.taxonomy # freq=1456553 freq=132835
-AndHighMedDayTaxoFacets: +but +02 +facets:DayOfYear.taxonomy # freq=1456553 freq=319783
-AndHighMedDayTaxoFacets: +see +historic +facets:DayOfYear.taxonomy # freq=1044180 freq=112292
-AndHighMedDayTaxoFacets: +which +wife +facets:DayOfYear.taxonomy # freq=1963428 freq=130807
-AndHighMedDayTaxoFacets: +1 +grand +facets:DayOfYear.taxonomy # freq=1641090 freq=139202
-AndHighMedDayTaxoFacets: +it +real +facets:DayOfYear.taxonomy # freq=2675552 freq=151505
-AndHighMedDayTaxoFacets: +its +development +facets:DayOfYear.taxonomy # freq=1173450 freq=230286
-AndHighMedDayTaxoFacets: +3 +office +facets:DayOfYear.taxonomy # freq=1148799 freq=225338
-AndHighMedDayTaxoFacets: +10 +class +facets:DayOfYear.taxonomy # freq=918339 freq=556838
-AndHighMedDayTaxoFacets: +not +abbr +facets:DayOfYear.taxonomy # freq=1713264 freq=96135
-AndHighMedDayTaxoFacets: +accessdate +hand +facets:DayOfYear.taxonomy # freq=1228887 freq=119947
-AndHighMedDayTaxoFacets: +2011 +trade +facets:DayOfYear.taxonomy # freq=871410 freq=106384
-AndHighMedDayTaxoFacets: +that +love +facets:DayOfYear.taxonomy # freq=2931020 freq=177242
-AndHighMedDayTaxoFacets: +from +took +facets:DayOfYear.taxonomy # freq=3224339 freq=247388
-AndHighMedDayTaxoFacets: +united +id +facets:DayOfYear.taxonomy # freq=1196944 freq=579566
-AndHighMedDayTaxoFacets: +s +mi +facets:DayOfYear.taxonomy # freq=1581243 freq=97131
-AndHighMedDayTaxoFacets: +as +young +facets:DayOfYear.taxonomy # freq=3925535 freq=196428
-AndHighMedDayTaxoFacets: +3 +opening +facets:DayOfYear.taxonomy # freq=1148799 freq=84576
-AndHighMedDayTaxoFacets: +other +european +facets:DayOfYear.taxonomy # freq=1269961 freq=193975
-AndHighMedDayTaxoFacets: +ref +chart +facets:DayOfYear.taxonomy # freq=3793973 freq=84194
-AndHighMedDayTaxoFacets: +about +thought +facets:DayOfYear.taxonomy # freq=850283 freq=108963
-AndHighMedDayTaxoFacets: +for +should +facets:DayOfYear.taxonomy # freq=4380011 freq=401379
-AndHighMedDayTaxoFacets: +united +lead +facets:DayOfYear.taxonomy # freq=1196944 freq=141336
-AndHighMedDayTaxoFacets: +this +movie +facets:DayOfYear.taxonomy # freq=2224932 freq=133291
-AndHighMedDayTaxoFacets: +2011 +winning +facets:DayOfYear.taxonomy # freq=871410 freq=95704
-AndHighMedDayTaxoFacets: +new +shows +facets:DayOfYear.taxonomy # freq=1657293 freq=131923
-AndHighMedDayTaxoFacets: +no +him +facets:DayOfYear.taxonomy # freq=1045000 freq=507350
-AndHighMedDayTaxoFacets: +has +always +facets:DayOfYear.taxonomy # freq=1502961 freq=112388
-AndHighMedDayTaxoFacets: +ref +above +facets:DayOfYear.taxonomy # freq=3793973 freq=246135
-AndHighMedDayTaxoFacets: +have +uses +facets:DayOfYear.taxonomy # freq=1297121 freq=134331
-AndHighMedDayTaxoFacets: +who +80 +facets:DayOfYear.taxonomy # freq=1196171 freq=104865
-AndHighMedDayTaxoFacets: +2008 +series +facets:DayOfYear.taxonomy # freq=831253 freq=521861
-AndHighMedDayTaxoFacets: +ref +40 +facets:DayOfYear.taxonomy # freq=3793973 freq=221687
-AndHighMedDayTaxoFacets: +when +second +facets:DayOfYear.taxonomy # freq=1027487 freq=505575
-AndHighMedDayTaxoFacets: +at +parliament +facets:DayOfYear.taxonomy # freq=2857534 freq=127008
-AndHighMedDayTaxoFacets: +were +pacific +facets:DayOfYear.taxonomy # freq=1524630 freq=107648
-AndHighMedDayTaxoFacets: +2 +recent +facets:DayOfYear.taxonomy # freq=1549245 freq=113385
-AndHighMedDayTaxoFacets: +http +close +facets:DayOfYear.taxonomy # freq=3493581 freq=136706
-AndHighMedDayTaxoFacets: +has +power +facets:DayOfYear.taxonomy # freq=1502961 freq=262586
-AndHighMedDayTaxoFacets: +or +words +facets:DayOfYear.taxonomy # freq=1858841 freq=104783
-AndHighMedDayTaxoFacets: +after +mary +facets:DayOfYear.taxonomy # freq=1247398 freq=96445
-AndHighMedDayTaxoFacets: +3 +state +facets:DayOfYear.taxonomy # freq=1148799 freq=702598
-AndHighMedDayTaxoFacets: +its +directed +facets:DayOfYear.taxonomy # freq=1173450 freq=86592
-AndHighMedDayTaxoFacets: +more +army +facets:DayOfYear.taxonomy # freq=963533 freq=228105
-AndHighMedDayTaxoFacets: +see +genre +facets:DayOfYear.taxonomy # freq=1044180 freq=121233
-AndHighMedDayTaxoFacets: +5 +natural +facets:DayOfYear.taxonomy # freq=891361 freq=125503
-AndHighMedDayTaxoFacets: +into +ship +facets:DayOfYear.taxonomy # freq=888684 freq=113012
-AndHighMedDayTaxoFacets: +2005 +construction +facets:DayOfYear.taxonomy # freq=835460 freq=124179
-AndHighMedDayTaxoFacets: +some +found +facets:DayOfYear.taxonomy # freq=839919 freq=313247
-AndHighMedDayTaxoFacets: +2 +actor +facets:DayOfYear.taxonomy # freq=1549245 freq=144573
-AndHighMedDayTaxoFacets: +and +owned +facets:DayOfYear.taxonomy # freq=7318061 freq=93981
-AndHighMedDayTaxoFacets: +which +authority +facets:DayOfYear.taxonomy # freq=1963428 freq=85540
-AndHighMedDayTaxoFacets: +have +r +facets:DayOfYear.taxonomy # freq=1297121 freq=296283
-AndHighMedDayTaxoFacets: +is +approximately +facets:DayOfYear.taxonomy # freq=4074455 freq=88426
-AndHighMedDayTaxoFacets: +he +deletion +facets:DayOfYear.taxonomy # freq=1659434 freq=166633
-AndHighMedDayTaxoFacets: +and +jean +facets:DayOfYear.taxonomy # freq=7318061 freq=84299
-AndHighMedDayTaxoFacets: +have +43 +facets:DayOfYear.taxonomy # freq=1297121 freq=115496
-AndHighMedDayTaxoFacets: +only +daily +facets:DayOfYear.taxonomy # freq=875561 freq=111717
-AndHighMedDayTaxoFacets: +united +zealand +facets:DayOfYear.taxonomy # freq=1196944 freq=92761
-AndHighMedDayTaxoFacets: +also +read +facets:DayOfYear.taxonomy # freq=1959419 freq=86513
-AndHighMedDayTaxoFacets: +are +division +facets:DayOfYear.taxonomy # freq=1877802 freq=182624
-AndHighMedDayTaxoFacets: +for +seat +facets:DayOfYear.taxonomy # freq=4380011 freq=91288
-AndHighMedDayTaxoFacets: +2005 +hand +facets:DayOfYear.taxonomy # freq=835460 freq=119947
-AndHighMedDayTaxoFacets: +publisher +usually +facets:DayOfYear.taxonomy # freq=1289029 freq=176058
-AndHighMedDayTaxoFacets: +from +teams +facets:DayOfYear.taxonomy # freq=3224339 freq=105245
-AndHighMedDayTaxoFacets: +in +wife +facets:DayOfYear.taxonomy # freq=7320987 freq=130807
-AndHighMedDayTaxoFacets: +2006 +james +facets:DayOfYear.taxonomy # freq=889954 freq=281597
-AndHighMedDayTaxoFacets: +2005 +found +facets:DayOfYear.taxonomy # freq=835460 freq=313247
-AndHighMedDayTaxoFacets: +after +replaced +facets:DayOfYear.taxonomy # freq=1247398 freq=112506
-AndHighMedDayTaxoFacets: +5 +played +facets:DayOfYear.taxonomy # freq=891361 freq=248191
-AndHighMedDayTaxoFacets: +last +1945 +facets:DayOfYear.taxonomy # freq=958437 freq=106881
-AndHighMedDayTaxoFacets: +not +william +facets:DayOfYear.taxonomy # freq=1713264 freq=284592
-AndHighMedDayTaxoFacets: +may +changed +facets:DayOfYear.taxonomy # freq=1071932 freq=112032
-AndHighMedDayTaxoFacets: +one +might +facets:DayOfYear.taxonomy # freq=1527689 freq=114290
-AndHighMedDayTaxoFacets: +one +1966 +facets:DayOfYear.taxonomy # freq=1527689 freq=106672
-AndHighMedDayTaxoFacets: +2006 +mother +facets:DayOfYear.taxonomy # freq=889954 freq=122930
-AndHighMedDayTaxoFacets: +no +hi +facets:DayOfYear.taxonomy # freq=1045000 freq=91593
-AndHighMedDayTaxoFacets: +they +my +facets:DayOfYear.taxonomy # freq=1021945 freq=274256
-AndHighMedDayTaxoFacets: +it +london +facets:DayOfYear.taxonomy # freq=2675552 freq=348918
-AndHighMedDayTaxoFacets: +but +according +facets:DayOfYear.taxonomy # freq=1456553 freq=256949
-AndHighMedDayTaxoFacets: +an +results +facets:DayOfYear.taxonomy # freq=2628056 freq=137248
-AndHighMedDayTaxoFacets: +from +you +facets:DayOfYear.taxonomy # freq=3224339 freq=461587
-AndHighMedDayTaxoFacets: +web +single +facets:DayOfYear.taxonomy # freq=1118334 freq=283824
-AndHighMedDayTaxoFacets: +two +old +facets:DayOfYear.taxonomy # freq=1104053 freq=381809
-AndHighMedDayTaxoFacets: +some +daughter +facets:DayOfYear.taxonomy # freq=839919 freq=103883
-AndHighMedDayTaxoFacets: +url +various +facets:DayOfYear.taxonomy # freq=1513595 freq=224593
-AndHighMedDayTaxoFacets: +have +would +facets:DayOfYear.taxonomy # freq=1297121 freq=690480
-AndHighMedDayTaxoFacets: +to +released +facets:DayOfYear.taxonomy # freq=6155577 freq=322473
-AndHighMedDayTaxoFacets: +had +refer +facets:DayOfYear.taxonomy # freq=1246743 freq=110259
-AndHighMedDayTaxoFacets: +url +article +facets:DayOfYear.taxonomy # freq=1513595 freq=610650
-AndHighMedDayTaxoFacets: +when +designed +facets:DayOfYear.taxonomy # freq=1027487 freq=118748
-AndHighMedDayTaxoFacets: +which +party +facets:DayOfYear.taxonomy # freq=1963428 freq=394410
-AndHighMedDayTaxoFacets: +a +florida +facets:DayOfYear.taxonomy # freq=6560531 freq=92166
-AndHighMedDayTaxoFacets: +the +image_caption +facets:DayOfYear.taxonomy # freq=8217362 freq=87977
-AndHighMedDayTaxoFacets: +last +width +facets:DayOfYear.taxonomy # freq=958437 freq=172609
-AndHighMedDayTaxoFacets: +may +r +facets:DayOfYear.taxonomy # freq=1071932 freq=296283
-AndHighMedDayTaxoFacets: +at +inside +facets:DayOfYear.taxonomy # freq=2857534 freq=84712
-AndHighMedDayTaxoFacets: +3 +p +facets:DayOfYear.taxonomy # freq=1148799 freq=616159
-AndHighMedDayTaxoFacets: +2009 +imperial +facets:DayOfYear.taxonomy # freq=887702 freq=86508
-AndHighMedDayTaxoFacets: +for +access +facets:DayOfYear.taxonomy # freq=4380011 freq=100041
-AndHighMedDayTaxoFacets: +some +former +facets:DayOfYear.taxonomy # freq=839919 freq=332750
-AndHighMedDayTaxoFacets: +url +important +facets:DayOfYear.taxonomy # freq=1513595 freq=195851
-AndHighMedDayTaxoFacets: +which +recorded +facets:DayOfYear.taxonomy # freq=1963428 freq=160249
-AndHighMedDayTaxoFacets: +of +family +facets:DayOfYear.taxonomy # freq=8184358 freq=387175
-AndHighMedDayTaxoFacets: +2 +family +facets:DayOfYear.taxonomy # freq=1549245 freq=387175
-AndHighMedDayTaxoFacets: +was +old +facets:DayOfYear.taxonomy # freq=3763623 freq=381809
-AndHighMedDayTaxoFacets: +more +jpg +facets:DayOfYear.taxonomy # freq=963533 freq=322278
-AndHighMedDayTaxoFacets: +2005 +1979 +facets:DayOfYear.taxonomy # freq=835460 freq=145407
-AndHighMedDayTaxoFacets: +are +became +facets:DayOfYear.taxonomy # freq=1877802 freq=465594
-AndHighMedDayTaxoFacets: +new +products +facets:DayOfYear.taxonomy # freq=1657293 freq=88448
-AndHighMedDayTaxoFacets: +first +mexico +facets:DayOfYear.taxonomy # freq=1933372 freq=88689
-AndHighMedDayTaxoFacets: +10 +nbsp +facets:DayOfYear.taxonomy # freq=918339 freq=506054
-AndHighMedDayTaxoFacets: +by +25 +facets:DayOfYear.taxonomy # freq=3826691 freq=491957
-AndHighMedDayTaxoFacets: +was +language +facets:DayOfYear.taxonomy # freq=3763623 freq=416771
-AndHighMedDayTaxoFacets: +and +future +facets:DayOfYear.taxonomy # freq=7318061 freq=136421
-AndHighMedDayTaxoFacets: +their +flight +facets:DayOfYear.taxonomy # freq=1158682 freq=84316
-AndHighMedDayTaxoFacets: +2011 +hold +facets:DayOfYear.taxonomy # freq=871410 freq=82579
-AndHighMedDayTaxoFacets: +there +programs +facets:DayOfYear.taxonomy # freq=956153 freq=83974
-AndHighMedDayTaxoFacets: +after +original +facets:DayOfYear.taxonomy # freq=1247398 freq=323521
-AndHighMedDayTaxoFacets: +only +ten +facets:DayOfYear.taxonomy # freq=875561 freq=114388
-AndHighMedDayTaxoFacets: +to +traditional +facets:DayOfYear.taxonomy # freq=6155577 freq=110425
-AndHighMedDayTaxoFacets: +also +centre +facets:DayOfYear.taxonomy # freq=1959419 freq=159597
-AndHighMedDayTaxoFacets: +all +isbn +facets:DayOfYear.taxonomy # freq=1203572 freq=467574
-AndHighMedDayTaxoFacets: +this +direct +facets:DayOfYear.taxonomy # freq=2224932 freq=82292
-AndHighMedDayTaxoFacets: +http +earlier +facets:DayOfYear.taxonomy # freq=3493581 freq=100372
-AndHighMedDayTaxoFacets: +cite +system +facets:DayOfYear.taxonomy # freq=1741194 freq=412862
-AndHighMedDayTaxoFacets: +were +library +facets:DayOfYear.taxonomy # freq=1524630 freq=138468
-AndHighMedDayTaxoFacets: +first +alone +facets:DayOfYear.taxonomy # freq=1933372 freq=93166
-AndHighMedDayTaxoFacets: +new +century +facets:DayOfYear.taxonomy # freq=1657293 freq=385541
-AndHighMedDayTaxoFacets: +s +reached +facets:DayOfYear.taxonomy # freq=1581243 freq=89854
-AndHighMedDayTaxoFacets: +united +le +facets:DayOfYear.taxonomy # freq=1196944 freq=84979
-AndHighMedDayTaxoFacets: +url +auto +facets:DayOfYear.taxonomy # freq=1513595 freq=103107
-AndHighMedDayTaxoFacets: +3 +practice +facets:DayOfYear.taxonomy # freq=1148799 freq=93287
-AndHighMedDayTaxoFacets: +http +working +facets:DayOfYear.taxonomy # freq=3493581 freq=144617
-AndHighMedDayTaxoFacets: +in +fire +facets:DayOfYear.taxonomy # freq=7320987 freq=133712
-AndHighMedDayTaxoFacets: +10 +52 +facets:DayOfYear.taxonomy # freq=918339 freq=108395
-AndHighMedDayTaxoFacets: +more +singer +facets:DayOfYear.taxonomy # freq=963533 freq=114006
-AndHighMedDayTaxoFacets: +new +low +facets:DayOfYear.taxonomy # freq=1657293 freq=157852
-AndHighMedDayTaxoFacets: +with +previously +facets:DayOfYear.taxonomy # freq=3709421 freq=96083
-AndHighMedDayTaxoFacets: +first +original +facets:DayOfYear.taxonomy # freq=1933372 freq=323521
-AndHighMedDayTaxoFacets: +2008 +wikitable +facets:DayOfYear.taxonomy # freq=831253 freq=210990
-AndHighMedDayTaxoFacets: +http +can +facets:DayOfYear.taxonomy # freq=3493581 freq=765163
-AndHighMedDayTaxoFacets: +year +1965 +facets:DayOfYear.taxonomy # freq=1235231 freq=104539
-AndHighMedDayTaxoFacets: +have +mother +facets:DayOfYear.taxonomy # freq=1297121 freq=122930
-AndHighMedDayTaxoFacets: +states +lived +facets:DayOfYear.taxonomy # freq=1034872 freq=91327
-AndHighMedDayTaxoFacets: +to +me +facets:DayOfYear.taxonomy # freq=6155577 freq=229204
-AndHighMedDayTaxoFacets: +4 +race +facets:DayOfYear.taxonomy # freq=986452 freq=148763
-AndHighMedDayTaxoFacets: +of +54 +facets:DayOfYear.taxonomy # freq=8184358 freq=101462
-AndHighMedDayTaxoFacets: +some +series +facets:DayOfYear.taxonomy # freq=839919 freq=521861
-AndHighMedDayTaxoFacets: +2 +big +facets:DayOfYear.taxonomy # freq=1549245 freq=163394
-AndHighMedDayTaxoFacets: +some +without +facets:DayOfYear.taxonomy # freq=839919 freq=249926
-AndHighMedDayTaxoFacets: +2011 +font +facets:DayOfYear.taxonomy # freq=871410 freq=269439
-AndHighMedDayTaxoFacets: +http +votes +facets:DayOfYear.taxonomy # freq=3493581 freq=93844
-AndHighMedDayTaxoFacets: +2009 +19th +facets:DayOfYear.taxonomy # freq=887702 freq=93290
-AndHighMedDayTaxoFacets: +an +central +facets:DayOfYear.taxonomy # freq=2628056 freq=272531
-AndHighMedDayTaxoFacets: +some +1959 +facets:DayOfYear.taxonomy # freq=839919 freq=87097
-AndHighMedDayTaxoFacets: +cite +out +facets:DayOfYear.taxonomy # freq=1741194 freq=733775
-AndHighMedDayTaxoFacets: +was +cross +facets:DayOfYear.taxonomy # freq=3763623 freq=127216
-AndHighMedDayTaxoFacets: +3 +1950 +facets:DayOfYear.taxonomy # freq=1148799 freq=89746
-AndHighMedDayTaxoFacets: +there +market +facets:DayOfYear.taxonomy # freq=956153 freq=118467
-AndHighMedDayTaxoFacets: +new +mid +facets:DayOfYear.taxonomy # freq=1657293 freq=126355
-AndHighMedDayTaxoFacets: +or +sent +facets:DayOfYear.taxonomy # freq=1858841 freq=103620
-AndHighMedDayTaxoFacets: +may +pp +facets:DayOfYear.taxonomy # freq=1071932 freq=204742
-AndHighMedDayTaxoFacets: +the +flagicon +facets:DayOfYear.taxonomy # freq=8217362 freq=107428
-AndHighMedDayTaxoFacets: +who +genre +facets:DayOfYear.taxonomy # freq=1196171 freq=121233
-AndHighMedDayTaxoFacets: +last +library +facets:DayOfYear.taxonomy # freq=958437 freq=138468
-AndHighMedDayTaxoFacets: +and +none +facets:DayOfYear.taxonomy # freq=7318061 freq=100192
-AndHighMedDayTaxoFacets: +an +majority +facets:DayOfYear.taxonomy # freq=2628056 freq=105058
-AndHighMedDayTaxoFacets: +it +religion +facets:DayOfYear.taxonomy # freq=2675552 freq=96655
-AndHighMedDayTaxoFacets: +first +brown +facets:DayOfYear.taxonomy # freq=1933372 freq=116178
-AndHighMedDayTaxoFacets: +more +standard +facets:DayOfYear.taxonomy # freq=963533 freq=185039
-AndHighMedDayTaxoFacets: +into +process +facets:DayOfYear.taxonomy # freq=888684 freq=152588
-AndHighMedDayTaxoFacets: +for +website +facets:DayOfYear.taxonomy # freq=4380011 freq=435941
-AndHighMedDayTaxoFacets: +name +parts +facets:DayOfYear.taxonomy # freq=2827713 freq=123891
-AndHighMedDayTaxoFacets: +for +few +facets:DayOfYear.taxonomy # freq=4380011 freq=226422
-AndHighMedDayTaxoFacets: +web +available +facets:DayOfYear.taxonomy # freq=1118334 freq=175514
-AndHighMedDayTaxoFacets: +other +christian +facets:DayOfYear.taxonomy # freq=1269961 freq=140312
-AndHighMedDayTaxoFacets: +2 +imperial +facets:DayOfYear.taxonomy # freq=1549245 freq=86508
-AndHighMedDayTaxoFacets: +at +space +facets:DayOfYear.taxonomy # freq=2857534 freq=163436
-AndHighMedDayTaxoFacets: +but +paul +facets:DayOfYear.taxonomy # freq=1456553 freq=207229
-AndHighMedDayTaxoFacets: +into +70 +facets:DayOfYear.taxonomy # freq=888684 freq=90305
-AndHighMedDayTaxoFacets: +s +mdash +facets:DayOfYear.taxonomy # freq=1581243 freq=111708
-AndHighMedDayTaxoFacets: +5 +brown +facets:DayOfYear.taxonomy # freq=891361 freq=116178
-AndHighMedDayTaxoFacets: +2005 +hill +facets:DayOfYear.taxonomy # freq=835460 freq=133714
-AndHighMedDayTaxoFacets: +2006 +eight +facets:DayOfYear.taxonomy # freq=889954 freq=106268
-AndHighMedDayTaxoFacets: +two +era +facets:DayOfYear.taxonomy # freq=1104053 freq=95989
-AndHighMedDayTaxoFacets: +time +100 +facets:DayOfYear.taxonomy # freq=1032071 freq=268978
-AndHighMedDayTaxoFacets: +title +70 +facets:DayOfYear.taxonomy # freq=2397378 freq=90305
-AndHighMedDayTaxoFacets: +3 +empire +facets:DayOfYear.taxonomy # freq=1148799 freq=143207
-AndHighMedDayTaxoFacets: +in +di +facets:DayOfYear.taxonomy # freq=7320987 freq=83139
-AndHighMedDayTaxoFacets: +and +included +facets:DayOfYear.taxonomy # freq=7318061 freq=216978
-AndHighMedDayTaxoFacets: +that +play +facets:DayOfYear.taxonomy # freq=2931020 freq=210199
-AndHighMedDayTaxoFacets: +an +might +facets:DayOfYear.taxonomy # freq=2628056 freq=114290
-AndHighMedDayTaxoFacets: +other +country +facets:DayOfYear.taxonomy # freq=1269961 freq=420052
-AndHighMedDayTaxoFacets: +also +success +facets:DayOfYear.taxonomy # freq=1959419 freq=112195
-AndHighMedDayTaxoFacets: +also +27 +facets:DayOfYear.taxonomy # freq=1959419 freq=383042
-AndHighMedDayTaxoFacets: +more +stations +facets:DayOfYear.taxonomy # freq=963533 freq=92011
-AndHighMedDayTaxoFacets: +they +system +facets:DayOfYear.taxonomy # freq=1021945 freq=412862
-AndHighMedDayTaxoFacets: +in +31 +facets:DayOfYear.taxonomy # freq=7320987 freq=298349
-AndHighMedDayTaxoFacets: +all +provided +facets:DayOfYear.taxonomy # freq=1203572 freq=110088
-AndHighMedDayTaxoFacets: +i +u.s +facets:DayOfYear.taxonomy # freq=956148 freq=428534
-AndHighMedDayTaxoFacets: +a +certain +facets:DayOfYear.taxonomy # freq=6560531 freq=105714
-AndHighMedDayTaxoFacets: +his +summary +facets:DayOfYear.taxonomy # freq=1777780 freq=106702
-AndHighMedDayTaxoFacets: +2009 +america +facets:DayOfYear.taxonomy # freq=887702 freq=240374
-AndHighMedDayTaxoFacets: +1 +chicago +facets:DayOfYear.taxonomy # freq=1641090 freq=117756
-AndHighMedDayTaxoFacets: +other +2000 +facets:DayOfYear.taxonomy # freq=1269961 freq=499639
-AndHighMedDayTaxoFacets: +year +men +facets:DayOfYear.taxonomy # freq=1235231 freq=182445
-AndHighMedDayTaxoFacets: +4 +upon +facets:DayOfYear.taxonomy # freq=986452 freq=169174
-AndHighMedDayTaxoFacets: +in +seems +facets:DayOfYear.taxonomy # freq=7320987 freq=83963
-AndHighMedDayTaxoFacets: +he +bank +facets:DayOfYear.taxonomy # freq=1659434 freq=88080
-AndHighMedDayTaxoFacets: +name +both +facets:DayOfYear.taxonomy # freq=2827713 freq=534900
-AndHighMedDayTaxoFacets: +publisher +e +facets:DayOfYear.taxonomy # freq=1289029 freq=408741
-AndHighMedDayTaxoFacets: +who +computer +facets:DayOfYear.taxonomy # freq=1196171 freq=126524
-AndHighMedDayTaxoFacets: +about +type +facets:DayOfYear.taxonomy # freq=850283 freq=318210
-AndHighMedDayTaxoFacets: +this +people +facets:DayOfYear.taxonomy # freq=2224932 freq=790960
-AndHighMedDayTaxoFacets: +their +1978 +facets:DayOfYear.taxonomy # freq=1158682 freq=135223
-AndHighMedDayTaxoFacets: +url +museum +facets:DayOfYear.taxonomy # freq=1513595 freq=135250
-AndHighMedDayTaxoFacets: +4 +least +facets:DayOfYear.taxonomy # freq=986452 freq=146209
-AndHighMedDayTaxoFacets: +2011 +money +facets:DayOfYear.taxonomy # freq=871410 freq=100440
-AndHighMedDayTaxoFacets: +first +referred +facets:DayOfYear.taxonomy # freq=1933372 freq=94811
-AndHighMedDayTaxoFacets: +he +20 +facets:DayOfYear.taxonomy # freq=1659434 freq=624967
-AndHighMedDayTaxoFacets: +were +events +facets:DayOfYear.taxonomy # freq=1524630 freq=158248
-AndHighMedDayTaxoFacets: +it +because +facets:DayOfYear.taxonomy # freq=2675552 freq=413003
-AndHighMedDayTaxoFacets: +accessdate +large +facets:DayOfYear.taxonomy # freq=1228887 freq=308888
-AndHighMedDayTaxoFacets: +there +usa +facets:DayOfYear.taxonomy # freq=956153 freq=191220
-AndHighMedDayTaxoFacets: +he +association +facets:DayOfYear.taxonomy # freq=1659434 freq=247156
-AndHighMedDayTaxoFacets: +2010 +rest +facets:DayOfYear.taxonomy # freq=950573 freq=95113
-AndHighMedDayTaxoFacets: +he +face +facets:DayOfYear.taxonomy # freq=1659434 freq=95144
-AndHighMedDayTaxoFacets: +title +out +facets:DayOfYear.taxonomy # freq=2397378 freq=733775
-AndHighMedDayTaxoFacets: +first +christian +facets:DayOfYear.taxonomy # freq=1933372 freq=140312
-AndHighMedDayTaxoFacets: +has +april +facets:DayOfYear.taxonomy # freq=1502961 freq=587542
-AndHighMedDayTaxoFacets: +in +very +facets:DayOfYear.taxonomy # freq=7320987 freq=354898
-AndHighMedDayTaxoFacets: +no +century +facets:DayOfYear.taxonomy # freq=1045000 freq=385541
-AndHighMedDayTaxoFacets: +accessdate +recording +facets:DayOfYear.taxonomy # freq=1228887 freq=90757
-AndHighMedDayTaxoFacets: +by +55 +facets:DayOfYear.taxonomy # freq=3826691 freq=110526
-AndHighMedDayTaxoFacets: +2005 +54 +facets:DayOfYear.taxonomy # freq=835460 freq=101462
-AndHighMedDayTaxoFacets: +this +x +facets:DayOfYear.taxonomy # freq=2224932 freq=272695
-AndHighMedDayTaxoFacets: +url +following +facets:DayOfYear.taxonomy # freq=1513595 freq=416515
-AndHighMedDayTaxoFacets: +s +per +facets:DayOfYear.taxonomy # freq=1581243 freq=283568
-AndHighMedDayTaxoFacets: +2005 +bureau +facets:DayOfYear.taxonomy # freq=835460 freq=83671
-AndHighMedDayTaxoFacets: +1 +09 +facets:DayOfYear.taxonomy # freq=1641090 freq=296300
-AndHighMedDayTaxoFacets: +title +buildings +facets:DayOfYear.taxonomy # freq=2397378 freq=89046
-AndHighMedDayTaxoFacets: +by +appears +facets:DayOfYear.taxonomy # freq=3826691 freq=104511
-AndHighMedDayTaxoFacets: +year +taken +facets:DayOfYear.taxonomy # freq=1235231 freq=166217
-AndHighMedDayTaxoFacets: +on +size +facets:DayOfYear.taxonomy # freq=4074624 freq=237662
-AndHighMedDayTaxoFacets: +2005 +thomas +facets:DayOfYear.taxonomy # freq=835460 freq=191625
-AndHighMedDayTaxoFacets: +2008 +chicago +facets:DayOfYear.taxonomy # freq=831253 freq=117756
-AndHighMedDayTaxoFacets: +2 +1991 +facets:DayOfYear.taxonomy # freq=1549245 freq=207589
-AndHighMedDayTaxoFacets: +only +2003 +facets:DayOfYear.taxonomy # freq=875561 freq=456990
-AndHighMedDayTaxoFacets: +their +found +facets:DayOfYear.taxonomy # freq=1158682 freq=313247
-AndHighMedDayTaxoFacets: +for +long +facets:DayOfYear.taxonomy # freq=4380011 freq=385787
-AndHighMedDayTaxoFacets: +2011 +low +facets:DayOfYear.taxonomy # freq=871410 freq=157852
-AndHighMedDayTaxoFacets: +for +iii +facets:DayOfYear.taxonomy # freq=4380011 freq=123618
-AndHighMedDayTaxoFacets: +is +1990s +facets:DayOfYear.taxonomy # freq=4074455 freq=83166
-AndHighMedDayTaxoFacets: +some +instead +facets:DayOfYear.taxonomy # freq=839919 freq=149345
-AndHighMedDayTaxoFacets: +publisher +historical +facets:DayOfYear.taxonomy # freq=1289029 freq=159636
-AndHighMedDayTaxoFacets: +are +please +facets:DayOfYear.taxonomy # freq=1877802 freq=229602
-AndHighMedDayTaxoFacets: +who +brown +facets:DayOfYear.taxonomy # freq=1196171 freq=116178
-AndHighMedDayTaxoFacets: +an +professional +facets:DayOfYear.taxonomy # freq=2628056 freq=138520
-AndHighMedDayTaxoFacets: +name +security +facets:DayOfYear.taxonomy # freq=2827713 freq=89382
-AndHighMedDayTaxoFacets: +name +8 +facets:DayOfYear.taxonomy # freq=2827713 freq=635822
-AndHighMedDayTaxoFacets: +from +china +facets:DayOfYear.taxonomy # freq=3224339 freq=130849
-AndHighMedDayTaxoFacets: +a +early +facets:DayOfYear.taxonomy # freq=6560531 freq=482793
-AndHighMedDayTaxoFacets: +cite +changes +facets:DayOfYear.taxonomy # freq=1741194 freq=105677
-AndHighMedDayTaxoFacets: +it +debate +facets:DayOfYear.taxonomy # freq=2675552 freq=177827
-AndHighMedDayTaxoFacets: +by +total +facets:DayOfYear.taxonomy # freq=3826691 freq=230013
-AndHighMedDayTaxoFacets: +it +event +facets:DayOfYear.taxonomy # freq=2675552 freq=114340
-AndHighMedDayTaxoFacets: +2005 +cup +facets:DayOfYear.taxonomy # freq=835460 freq=141942
-AndHighMedDayTaxoFacets: +publisher +1950 +facets:DayOfYear.taxonomy # freq=1289029 freq=89746
-AndHighMedDayTaxoFacets: +no +christian +facets:DayOfYear.taxonomy # freq=1045000 freq=140312
-AndHighMedDayTaxoFacets: +from +forces +facets:DayOfYear.taxonomy # freq=3224339 freq=152939
-AndHighMedDayTaxoFacets: +when +between +facets:DayOfYear.taxonomy # freq=1027487 freq=630650
-AndHighMedDayTaxoFacets: +its +words +facets:DayOfYear.taxonomy # freq=1173450 freq=104783
-AndHighMedDayTaxoFacets: +a +she +facets:DayOfYear.taxonomy # freq=6560531 freq=426267
-AndHighMedDayTaxoFacets: +s +align +facets:DayOfYear.taxonomy # freq=1581243 freq=300455
-AndHighMedDayTaxoFacets: +http +served +facets:DayOfYear.taxonomy # freq=3493581 freq=188351
-AndHighMedDayTaxoFacets: +of +finally +facets:DayOfYear.taxonomy # freq=8184358 freq=99185
-AndHighMedDayTaxoFacets: +some +pre +facets:DayOfYear.taxonomy # freq=839919 freq=90549
-AndHighMedDayTaxoFacets: +which +am +facets:DayOfYear.taxonomy # freq=1963428 freq=127152
-AndHighMedDayTaxoFacets: +with +governor +facets:DayOfYear.taxonomy # freq=3709421 freq=102274
-AndHighMedDayTaxoFacets: +publisher +f.c +facets:DayOfYear.taxonomy # freq=1289029 freq=83548
-AndHighMedDayTaxoFacets: +on +player +facets:DayOfYear.taxonomy # freq=4074624 freq=241451
-AndHighMedDayTaxoFacets: +time +including +facets:DayOfYear.taxonomy # freq=1032071 freq=521324
-AndHighMedDayTaxoFacets: +work +1950 +facets:DayOfYear.taxonomy # freq=853422 freq=89746
-AndHighMedDayTaxoFacets: +http +now +facets:DayOfYear.taxonomy # freq=3493581 freq=484114
-AndHighMedDayTaxoFacets: +is +separate +facets:DayOfYear.taxonomy # freq=4074455 freq=88604
-AndHighMedDayTaxoFacets: +be +having +facets:DayOfYear.taxonomy # freq=2051702 freq=213416
-AndHighMedDayTaxoFacets: +its +practice +facets:DayOfYear.taxonomy # freq=1173450 freq=93287
-AndHighMedDayTaxoFacets: +new +30 +facets:DayOfYear.taxonomy # freq=1657293 freq=488930
-AndHighMedDayTaxoFacets: +date +most +facets:DayOfYear.taxonomy # freq=2020626 freq=819634
-AndHighMedDayTaxoFacets: +by +railway +facets:DayOfYear.taxonomy # freq=3826691 freq=125543
-AndHighMedDayTaxoFacets: +that +related +facets:DayOfYear.taxonomy # freq=2931020 freq=174856
-AndHighMedDayTaxoFacets: +other +data +facets:DayOfYear.taxonomy # freq=1269961 freq=159657
-AndHighMedDayTaxoFacets: +an +daily +facets:DayOfYear.taxonomy # freq=2628056 freq=111717
-AndHighMedDayTaxoFacets: +web +performance +facets:DayOfYear.taxonomy # freq=1118334 freq=130862
-AndHighMedDayTaxoFacets: +their +engine +facets:DayOfYear.taxonomy # freq=1158682 freq=100930
-AndHighMedDayTaxoFacets: +states +found +facets:DayOfYear.taxonomy # freq=1034872 freq=313247
-AndHighMedDayTaxoFacets: +name +takes +facets:DayOfYear.taxonomy # freq=2827713 freq=95889
-AndHighMedDayTaxoFacets: +cite +editor +facets:DayOfYear.taxonomy # freq=1741194 freq=119419
-AndHighMedDayTaxoFacets: +last +canadian +facets:DayOfYear.taxonomy # freq=958437 freq=181906
-AndHighMedDayTaxoFacets: +2 +jersey +facets:DayOfYear.taxonomy # freq=1549245 freq=88847
-AndHighMedDayTaxoFacets: +5 +far +facets:DayOfYear.taxonomy # freq=891361 freq=143873
-AndHighMedDayTaxoFacets: +it +3rd +facets:DayOfYear.taxonomy # freq=2675552 freq=90723
-AndHighMedDayTaxoFacets: +ref +say +facets:DayOfYear.taxonomy # freq=3793973 freq=110895
-AndHighMedDayTaxoFacets: +be +forces +facets:DayOfYear.taxonomy # freq=2051702 freq=152939
-AndHighMedDayTaxoFacets: +2010 +where +facets:DayOfYear.taxonomy # freq=950573 freq=630647
-AndHighMedDayTaxoFacets: +states +earlier +facets:DayOfYear.taxonomy # freq=1034872 freq=100372
-AndHighMedDayTaxoFacets: +has +organization +facets:DayOfYear.taxonomy # freq=1502961 freq=119614
-AndHighMedDayTaxoFacets: +its +fiction +facets:DayOfYear.taxonomy # freq=1173450 freq=87227
-AndHighMedDayTaxoFacets: +it +star +facets:DayOfYear.taxonomy # freq=2675552 freq=195768
-AndHighMedDayTaxoFacets: +have +speed +facets:DayOfYear.taxonomy # freq=1297121 freq=99899
-AndHighMedDayTaxoFacets: +into +2nd +facets:DayOfYear.taxonomy # freq=888684 freq=167463
-AndHighMedDayTaxoFacets: +name +having +facets:DayOfYear.taxonomy # freq=2827713 freq=213416
-AndHighMedDayTaxoFacets: +his +head +facets:DayOfYear.taxonomy # freq=1777780 freq=194682
-AndHighMedDayTaxoFacets: +when +change +facets:DayOfYear.taxonomy # freq=1027487 freq=182336
-AndHighMedDayTaxoFacets: +2005 +edit +facets:DayOfYear.taxonomy # freq=835460 freq=129064
-AndHighMedDayTaxoFacets: +about +mass +facets:DayOfYear.taxonomy # freq=850283 freq=82794
-AndHighMedDayTaxoFacets: +not +profile +facets:DayOfYear.taxonomy # freq=1713264 freq=86788
-AndHighMedDayTaxoFacets: +of +mayor +facets:DayOfYear.taxonomy # freq=8184358 freq=88578
-AndHighMedDayTaxoFacets: +no +woman +facets:DayOfYear.taxonomy # freq=1045000 freq=92071
-AndHighMedDayTaxoFacets: +from +these +facets:DayOfYear.taxonomy # freq=3224339 freq=623267
-AndHighMedDayTaxoFacets: +2005 +literature +facets:DayOfYear.taxonomy # freq=835460 freq=96743
-AndHighMedDayTaxoFacets: +an +07 +facets:DayOfYear.taxonomy # freq=2628056 freq=299351
-AndHighMedDayTaxoFacets: +that +age +facets:DayOfYear.taxonomy # freq=2931020 freq=395368
-AndHighMedDayTaxoFacets: +2008 +august +facets:DayOfYear.taxonomy # freq=831253 freq=527806
-AndHighMedDayTaxoFacets: +date +type +facets:DayOfYear.taxonomy # freq=2020626 freq=318210
-AndHighMedDayTaxoFacets: +other +most +facets:DayOfYear.taxonomy # freq=1269961 freq=819634
-AndHighMedDayTaxoFacets: +his +mark +facets:DayOfYear.taxonomy # freq=1777780 freq=160033
-AndHighMedDayTaxoFacets: +was +elected +facets:DayOfYear.taxonomy # freq=3763623 freq=119941
-AndHighMedDayTaxoFacets: +title +parliament +facets:DayOfYear.taxonomy # freq=2397378 freq=127008
-AndHighMedDayTaxoFacets: +been +27 +facets:DayOfYear.taxonomy # freq=1041183 freq=383042
-AndHighMedDayTaxoFacets: +publisher +western +facets:DayOfYear.taxonomy # freq=1289029 freq=232781
-AndHighMedDayTaxoFacets: +its +done +facets:DayOfYear.taxonomy # freq=1173450 freq=102033
-AndHighMedDayTaxoFacets: +more +web.archive.org +facets:DayOfYear.taxonomy # freq=963533 freq=95902
-AndHighMedDayTaxoFacets: +date +half +facets:DayOfYear.taxonomy # freq=2020626 freq=155387
-AndHighMedDayTaxoFacets: +that +lower +facets:DayOfYear.taxonomy # freq=2931020 freq=127260
-AndHighMedDayTaxoFacets: +more +already +facets:DayOfYear.taxonomy # freq=963533 freq=126694
-AndHighMedDayTaxoFacets: +for +report +facets:DayOfYear.taxonomy # freq=4380011 freq=153204
-AndHighMedDayTaxoFacets: +5 +ed +facets:DayOfYear.taxonomy # freq=891361 freq=134224
-AndHighMedDayTaxoFacets: +http +1965 +facets:DayOfYear.taxonomy # freq=3493581 freq=104539
-AndHighMedDayTaxoFacets: +s +debate +facets:DayOfYear.taxonomy # freq=1581243 freq=177827
-AndHighMedDayTaxoFacets: +only +official +facets:DayOfYear.taxonomy # freq=875561 freq=326177
-AndHighMedDayTaxoFacets: +2006 +seat +facets:DayOfYear.taxonomy # freq=889954 freq=91288
-AndHighMedDayTaxoFacets: +in +27 +facets:DayOfYear.taxonomy # freq=7320987 freq=383042
-AndHighMedDayTaxoFacets: +cite +fields +facets:DayOfYear.taxonomy # freq=1741194 freq=86938
-AndHighMedDayTaxoFacets: +states +remained +facets:DayOfYear.taxonomy # freq=1034872 freq=107736
-AndHighMedDayTaxoFacets: +for +hold +facets:DayOfYear.taxonomy # freq=4380011 freq=82579
-AndHighMedDayTaxoFacets: +2011 +joseph +facets:DayOfYear.taxonomy # freq=871410 freq=121533
-AndHighMedDayTaxoFacets: +2009 +met +facets:DayOfYear.taxonomy # freq=887702 freq=84001
-AndHighMedDayTaxoFacets: +an +31 +facets:DayOfYear.taxonomy # freq=2628056 freq=298349
-AndHighMedDayTaxoFacets: +there +hill +facets:DayOfYear.taxonomy # freq=956153 freq=133714
-AndHighMedDayTaxoFacets: +3 +allowed +facets:DayOfYear.taxonomy # freq=1148799 freq=98720
-AndHighMedDayTaxoFacets: +4 +table +facets:DayOfYear.taxonomy # freq=986452 freq=99163
-AndHighMedDayTaxoFacets: +accessdate +later +facets:DayOfYear.taxonomy # freq=1228887 freq=604921
-AndHighMedDayTaxoFacets: +2008 +rather +facets:DayOfYear.taxonomy # freq=831253 freq=174136
-AndHighMedDayTaxoFacets: +also +late +facets:DayOfYear.taxonomy # freq=1959419 freq=243636
-AndHighMedDayTaxoFacets: +2008 +60 +facets:DayOfYear.taxonomy # freq=831253 freq=118403
-AndHighMedDayTaxoFacets: +1 +why +facets:DayOfYear.taxonomy # freq=1641090 freq=108161
-AndHighMedDayTaxoFacets: +new +winning +facets:DayOfYear.taxonomy # freq=1657293 freq=95704
-AndHighMedDayTaxoFacets: +accessdate +towards +facets:DayOfYear.taxonomy # freq=1228887 freq=95574
-AndHighMedDayTaxoFacets: +date +t +facets:DayOfYear.taxonomy # freq=2020626 freq=262832
-AndHighMedDayTaxoFacets: +2 +nbsp +facets:DayOfYear.taxonomy # freq=1549245 freq=506054
-AndHighMedDayTaxoFacets: +time +website +facets:DayOfYear.taxonomy # freq=1032071 freq=435941
-AndHighMedDayTaxoFacets: +5 +republic +facets:DayOfYear.taxonomy # freq=891361 freq=166154
-AndHighMedDayTaxoFacets: +were +hold +facets:DayOfYear.taxonomy # freq=1524630 freq=82579
-AndHighMedDayTaxoFacets: +the +whom +facets:DayOfYear.taxonomy # freq=8217362 freq=95520
-AndHighMedDayTaxoFacets: +http +free +facets:DayOfYear.taxonomy # freq=3493581 freq=270199
-AndHighMedDayTaxoFacets: +his +self +facets:DayOfYear.taxonomy # freq=1777780 freq=135012
-AndHighMedDayTaxoFacets: +with +music +facets:DayOfYear.taxonomy # freq=3709421 freq=473240
-AndHighMedDayTaxoFacets: +is +academy +facets:DayOfYear.taxonomy # freq=4074455 freq=119055
-AndHighMedDayTaxoFacets: +year +appearance +facets:DayOfYear.taxonomy # freq=1235231 freq=89229
-AndHighMedDayTaxoFacets: +year +square +facets:DayOfYear.taxonomy # freq=1235231 freq=123538
-AndHighMedDayTaxoFacets: +i +h +facets:DayOfYear.taxonomy # freq=956148 freq=241946
-AndHighMedDayTaxoFacets: +by +35 +facets:DayOfYear.taxonomy # freq=3826691 freq=155506
-AndHighMedDayTaxoFacets: +2005 +sports +facets:DayOfYear.taxonomy # freq=835460 freq=178542
-AndHighMedDayTaxoFacets: +united +series +facets:DayOfYear.taxonomy # freq=1196944 freq=521861
-AndHighMedDayTaxoFacets: +may +congress +facets:DayOfYear.taxonomy # freq=1071932 freq=92382
-AndHighMedDayTaxoFacets: +title +la +facets:DayOfYear.taxonomy # freq=2397378 freq=232610
-AndHighMedDayTaxoFacets: +its +category:american +facets:DayOfYear.taxonomy # freq=1173450 freq=107823
-AndHighMedDayTaxoFacets: +the +lake +facets:DayOfYear.taxonomy # freq=8217362 freq=131603
-AndHighMedDayTaxoFacets: +who +foundation +facets:DayOfYear.taxonomy # freq=1196171 freq=107123
-AndHighMedDayTaxoFacets: +3 +57 +facets:DayOfYear.taxonomy # freq=1148799 freq=93708
-AndHighMedDayTaxoFacets: +date +flag +facets:DayOfYear.taxonomy # freq=2020626 freq=104210
-AndHighMedDayTaxoFacets: +10 +dq +facets:DayOfYear.taxonomy # freq=918339 freq=88557
-AndHighMedDayTaxoFacets: +that +study +facets:DayOfYear.taxonomy # freq=2931020 freq=137170
-AndHighMedDayTaxoFacets: +first +france +facets:DayOfYear.taxonomy # freq=1933372 freq=220058
-AndHighMedDayTaxoFacets: +on +culture +facets:DayOfYear.taxonomy # freq=4074624 freq=157773
-AndHighMedDayTaxoFacets: +to +1984 +facets:DayOfYear.taxonomy # freq=6155577 freq=161404
-AndHighMedDayTaxoFacets: +all +u.s +facets:DayOfYear.taxonomy # freq=1203572 freq=428534
-AndHighMedDayTaxoFacets: +name +era +facets:DayOfYear.taxonomy # freq=2827713 freq=95989
-AndHighMedDayTaxoFacets: +url +02 +facets:DayOfYear.taxonomy # freq=1513595 freq=319783
-AndHighMedDayTaxoFacets: +a +teams +facets:DayOfYear.taxonomy # freq=6560531 freq=105245
-AndHighMedDayTaxoFacets: +name +paul +facets:DayOfYear.taxonomy # freq=2827713 freq=207229
-AndHighMedDayTaxoFacets: +2008 +command +facets:DayOfYear.taxonomy # freq=831253 freq=87496
-AndHighMedDayTaxoFacets: +after +today +facets:DayOfYear.taxonomy # freq=1247398 freq=168864
-AndHighMedDayTaxoFacets: +no +native +facets:DayOfYear.taxonomy # freq=1045000 freq=129103
-AndHighMedDayTaxoFacets: +into +st +facets:DayOfYear.taxonomy # freq=888684 freq=309092
-AndHighMedDayTaxoFacets: +accessdate +m +facets:DayOfYear.taxonomy # freq=1228887 freq=441232
-AndHighMedDayTaxoFacets: +a +heart +facets:DayOfYear.taxonomy # freq=6560531 freq=95365
-AndHighMedDayTaxoFacets: +2010 +1986 +facets:DayOfYear.taxonomy # freq=950573 freq=167724
-AndHighMedDayTaxoFacets: +2008 +remained +facets:DayOfYear.taxonomy # freq=831253 freq=107736
-AndHighMedDayTaxoFacets: +this +college +facets:DayOfYear.taxonomy # freq=2224932 freq=278094
-AndHighMedDayTaxoFacets: +date +note +facets:DayOfYear.taxonomy # freq=2020626 freq=194472
-AndHighMedDayTaxoFacets: +5 +coast +facets:DayOfYear.taxonomy # freq=891361 freq=119047
-AndHighMedDayTaxoFacets: +time +sometimes +facets:DayOfYear.taxonomy # freq=1032071 freq=144078
-AndHighMedDayTaxoFacets: +3 +look +facets:DayOfYear.taxonomy # freq=1148799 freq=91122
-AndHighMedDayTaxoFacets: +states +people +facets:DayOfYear.taxonomy # freq=1034872 freq=790960
-AndHighMedDayTaxoFacets: +to +specific +facets:DayOfYear.taxonomy # freq=6155577 freq=93622
-AndHighMedDayTaxoFacets: +year +between +facets:DayOfYear.taxonomy # freq=1235231 freq=630650
-AndHighMedDayTaxoFacets: +publisher +led +facets:DayOfYear.taxonomy # freq=1289029 freq=210033
-AndHighMedDayTaxoFacets: +a +given +facets:DayOfYear.taxonomy # freq=6560531 freq=235719
-AndHighMedDayTaxoFacets: +2008 +stations +facets:DayOfYear.taxonomy # freq=831253 freq=92011
-AndHighMedDayTaxoFacets: +his +england +facets:DayOfYear.taxonomy # freq=1777780 freq=317884
-AndHighMedDayTaxoFacets: +states +geo +facets:DayOfYear.taxonomy # freq=1034872 freq=83404
-AndHighMedDayTaxoFacets: +at +1960 +facets:DayOfYear.taxonomy # freq=2857534 freq=109083
-AndHighMedDayTaxoFacets: +be +60 +facets:DayOfYear.taxonomy # freq=2051702 freq=118403
-AndHighMedDayTaxoFacets: +there +schools +facets:DayOfYear.taxonomy # freq=956153 freq=141308
-AndHighMedDayTaxoFacets: +that +value +facets:DayOfYear.taxonomy # freq=2931020 freq=86806
-AndHighMedDayTaxoFacets: +no +needed +facets:DayOfYear.taxonomy # freq=1045000 freq=281051
-AndHighMedDayTaxoFacets: +2011 +31 +facets:DayOfYear.taxonomy # freq=871410 freq=298349
-AndHighMedDayTaxoFacets: +year +16 +facets:DayOfYear.taxonomy # freq=1235231 freq=540539
-AndHighMedDayTaxoFacets: +title +set +facets:DayOfYear.taxonomy # freq=2397378 freq=294255
-AndHighMedDayTaxoFacets: +work +sport +facets:DayOfYear.taxonomy # freq=853422 freq=106696
-AndHighMedDayTaxoFacets: +all +42 +facets:DayOfYear.taxonomy # freq=1203572 freq=124253
-OrHighMedDayTaxoFacets: there background +facets:DayOfYear.taxonomy # freq=956153 freq=314229
-OrHighMedDayTaxoFacets: be important +facets:DayOfYear.taxonomy # freq=2051702 freq=195851
-OrHighMedDayTaxoFacets: name cd +facets:DayOfYear.taxonomy # freq=2827713 freq=87105
-OrHighMedDayTaxoFacets: when regular +facets:DayOfYear.taxonomy # freq=1027487 freq=93809
-OrHighMedDayTaxoFacets: 1 called +facets:DayOfYear.taxonomy # freq=1641090 freq=454580
-OrHighMedDayTaxoFacets: may force +facets:DayOfYear.taxonomy # freq=1071932 freq=198556
-OrHighMedDayTaxoFacets: 1 regular +facets:DayOfYear.taxonomy # freq=1641090 freq=93809
-OrHighMedDayTaxoFacets: s 1986 +facets:DayOfYear.taxonomy # freq=1581243 freq=167724
-OrHighMedDayTaxoFacets: 2011 co +facets:DayOfYear.taxonomy # freq=871410 freq=209086
-OrHighMedDayTaxoFacets: he artist +facets:DayOfYear.taxonomy # freq=1659434 freq=210591
-OrHighMedDayTaxoFacets: 2009 him +facets:DayOfYear.taxonomy # freq=887702 freq=507350
-OrHighMedDayTaxoFacets: at interest +facets:DayOfYear.taxonomy # freq=2857534 freq=108551
-OrHighMedDayTaxoFacets: and 1959 +facets:DayOfYear.taxonomy # freq=7318061 freq=87097
-OrHighMedDayTaxoFacets: had few +facets:DayOfYear.taxonomy # freq=1246743 freq=226422
-OrHighMedDayTaxoFacets: this era +facets:DayOfYear.taxonomy # freq=2224932 freq=95989
-OrHighMedDayTaxoFacets: also video +facets:DayOfYear.taxonomy # freq=1959419 freq=202380
-OrHighMedDayTaxoFacets: into capital +facets:DayOfYear.taxonomy # freq=888684 freq=120421
-OrHighMedDayTaxoFacets: who los +facets:DayOfYear.taxonomy # freq=1196171 freq=145404
-OrHighMedDayTaxoFacets: that ii +facets:DayOfYear.taxonomy # freq=2931020 freq=340800
-OrHighMedDayTaxoFacets: as working +facets:DayOfYear.taxonomy # freq=3925535 freq=144617
-OrHighMedDayTaxoFacets: accessdate status +facets:DayOfYear.taxonomy # freq=1228887 freq=133818
-OrHighMedDayTaxoFacets: not put +facets:DayOfYear.taxonomy # freq=1713264 freq=139882
-OrHighMedDayTaxoFacets: cite soviet +facets:DayOfYear.taxonomy # freq=1741194 freq=89070
-OrHighMedDayTaxoFacets: see reading +facets:DayOfYear.taxonomy # freq=1044180 freq=101214
-OrHighMedDayTaxoFacets: all area +facets:DayOfYear.taxonomy # freq=1203572 freq=559023
-OrHighMedDayTaxoFacets: his influence +facets:DayOfYear.taxonomy # freq=1777780 freq=83101
-OrHighMedDayTaxoFacets: new less +facets:DayOfYear.taxonomy # freq=1657293 freq=170266
-OrHighMedDayTaxoFacets: states 14 +facets:DayOfYear.taxonomy # freq=1034872 freq=534005
-OrHighMedDayTaxoFacets: no april +facets:DayOfYear.taxonomy # freq=1045000 freq=587542
-OrHighMedDayTaxoFacets: http wife +facets:DayOfYear.taxonomy # freq=3493581 freq=130807
-OrHighMedDayTaxoFacets: had stories +facets:DayOfYear.taxonomy # freq=1246743 freq=110223
-OrHighMedDayTaxoFacets: this established +facets:DayOfYear.taxonomy # freq=2224932 freq=282471
-OrHighMedDayTaxoFacets: other source +facets:DayOfYear.taxonomy # freq=1269961 freq=231838
-OrHighMedDayTaxoFacets: 1 alone +facets:DayOfYear.taxonomy # freq=1641090 freq=93166
-OrHighMedDayTaxoFacets: and per +facets:DayOfYear.taxonomy # freq=7318061 freq=283568
-OrHighMedDayTaxoFacets: into larger +facets:DayOfYear.taxonomy # freq=888684 freq=87424
-OrHighMedDayTaxoFacets: to book +facets:DayOfYear.taxonomy # freq=6155577 freq=617297
-OrHighMedDayTaxoFacets: at london +facets:DayOfYear.taxonomy # freq=2857534 freq=348918
-OrHighMedDayTaxoFacets: at km +facets:DayOfYear.taxonomy # freq=2857534 freq=233831
-OrHighMedDayTaxoFacets: in convert +facets:DayOfYear.taxonomy # freq=7320987 freq=267974
-OrHighMedDayTaxoFacets: s yet +facets:DayOfYear.taxonomy # freq=1581243 freq=100857
-OrHighMedDayTaxoFacets: 1 1973 +facets:DayOfYear.taxonomy # freq=1641090 freq=125985
-OrHighMedDayTaxoFacets: 1 yet +facets:DayOfYear.taxonomy # freq=1641090 freq=100857
-OrHighMedDayTaxoFacets: 3 preserved +facets:DayOfYear.taxonomy # freq=1148799 freq=111088
-OrHighMedDayTaxoFacets: when various +facets:DayOfYear.taxonomy # freq=1027487 freq=224593
-OrHighMedDayTaxoFacets: his result +facets:DayOfYear.taxonomy # freq=1777780 freq=276803
-OrHighMedDayTaxoFacets: into film +facets:DayOfYear.taxonomy # freq=888684 freq=432758
-OrHighMedDayTaxoFacets: was leader +facets:DayOfYear.taxonomy # freq=3763623 freq=127591
-OrHighMedDayTaxoFacets: see list +facets:DayOfYear.taxonomy # freq=1044180 freq=585922
-OrHighMedDayTaxoFacets: first institute +facets:DayOfYear.taxonomy # freq=1933372 freq=136311
-OrHighMedDayTaxoFacets: work got +facets:DayOfYear.taxonomy # freq=853422 freq=92640
-OrHighMedDayTaxoFacets: had rule +facets:DayOfYear.taxonomy # freq=1246743 freq=86729
-OrHighMedDayTaxoFacets: 1 thought +facets:DayOfYear.taxonomy # freq=1641090 freq=108963
-OrHighMedDayTaxoFacets: an hard +facets:DayOfYear.taxonomy # freq=2628056 freq=90149
-OrHighMedDayTaxoFacets: only 1972 +facets:DayOfYear.taxonomy # freq=875561 freq=130791
-OrHighMedDayTaxoFacets: was american +facets:DayOfYear.taxonomy # freq=3763623 freq=758337
-OrHighMedDayTaxoFacets: 2009 lines +facets:DayOfYear.taxonomy # freq=887702 freq=96969
-OrHighMedDayTaxoFacets: no followed +facets:DayOfYear.taxonomy # freq=1045000 freq=121848
-OrHighMedDayTaxoFacets: had five +facets:DayOfYear.taxonomy # freq=1246743 freq=262923
-OrHighMedDayTaxoFacets: was q +facets:DayOfYear.taxonomy # freq=3763623 freq=149271
-OrHighMedDayTaxoFacets: cite wikipedia +facets:DayOfYear.taxonomy # freq=1741194 freq=149673
-OrHighMedDayTaxoFacets: other already +facets:DayOfYear.taxonomy # freq=1269961 freq=126694
-OrHighMedDayTaxoFacets: it keep +facets:DayOfYear.taxonomy # freq=2675552 freq=177996
-OrHighMedDayTaxoFacets: states t +facets:DayOfYear.taxonomy # freq=1034872 freq=262832
-OrHighMedDayTaxoFacets: 1 listed +facets:DayOfYear.taxonomy # freq=1641090 freq=94990
-OrHighMedDayTaxoFacets: there modify +facets:DayOfYear.taxonomy # freq=956153 freq=109819
-OrHighMedDayTaxoFacets: url win +facets:DayOfYear.taxonomy # freq=1513595 freq=121070
-OrHighMedDayTaxoFacets: may 39 +facets:DayOfYear.taxonomy # freq=1071932 freq=132689
-OrHighMedDayTaxoFacets: two charles +facets:DayOfYear.taxonomy # freq=1104053 freq=204987
-OrHighMedDayTaxoFacets: also appears +facets:DayOfYear.taxonomy # freq=1959419 freq=104511
-OrHighMedDayTaxoFacets: more rowspan +facets:DayOfYear.taxonomy # freq=963533 freq=124637
-OrHighMedDayTaxoFacets: web north +facets:DayOfYear.taxonomy # freq=1118334 freq=564195
-OrHighMedDayTaxoFacets: 1 smith +facets:DayOfYear.taxonomy # freq=1641090 freq=126344
-OrHighMedDayTaxoFacets: 2010 2000 +facets:DayOfYear.taxonomy # freq=950573 freq=499639
-OrHighMedDayTaxoFacets: they features +facets:DayOfYear.taxonomy # freq=1021945 freq=156867
-OrHighMedDayTaxoFacets: 2 project +facets:DayOfYear.taxonomy # freq=1549245 freq=180139
-OrHighMedDayTaxoFacets: http instead +facets:DayOfYear.taxonomy # freq=3493581 freq=149345
-OrHighMedDayTaxoFacets: by am +facets:DayOfYear.taxonomy # freq=3826691 freq=127152
-OrHighMedDayTaxoFacets: it pacific +facets:DayOfYear.taxonomy # freq=2675552 freq=107648
-OrHighMedDayTaxoFacets: states times +facets:DayOfYear.taxonomy # freq=1034872 freq=407155
-OrHighMedDayTaxoFacets: name middle +facets:DayOfYear.taxonomy # freq=2827713 freq=156728
-OrHighMedDayTaxoFacets: is 1988 +facets:DayOfYear.taxonomy # freq=4074455 freq=181327
-OrHighMedDayTaxoFacets: 5 c +facets:DayOfYear.taxonomy # freq=891361 freq=444247
-OrHighMedDayTaxoFacets: their court +facets:DayOfYear.taxonomy # freq=1158682 freq=169309
-OrHighMedDayTaxoFacets: they double +facets:DayOfYear.taxonomy # freq=1021945 freq=87304
-OrHighMedDayTaxoFacets: in george +facets:DayOfYear.taxonomy # freq=7320987 freq=256196
-OrHighMedDayTaxoFacets: after appears +facets:DayOfYear.taxonomy # freq=1247398 freq=104511
-OrHighMedDayTaxoFacets: is thomas +facets:DayOfYear.taxonomy # freq=4074455 freq=191625
-OrHighMedDayTaxoFacets: about specific +facets:DayOfYear.taxonomy # freq=850283 freq=93622
-OrHighMedDayTaxoFacets: be captain +facets:DayOfYear.taxonomy # freq=2051702 freq=91635
-OrHighMedDayTaxoFacets: be journal +facets:DayOfYear.taxonomy # freq=2051702 freq=348162
-OrHighMedDayTaxoFacets: this month +facets:DayOfYear.taxonomy # freq=2224932 freq=162128
-OrHighMedDayTaxoFacets: last given +facets:DayOfYear.taxonomy # freq=958437 freq=235719
-OrHighMedDayTaxoFacets: from running +facets:DayOfYear.taxonomy # freq=3224339 freq=101764
-OrHighMedDayTaxoFacets: 2008 liberal +facets:DayOfYear.taxonomy # freq=831253 freq=93070
-OrHighMedDayTaxoFacets: i island +facets:DayOfYear.taxonomy # freq=956148 freq=203023
-OrHighMedDayTaxoFacets: or pp +facets:DayOfYear.taxonomy # freq=1858841 freq=204742
-OrHighMedDayTaxoFacets: which earth +facets:DayOfYear.taxonomy # freq=1963428 freq=110512
-OrHighMedDayTaxoFacets: united school +facets:DayOfYear.taxonomy # freq=1196944 freq=462166
-OrHighMedDayTaxoFacets: at fall +facets:DayOfYear.taxonomy # freq=2857534 freq=103379
-OrHighMedDayTaxoFacets: by talk +facets:DayOfYear.taxonomy # freq=3826691 freq=364194
-OrHighMedDayTaxoFacets: title appropriate +facets:DayOfYear.taxonomy # freq=2397378 freq=135343
-OrHighMedDayTaxoFacets: first data +facets:DayOfYear.taxonomy # freq=1933372 freq=159657
-OrHighMedDayTaxoFacets: by community +facets:DayOfYear.taxonomy # freq=3826691 freq=225571
-OrHighMedDayTaxoFacets: it anti +facets:DayOfYear.taxonomy # freq=2675552 freq=99993
-OrHighMedDayTaxoFacets: 2005 would +facets:DayOfYear.taxonomy # freq=835460 freq=690480
-OrHighMedDayTaxoFacets: no archive +facets:DayOfYear.taxonomy # freq=1045000 freq=215381
-OrHighMedDayTaxoFacets: had 11 +facets:DayOfYear.taxonomy # freq=1246743 freq=730505
-OrHighMedDayTaxoFacets: which 978 +facets:DayOfYear.taxonomy # freq=1963428 freq=101276
-OrHighMedDayTaxoFacets: accessdate seems +facets:DayOfYear.taxonomy # freq=1228887 freq=83963
-OrHighMedDayTaxoFacets: 2011 commission +facets:DayOfYear.taxonomy # freq=871410 freq=91476
-OrHighMedDayTaxoFacets: that county +facets:DayOfYear.taxonomy # freq=2931020 freq=521126
-OrHighMedDayTaxoFacets: they hard +facets:DayOfYear.taxonomy # freq=1021945 freq=90149
-OrHighMedDayTaxoFacets: first historic +facets:DayOfYear.taxonomy # freq=1933372 freq=112292
-OrHighMedDayTaxoFacets: this category +facets:DayOfYear.taxonomy # freq=2224932 freq=595446
-OrHighMedDayTaxoFacets: its counties +facets:DayOfYear.taxonomy # freq=1173450 freq=87574
-OrHighMedDayTaxoFacets: year 1963 +facets:DayOfYear.taxonomy # freq=1235231 freq=96439
-OrHighMedDayTaxoFacets: this include +facets:DayOfYear.taxonomy # freq=2224932 freq=276466
-OrHighMedDayTaxoFacets: one british +facets:DayOfYear.taxonomy # freq=1527689 freq=417307
-OrHighMedDayTaxoFacets: was world +facets:DayOfYear.taxonomy # freq=3763623 freq=808563
-OrHighMedDayTaxoFacets: the references +facets:DayOfYear.taxonomy # freq=8217362 freq=760306
-OrHighMedDayTaxoFacets: its 56 +facets:DayOfYear.taxonomy # freq=1173450 freq=96215
-OrHighMedDayTaxoFacets: their son +facets:DayOfYear.taxonomy # freq=1158682 freq=202340
-OrHighMedDayTaxoFacets: the federal +facets:DayOfYear.taxonomy # freq=8217362 freq=166274
-OrHighMedDayTaxoFacets: with jpg +facets:DayOfYear.taxonomy # freq=3709421 freq=322278
-OrHighMedDayTaxoFacets: on training +facets:DayOfYear.taxonomy # freq=4074624 freq=107271
-OrHighMedDayTaxoFacets: for famous +facets:DayOfYear.taxonomy # freq=4380011 freq=139092
-OrHighMedDayTaxoFacets: work run +facets:DayOfYear.taxonomy # freq=853422 freq=183609
-OrHighMedDayTaxoFacets: which start +facets:DayOfYear.taxonomy # freq=1963428 freq=233925
-OrHighMedDayTaxoFacets: and author +facets:DayOfYear.taxonomy # freq=7318061 freq=567768
-OrHighMedDayTaxoFacets: name mother +facets:DayOfYear.taxonomy # freq=2827713 freq=122930
-OrHighMedDayTaxoFacets: who current +facets:DayOfYear.taxonomy # freq=1196171 freq=217174
-OrHighMedDayTaxoFacets: s vote +facets:DayOfYear.taxonomy # freq=1581243 freq=96871
-OrHighMedDayTaxoFacets: 4 51 +facets:DayOfYear.taxonomy # freq=986452 freq=108800
-OrHighMedDayTaxoFacets: 2011 special +facets:DayOfYear.taxonomy # freq=871410 freq=198917
-OrHighMedDayTaxoFacets: accessdate st +facets:DayOfYear.taxonomy # freq=1228887 freq=309092
-OrHighMedDayTaxoFacets: about must +facets:DayOfYear.taxonomy # freq=850283 freq=228491
-OrHighMedDayTaxoFacets: had census +facets:DayOfYear.taxonomy # freq=1246743 freq=205166
-OrHighMedDayTaxoFacets: publisher 56 +facets:DayOfYear.taxonomy # freq=1289029 freq=96215
-OrHighMedDayTaxoFacets: other 12 +facets:DayOfYear.taxonomy # freq=1269961 freq=774572
-OrHighMedDayTaxoFacets: or 22 +facets:DayOfYear.taxonomy # freq=1858841 freq=502778
-OrHighMedDayTaxoFacets: of deletion +facets:DayOfYear.taxonomy # freq=8184358 freq=166633
-OrHighMedDayTaxoFacets: as married +facets:DayOfYear.taxonomy # freq=3925535 freq=156752
-OrHighMedDayTaxoFacets: also do +facets:DayOfYear.taxonomy # freq=1959419 freq=511178
-OrHighMedDayTaxoFacets: of larger +facets:DayOfYear.taxonomy # freq=8184358 freq=87424
-OrHighMedDayTaxoFacets: the wikipedia:persondata +facets:DayOfYear.taxonomy # freq=8217362 freq=222385
-OrHighMedDayTaxoFacets: be books +facets:DayOfYear.taxonomy # freq=2051702 freq=341376
-OrHighMedDayTaxoFacets: url george +facets:DayOfYear.taxonomy # freq=1513595 freq=256196
-OrHighMedDayTaxoFacets: accessdate del +facets:DayOfYear.taxonomy # freq=1228887 freq=82614
-OrHighMedDayTaxoFacets: about command +facets:DayOfYear.taxonomy # freq=850283 freq=87496
-OrHighMedDayTaxoFacets: there soon +facets:DayOfYear.taxonomy # freq=956153 freq=123657
-OrHighMedDayTaxoFacets: url special +facets:DayOfYear.taxonomy # freq=1513595 freq=198917
-OrHighMedDayTaxoFacets: may authority +facets:DayOfYear.taxonomy # freq=1071932 freq=85540
-OrHighMedDayTaxoFacets: url ever +facets:DayOfYear.taxonomy # freq=1513595 freq=128732
-OrHighMedDayTaxoFacets: see 1987 +facets:DayOfYear.taxonomy # freq=1044180 freq=172453
-OrHighMedDayTaxoFacets: his ended +facets:DayOfYear.taxonomy # freq=1777780 freq=84664
-OrHighMedDayTaxoFacets: who prime +facets:DayOfYear.taxonomy # freq=1196171 freq=96945
-OrHighMedDayTaxoFacets: a success +facets:DayOfYear.taxonomy # freq=6560531 freq=112195
-OrHighMedDayTaxoFacets: cite elected +facets:DayOfYear.taxonomy # freq=1741194 freq=119941
-OrHighMedDayTaxoFacets: 2008 without +facets:DayOfYear.taxonomy # freq=831253 freq=249926
-OrHighMedDayTaxoFacets: after km +facets:DayOfYear.taxonomy # freq=1247398 freq=233831
-OrHighMedDayTaxoFacets: no fields +facets:DayOfYear.taxonomy # freq=1045000 freq=86938
-OrHighMedDayTaxoFacets: the financial +facets:DayOfYear.taxonomy # freq=8217362 freq=82536
-OrHighMedDayTaxoFacets: had features +facets:DayOfYear.taxonomy # freq=1246743 freq=156867
-OrHighMedDayTaxoFacets: into dead +facets:DayOfYear.taxonomy # freq=888684 freq=171386
-OrHighMedDayTaxoFacets: of caused +facets:DayOfYear.taxonomy # freq=8184358 freq=86397
-OrHighMedDayTaxoFacets: as changes +facets:DayOfYear.taxonomy # freq=3925535 freq=105677
-OrHighMedDayTaxoFacets: no president +facets:DayOfYear.taxonomy # freq=1045000 freq=263341
-OrHighMedDayTaxoFacets: one within +facets:DayOfYear.taxonomy # freq=1527689 freq=291049
-OrHighMedDayTaxoFacets: at mark +facets:DayOfYear.taxonomy # freq=2857534 freq=160033
-OrHighMedDayTaxoFacets: first down +facets:DayOfYear.taxonomy # freq=1933372 freq=280662
-OrHighMedDayTaxoFacets: be leader +facets:DayOfYear.taxonomy # freq=2051702 freq=127591
-OrHighMedDayTaxoFacets: were know +facets:DayOfYear.taxonomy # freq=1524630 freq=129655
-OrHighMedDayTaxoFacets: s england +facets:DayOfYear.taxonomy # freq=1581243 freq=317884
-OrHighMedDayTaxoFacets: one set +facets:DayOfYear.taxonomy # freq=1527689 freq=294255
-OrHighMedDayTaxoFacets: 5 flight +facets:DayOfYear.taxonomy # freq=891361 freq=84316
-OrHighMedDayTaxoFacets: i works +facets:DayOfYear.taxonomy # freq=956148 freq=199177
-OrHighMedDayTaxoFacets: was 1982 +facets:DayOfYear.taxonomy # freq=3763623 freq=153269
-OrHighMedDayTaxoFacets: but 57 +facets:DayOfYear.taxonomy # freq=1456553 freq=93708
-OrHighMedDayTaxoFacets: date coord +facets:DayOfYear.taxonomy # freq=2020626 freq=180590
-OrHighMedDayTaxoFacets: cite science +facets:DayOfYear.taxonomy # freq=1741194 freq=219988
-OrHighMedDayTaxoFacets: two past +facets:DayOfYear.taxonomy # freq=1104053 freq=126130
-OrHighMedDayTaxoFacets: first albums +facets:DayOfYear.taxonomy # freq=1933372 freq=118322
-OrHighMedDayTaxoFacets: its 14 +facets:DayOfYear.taxonomy # freq=1173450 freq=534005
-OrHighMedDayTaxoFacets: when rowspan +facets:DayOfYear.taxonomy # freq=1027487 freq=124637
-OrHighMedDayTaxoFacets: for league +facets:DayOfYear.taxonomy # freq=4380011 freq=270223
-OrHighMedDayTaxoFacets: to keep +facets:DayOfYear.taxonomy # freq=6155577 freq=177996
-OrHighMedDayTaxoFacets: a baseball +facets:DayOfYear.taxonomy # freq=6560531 freq=93326
-OrHighMedDayTaxoFacets: publisher colspan +facets:DayOfYear.taxonomy # freq=1289029 freq=134521
-OrHighMedDayTaxoFacets: when release +facets:DayOfYear.taxonomy # freq=1027487 freq=189375
-OrHighMedDayTaxoFacets: see down +facets:DayOfYear.taxonomy # freq=1044180 freq=280662
-OrHighMedDayTaxoFacets: date does +facets:DayOfYear.taxonomy # freq=2020626 freq=232202
-OrHighMedDayTaxoFacets: s boston +facets:DayOfYear.taxonomy # freq=1581243 freq=85235
-OrHighMedDayTaxoFacets: but center +facets:DayOfYear.taxonomy # freq=1456553 freq=489673
-OrHighMedDayTaxoFacets: some originally +facets:DayOfYear.taxonomy # freq=839919 freq=168282
-OrHighMedDayTaxoFacets: all movement +facets:DayOfYear.taxonomy # freq=1203572 freq=131692
-OrHighMedDayTaxoFacets: an human +facets:DayOfYear.taxonomy # freq=2628056 freq=182617
-OrHighMedDayTaxoFacets: time life +facets:DayOfYear.taxonomy # freq=1032071 freq=477007
-OrHighMedDayTaxoFacets: first bridge +facets:DayOfYear.taxonomy # freq=1933372 freq=92398
-OrHighMedDayTaxoFacets: one comments +facets:DayOfYear.taxonomy # freq=1527689 freq=185637
-OrHighMedDayTaxoFacets: he background +facets:DayOfYear.taxonomy # freq=1659434 freq=314229
-OrHighMedDayTaxoFacets: 2006 1988 +facets:DayOfYear.taxonomy # freq=889954 freq=181327
-OrHighMedDayTaxoFacets: http fiction +facets:DayOfYear.taxonomy # freq=3493581 freq=87227
-OrHighMedDayTaxoFacets: 4 case +facets:DayOfYear.taxonomy # freq=986452 freq=207307
-OrHighMedDayTaxoFacets: there mike +facets:DayOfYear.taxonomy # freq=956153 freq=91795
-OrHighMedDayTaxoFacets: there 29 +facets:DayOfYear.taxonomy # freq=956153 freq=372091
-OrHighMedDayTaxoFacets: 2010 near +facets:DayOfYear.taxonomy # freq=950573 freq=254492
-OrHighMedDayTaxoFacets: url channel +facets:DayOfYear.taxonomy # freq=1513595 freq=101401
-OrHighMedDayTaxoFacets: two robert +facets:DayOfYear.taxonomy # freq=1104053 freq=246405
-OrHighMedDayTaxoFacets: or public +facets:DayOfYear.taxonomy # freq=1858841 freq=368868
-OrHighMedDayTaxoFacets: other robert +facets:DayOfYear.taxonomy # freq=1269961 freq=246405
-OrHighMedDayTaxoFacets: ref germany +facets:DayOfYear.taxonomy # freq=3793973 freq=190478
-OrHighMedDayTaxoFacets: one english +facets:DayOfYear.taxonomy # freq=1527689 freq=412061
-OrHighMedDayTaxoFacets: no cd +facets:DayOfYear.taxonomy # freq=1045000 freq=87105
-OrHighMedDayTaxoFacets: publisher what +facets:DayOfYear.taxonomy # freq=1289029 freq=394675
-OrHighMedDayTaxoFacets: their win +facets:DayOfYear.taxonomy # freq=1158682 freq=121070
-OrHighMedDayTaxoFacets: an 1959 +facets:DayOfYear.taxonomy # freq=2628056 freq=87097
-OrHighMedDayTaxoFacets: but digital +facets:DayOfYear.taxonomy # freq=1456553 freq=82650
-OrHighMedDayTaxoFacets: but 30 +facets:DayOfYear.taxonomy # freq=1456553 freq=488930
-OrHighMedDayTaxoFacets: work information +facets:DayOfYear.taxonomy # freq=853422 freq=353153
-OrHighMedDayTaxoFacets: by population +facets:DayOfYear.taxonomy # freq=3826691 freq=374481
-OrHighMedDayTaxoFacets: in post +facets:DayOfYear.taxonomy # freq=7320987 freq=218570
-OrHighMedDayTaxoFacets: who birth +facets:DayOfYear.taxonomy # freq=1196171 freq=425138
-OrHighMedDayTaxoFacets: who multiple +facets:DayOfYear.taxonomy # freq=1196171 freq=89684
-OrHighMedDayTaxoFacets: ref trade +facets:DayOfYear.taxonomy # freq=3793973 freq=106384
-OrHighMedDayTaxoFacets: after lord +facets:DayOfYear.taxonomy # freq=1247398 freq=106633
-OrHighMedDayTaxoFacets: to significant +facets:DayOfYear.taxonomy # freq=6155577 freq=111574
-OrHighMedDayTaxoFacets: also 1976 +facets:DayOfYear.taxonomy # freq=1959419 freq=134555
-OrHighMedDayTaxoFacets: which awards +facets:DayOfYear.taxonomy # freq=1963428 freq=159679
-OrHighMedDayTaxoFacets: by blue +facets:DayOfYear.taxonomy # freq=3826691 freq=156658
-OrHighMedDayTaxoFacets: that cause +facets:DayOfYear.taxonomy # freq=2931020 freq=83898
-OrHighMedDayTaxoFacets: about began +facets:DayOfYear.taxonomy # freq=850283 freq=276036
-OrHighMedDayTaxoFacets: other entire +facets:DayOfYear.taxonomy # freq=1269961 freq=97485
-OrHighMedDayTaxoFacets: has internet +facets:DayOfYear.taxonomy # freq=1502961 freq=85510
-OrHighMedDayTaxoFacets: url highest +facets:DayOfYear.taxonomy # freq=1513595 freq=91072
-OrHighMedDayTaxoFacets: an stage +facets:DayOfYear.taxonomy # freq=2628056 freq=113041
-OrHighMedDayTaxoFacets: title imagesize +facets:DayOfYear.taxonomy # freq=2397378 freq=82746
-OrHighMedDayTaxoFacets: see span +facets:DayOfYear.taxonomy # freq=1044180 freq=146676
-OrHighMedDayTaxoFacets: states 2007 +facets:DayOfYear.taxonomy # freq=1034872 freq=801586
-OrHighMedDayTaxoFacets: in clear +facets:DayOfYear.taxonomy # freq=7320987 freq=109812
-OrHighMedDayTaxoFacets: with jean +facets:DayOfYear.taxonomy # freq=3709421 freq=84299
-OrHighMedDayTaxoFacets: other dq +facets:DayOfYear.taxonomy # freq=1269961 freq=88557
-OrHighMedDayTaxoFacets: from chris +facets:DayOfYear.taxonomy # freq=3224339 freq=85523
-OrHighMedDayTaxoFacets: no next +facets:DayOfYear.taxonomy # freq=1045000 freq=259039
-OrHighMedDayTaxoFacets: for musical +facets:DayOfYear.taxonomy # freq=4380011 freq=132600
-OrHighMedDayTaxoFacets: see came +facets:DayOfYear.taxonomy # freq=1044180 freq=197126
-OrHighMedDayTaxoFacets: two wales +facets:DayOfYear.taxonomy # freq=1104053 freq=103595
-OrHighMedDayTaxoFacets: new eastern +facets:DayOfYear.taxonomy # freq=1657293 freq=176853
-OrHighMedDayTaxoFacets: 2 marriage +facets:DayOfYear.taxonomy # freq=1549245 freq=97658
-OrHighMedDayTaxoFacets: 2009 forces +facets:DayOfYear.taxonomy # freq=887702 freq=152939
-OrHighMedDayTaxoFacets: at any +facets:DayOfYear.taxonomy # freq=2857534 freq=483514
-OrHighMedDayTaxoFacets: as live +facets:DayOfYear.taxonomy # freq=3925535 freq=242147
-OrHighMedDayTaxoFacets: see academy +facets:DayOfYear.taxonomy # freq=1044180 freq=119055
-OrHighMedDayTaxoFacets: their get +facets:DayOfYear.taxonomy # freq=1158682 freq=187847
-OrHighMedDayTaxoFacets: about via +facets:DayOfYear.taxonomy # freq=850283 freq=109090
-OrHighMedDayTaxoFacets: only fields +facets:DayOfYear.taxonomy # freq=875561 freq=86938
-OrHighMedDayTaxoFacets: time central +facets:DayOfYear.taxonomy # freq=1032071 freq=272531
-OrHighMedDayTaxoFacets: two my +facets:DayOfYear.taxonomy # freq=1104053 freq=274256
-OrHighMedDayTaxoFacets: with land +facets:DayOfYear.taxonomy # freq=3709421 freq=230284
-OrHighMedDayTaxoFacets: two financial +facets:DayOfYear.taxonomy # freq=1104053 freq=82536
-OrHighMedDayTaxoFacets: was convert +facets:DayOfYear.taxonomy # freq=3763623 freq=267974
-OrHighMedDayTaxoFacets: not course +facets:DayOfYear.taxonomy # freq=1713264 freq=106126
-OrHighMedDayTaxoFacets: 10 producer +facets:DayOfYear.taxonomy # freq=918339 freq=137098
-OrHighMedDayTaxoFacets: 3 52 +facets:DayOfYear.taxonomy # freq=1148799 freq=108395
-OrHighMedDayTaxoFacets: 2008 final +facets:DayOfYear.taxonomy # freq=831253 freq=230006
-OrHighMedDayTaxoFacets: from sir +facets:DayOfYear.taxonomy # freq=3224339 freq=107709
-OrHighMedDayTaxoFacets: to majority +facets:DayOfYear.taxonomy # freq=6155577 freq=105058
-OrHighMedDayTaxoFacets: work published +facets:DayOfYear.taxonomy # freq=853422 freq=243548
-OrHighMedDayTaxoFacets: but might +facets:DayOfYear.taxonomy # freq=1456553 freq=114290
-OrHighMedDayTaxoFacets: has radio +facets:DayOfYear.taxonomy # freq=1502961 freq=183866
-OrHighMedDayTaxoFacets: of 45 +facets:DayOfYear.taxonomy # freq=8184358 freq=180879
-OrHighMedDayTaxoFacets: some africa +facets:DayOfYear.taxonomy # freq=839919 freq=124511
-OrHighMedDayTaxoFacets: title club +facets:DayOfYear.taxonomy # freq=2397378 freq=232173
-OrHighMedDayTaxoFacets: his bgcolor +facets:DayOfYear.taxonomy # freq=1777780 freq=124305
-OrHighMedDayTaxoFacets: that opened +facets:DayOfYear.taxonomy # freq=2931020 freq=140033
-OrHighMedDayTaxoFacets: new station +facets:DayOfYear.taxonomy # freq=1657293 freq=239572
-OrHighMedDayTaxoFacets: were value +facets:DayOfYear.taxonomy # freq=1524630 freq=86806
-OrHighMedDayTaxoFacets: time end +facets:DayOfYear.taxonomy # freq=1032071 freq=526636
-OrHighMedDayTaxoFacets: date start +facets:DayOfYear.taxonomy # freq=2020626 freq=233925
-OrHighMedDayTaxoFacets: 3 across +facets:DayOfYear.taxonomy # freq=1148799 freq=134478
-OrHighMedDayTaxoFacets: 1 j +facets:DayOfYear.taxonomy # freq=1641090 freq=327713
-OrHighMedDayTaxoFacets: the ever +facets:DayOfYear.taxonomy # freq=8217362 freq=128732
-OrHighMedDayTaxoFacets: s archive +facets:DayOfYear.taxonomy # freq=1581243 freq=215381
-OrHighMedDayTaxoFacets: date style +facets:DayOfYear.taxonomy # freq=2020626 freq=606000
-OrHighMedDayTaxoFacets: 2010 caused +facets:DayOfYear.taxonomy # freq=950573 freq=86397
-OrHighMedDayTaxoFacets: or past +facets:DayOfYear.taxonomy # freq=1858841 freq=126130
-OrHighMedDayTaxoFacets: also edits +facets:DayOfYear.taxonomy # freq=1959419 freq=134321
-OrHighMedDayTaxoFacets: http stated +facets:DayOfYear.taxonomy # freq=3493581 freq=89795
-OrHighMedDayTaxoFacets: publisher association +facets:DayOfYear.taxonomy # freq=1289029 freq=247156
-OrHighMedDayTaxoFacets: other europe +facets:DayOfYear.taxonomy # freq=1269961 freq=188671
-OrHighMedDayTaxoFacets: work japan +facets:DayOfYear.taxonomy # freq=853422 freq=163103
-OrHighMedDayTaxoFacets: been committee +facets:DayOfYear.taxonomy # freq=1041183 freq=108636
-OrHighMedDayTaxoFacets: about five +facets:DayOfYear.taxonomy # freq=850283 freq=262923
-OrHighMedDayTaxoFacets: the throughout +facets:DayOfYear.taxonomy # freq=8217362 freq=143603
-OrHighMedDayTaxoFacets: first studies +facets:DayOfYear.taxonomy # freq=1933372 freq=128020
-OrHighMedDayTaxoFacets: his university +facets:DayOfYear.taxonomy # freq=1777780 freq=636959
-OrHighMedDayTaxoFacets: there legal +facets:DayOfYear.taxonomy # freq=956153 freq=90645
-OrHighMedDayTaxoFacets: all italian +facets:DayOfYear.taxonomy # freq=1203572 freq=107082
-OrHighMedDayTaxoFacets: may buildings +facets:DayOfYear.taxonomy # freq=1071932 freq=89046
-OrHighMedDayTaxoFacets: with day +facets:DayOfYear.taxonomy # freq=3709421 freq=402096
-OrHighMedDayTaxoFacets: is code +facets:DayOfYear.taxonomy # freq=4074455 freq=170156
-OrHighMedDayTaxoFacets: date asia +facets:DayOfYear.taxonomy # freq=2020626 freq=90307
-OrHighMedDayTaxoFacets: and thumb +facets:DayOfYear.taxonomy # freq=7318061 freq=672667
-OrHighMedDayTaxoFacets: 10 1970 +facets:DayOfYear.taxonomy # freq=918339 freq=139043
-OrHighMedDayTaxoFacets: from generated +facets:DayOfYear.taxonomy # freq=3224339 freq=97908
-OrHighMedDayTaxoFacets: for light +facets:DayOfYear.taxonomy # freq=4380011 freq=161671
-OrHighMedDayTaxoFacets: about 1970 +facets:DayOfYear.taxonomy # freq=850283 freq=139043
-OrHighMedDayTaxoFacets: states start +facets:DayOfYear.taxonomy # freq=1034872 freq=233925
-OrHighMedDayTaxoFacets: 2 sir +facets:DayOfYear.taxonomy # freq=1549245 freq=107709
-OrHighMedDayTaxoFacets: from information +facets:DayOfYear.taxonomy # freq=3224339 freq=353153
-OrHighMedDayTaxoFacets: 3 reflist +facets:DayOfYear.taxonomy # freq=1148799 freq=561253
-OrHighMedDayTaxoFacets: year modern +facets:DayOfYear.taxonomy # freq=1235231 freq=218831
-OrHighMedDayTaxoFacets: states successful +facets:DayOfYear.taxonomy # freq=1034872 freq=106021
-OrHighMedDayTaxoFacets: on local +facets:DayOfYear.taxonomy # freq=4074624 freq=299012
-OrHighMedDayTaxoFacets: also production +facets:DayOfYear.taxonomy # freq=1959419 freq=191554
-OrHighMedDayTaxoFacets: ref white +facets:DayOfYear.taxonomy # freq=3793973 freq=299411
-OrHighMedDayTaxoFacets: that too +facets:DayOfYear.taxonomy # freq=2931020 freq=161626
-OrHighMedDayTaxoFacets: 2 20 +facets:DayOfYear.taxonomy # freq=1549245 freq=624967
-OrHighMedDayTaxoFacets: 2008 strong +facets:DayOfYear.taxonomy # freq=831253 freq=125611
-OrHighMedDayTaxoFacets: no list +facets:DayOfYear.taxonomy # freq=1045000 freq=585922
-OrHighMedDayTaxoFacets: first label +facets:DayOfYear.taxonomy # freq=1933372 freq=159161
-OrHighMedDayTaxoFacets: see metadata +facets:DayOfYear.taxonomy # freq=1044180 freq=298533
-OrHighMedDayTaxoFacets: they before +facets:DayOfYear.taxonomy # freq=1021945 freq=580481
-OrHighMedDayTaxoFacets: been volume +facets:DayOfYear.taxonomy # freq=1041183 freq=312846
-OrHighMedDayTaxoFacets: last division +facets:DayOfYear.taxonomy # freq=958437 freq=182624
-OrHighMedDayTaxoFacets: new 1988 +facets:DayOfYear.taxonomy # freq=1657293 freq=181327
-OrHighMedDayTaxoFacets: its single +facets:DayOfYear.taxonomy # freq=1173450 freq=283824
-OrHighMedDayTaxoFacets: accessdate awards +facets:DayOfYear.taxonomy # freq=1228887 freq=159679
-OrHighMedDayTaxoFacets: of 1974 +facets:DayOfYear.taxonomy # freq=8184358 freq=132835
-OrHighMedDayTaxoFacets: and st +facets:DayOfYear.taxonomy # freq=7318061 freq=309092
-OrHighMedDayTaxoFacets: which 2002 +facets:DayOfYear.taxonomy # freq=1963428 freq=406953
-OrHighMedDayTaxoFacets: 10 role +facets:DayOfYear.taxonomy # freq=918339 freq=208579
-OrHighMedDayTaxoFacets: 2008 infobox +facets:DayOfYear.taxonomy # freq=831253 freq=524810
-OrHighMedDayTaxoFacets: by units +facets:DayOfYear.taxonomy # freq=3826691 freq=118189
-OrHighMedDayTaxoFacets: see reported +facets:DayOfYear.taxonomy # freq=1044180 freq=91533
-OrHighMedDayTaxoFacets: were love +facets:DayOfYear.taxonomy # freq=1524630 freq=177242
-OrHighMedDayTaxoFacets: their london +facets:DayOfYear.taxonomy # freq=1158682 freq=348918
-OrHighMedDayTaxoFacets: who persondata +facets:DayOfYear.taxonomy # freq=1196171 freq=246119
-OrHighMedDayTaxoFacets: be uk +facets:DayOfYear.taxonomy # freq=2051702 freq=319211
-OrHighMedDayTaxoFacets: for f +facets:DayOfYear.taxonomy # freq=4380011 freq=278015
-OrHighMedDayTaxoFacets: only hold +facets:DayOfYear.taxonomy # freq=875561 freq=82579
-OrHighMedDayTaxoFacets: new way +facets:DayOfYear.taxonomy # freq=1657293 freq=318344
-OrHighMedDayTaxoFacets: which lines +facets:DayOfYear.taxonomy # freq=1963428 freq=96969
-OrHighMedDayTaxoFacets: has div +facets:DayOfYear.taxonomy # freq=1502961 freq=206057
-OrHighMedDayTaxoFacets: all francisco +facets:DayOfYear.taxonomy # freq=1203572 freq=83200
-OrHighMedDayTaxoFacets: from per +facets:DayOfYear.taxonomy # freq=3224339 freq=283568
-OrHighMedDayTaxoFacets: it marriage +facets:DayOfYear.taxonomy # freq=2675552 freq=97658
-OrHighMedDayTaxoFacets: states small +facets:DayOfYear.taxonomy # freq=1034872 freq=581643
-OrHighMedDayTaxoFacets: 2011 july +facets:DayOfYear.taxonomy # freq=871410 freq=529655
-OrHighMedDayTaxoFacets: and mid +facets:DayOfYear.taxonomy # freq=7318061 freq=126355
-OrHighMedDayTaxoFacets: year copy +facets:DayOfYear.taxonomy # freq=1235231 freq=95252
-OrHighMedDayTaxoFacets: not ft +facets:DayOfYear.taxonomy # freq=1713264 freq=88505
-OrHighMedDayTaxoFacets: this 1988 +facets:DayOfYear.taxonomy # freq=2224932 freq=181327
-OrHighMedDayTaxoFacets: accessdate father +facets:DayOfYear.taxonomy # freq=1228887 freq=175393
-OrHighMedDayTaxoFacets: this continued +facets:DayOfYear.taxonomy # freq=2224932 freq=151209
-OrHighMedDayTaxoFacets: with union +facets:DayOfYear.taxonomy # freq=3709421 freq=214164
-OrHighMedDayTaxoFacets: 2011 festival +facets:DayOfYear.taxonomy # freq=871410 freq=85717
-OrHighMedDayTaxoFacets: states hall +facets:DayOfYear.taxonomy # freq=1034872 freq=177247
-OrHighMedDayTaxoFacets: after thomas +facets:DayOfYear.taxonomy # freq=1247398 freq=191625
-OrHighMedDayTaxoFacets: 2 god +facets:DayOfYear.taxonomy # freq=1549245 freq=97443
-OrHighMedDayTaxoFacets: states owned +facets:DayOfYear.taxonomy # freq=1034872 freq=93981
-OrHighMedDayTaxoFacets: were european +facets:DayOfYear.taxonomy # freq=1524630 freq=193975
-OrHighMedDayTaxoFacets: have jack +facets:DayOfYear.taxonomy # freq=1297121 freq=91552
-OrHighMedDayTaxoFacets: time majority +facets:DayOfYear.taxonomy # freq=1032071 freq=105058
-OrHighMedDayTaxoFacets: were went +facets:DayOfYear.taxonomy # freq=1524630 freq=172677
-OrHighMedDayTaxoFacets: only game +facets:DayOfYear.taxonomy # freq=875561 freq=315157
-OrHighMedDayTaxoFacets: a review +facets:DayOfYear.taxonomy # freq=6560531 freq=240157
-OrHighMedDayTaxoFacets: united thomas +facets:DayOfYear.taxonomy # freq=1196944 freq=191625
-OrHighMedDayTaxoFacets: may off +facets:DayOfYear.taxonomy # freq=1071932 freq=315473
-OrHighMedDayTaxoFacets: url persondata +facets:DayOfYear.taxonomy # freq=1513595 freq=246119
-OrHighMedDayTaxoFacets: new hill +facets:DayOfYear.taxonomy # freq=1657293 freq=133714
-OrHighMedDayTaxoFacets: at ice +facets:DayOfYear.taxonomy # freq=2857534 freq=87086
-OrHighMedDayTaxoFacets: 2008 fourth +facets:DayOfYear.taxonomy # freq=831253 freq=102351
-OrHighMedDayTaxoFacets: for 3rd +facets:DayOfYear.taxonomy # freq=4380011 freq=90723
-OrHighMedDayTaxoFacets: more cross +facets:DayOfYear.taxonomy # freq=963533 freq=127216
-OrHighMedDayTaxoFacets: not index.php +facets:DayOfYear.taxonomy # freq=1713264 freq=126813
-OrHighMedDayTaxoFacets: but census +facets:DayOfYear.taxonomy # freq=1456553 freq=205166
-OrHighMedDayTaxoFacets: work replaced +facets:DayOfYear.taxonomy # freq=853422 freq=112506
-OrHighMedDayTaxoFacets: some groups +facets:DayOfYear.taxonomy # freq=839919 freq=146670
-OrHighMedDayTaxoFacets: 10 collection +facets:DayOfYear.taxonomy # freq=918339 freq=110483
-OrHighMedDayTaxoFacets: not opening +facets:DayOfYear.taxonomy # freq=1713264 freq=84576
-OrHighMedDayTaxoFacets: see september +facets:DayOfYear.taxonomy # freq=1044180 freq=553409
-OrHighMedDayTaxoFacets: 4 steve +facets:DayOfYear.taxonomy # freq=986452 freq=84364
-OrHighMedDayTaxoFacets: ref appears +facets:DayOfYear.taxonomy # freq=3793973 freq=104511
-OrHighMedDayTaxoFacets: a named +facets:DayOfYear.taxonomy # freq=6560531 freq=310150
-OrHighMedDayTaxoFacets: which pre +facets:DayOfYear.taxonomy # freq=1963428 freq=90549
-OrHighMedDayTaxoFacets: has stone +facets:DayOfYear.taxonomy # freq=1502961 freq=92132
-OrHighMedDayTaxoFacets: to energy +facets:DayOfYear.taxonomy # freq=6155577 freq=91150
-OrHighMedDayTaxoFacets: not should +facets:DayOfYear.taxonomy # freq=1713264 freq=401379
-OrHighMedDayTaxoFacets: 2010 media +facets:DayOfYear.taxonomy # freq=950573 freq=206574
-OrHighMedDayTaxoFacets: was behind +facets:DayOfYear.taxonomy # freq=3763623 freq=112070
-OrHighMedDayTaxoFacets: that black +facets:DayOfYear.taxonomy # freq=2931020 freq=256526
-OrHighMedDayTaxoFacets: are itself +facets:DayOfYear.taxonomy # freq=1877802 freq=138231
-OrHighMedDayTaxoFacets: only 90 +facets:DayOfYear.taxonomy # freq=875561 freq=116206
-OrHighMedDayTaxoFacets: 4 main +facets:DayOfYear.taxonomy # freq=986452 freq=470429
-OrHighMedDayTaxoFacets: with august +facets:DayOfYear.taxonomy # freq=3709421 freq=527806
-OrHighMedDayTaxoFacets: have age +facets:DayOfYear.taxonomy # freq=1297121 freq=395368
-OrHighMedDayTaxoFacets: time citation +facets:DayOfYear.taxonomy # freq=1032071 freq=291478
-OrHighMedDayTaxoFacets: his notes +facets:DayOfYear.taxonomy # freq=1777780 freq=210029
-OrHighMedDayTaxoFacets: year 17 +facets:DayOfYear.taxonomy # freq=1235231 freq=507396
-OrHighMedDayTaxoFacets: i bbc +facets:DayOfYear.taxonomy # freq=956148 freq=138548
-OrHighMedDayTaxoFacets: name 1984 +facets:DayOfYear.taxonomy # freq=2827713 freq=161404
-OrHighMedDayTaxoFacets: his greek +facets:DayOfYear.taxonomy # freq=1777780 freq=94348
-OrHighMedDayTaxoFacets: cite votes +facets:DayOfYear.taxonomy # freq=1741194 freq=93844
-OrHighMedDayTaxoFacets: be fire +facets:DayOfYear.taxonomy # freq=2051702 freq=133712
-OrHighMedDayTaxoFacets: in sometimes +facets:DayOfYear.taxonomy # freq=7320987 freq=144078
-OrHighMedDayTaxoFacets: last better +facets:DayOfYear.taxonomy # freq=958437 freq=125889
-OrHighMedDayTaxoFacets: by considered +facets:DayOfYear.taxonomy # freq=3826691 freq=186840
-OrHighMedDayTaxoFacets: no leading +facets:DayOfYear.taxonomy # freq=1045000 freq=120945
-OrHighMedDayTaxoFacets: name influence +facets:DayOfYear.taxonomy # freq=2827713 freq=83101
-OrHighMedDayTaxoFacets: 2009 power +facets:DayOfYear.taxonomy # freq=887702 freq=262586
-OrHighMedDayTaxoFacets: is institute +facets:DayOfYear.taxonomy # freq=4074455 freq=136311
-OrHighMedDayTaxoFacets: into doi +facets:DayOfYear.taxonomy # freq=888684 freq=170085
-OrHighMedDayTaxoFacets: into short +facets:DayOfYear.taxonomy # freq=888684 freq=465205
-OrHighMedDayTaxoFacets: were gr +facets:DayOfYear.taxonomy # freq=1524630 freq=83712
-OrHighMedDayTaxoFacets: has 16 +facets:DayOfYear.taxonomy # freq=1502961 freq=540539
-OrHighMedDayTaxoFacets: this towards +facets:DayOfYear.taxonomy # freq=2224932 freq=95574
-OrHighMedDayTaxoFacets: the div +facets:DayOfYear.taxonomy # freq=8217362 freq=206057
-OrHighMedDayTaxoFacets: its jean +facets:DayOfYear.taxonomy # freq=1173450 freq=84299
-OrHighMedDayTaxoFacets: their continued +facets:DayOfYear.taxonomy # freq=1158682 freq=151209
-OrHighMedDayTaxoFacets: publisher come +facets:DayOfYear.taxonomy # freq=1289029 freq=139047
-OrHighMedDayTaxoFacets: name yet +facets:DayOfYear.taxonomy # freq=2827713 freq=100857
-OrHighMedDayTaxoFacets: be before +facets:DayOfYear.taxonomy # freq=2051702 freq=580481
-OrHighMedDayTaxoFacets: ref britain +facets:DayOfYear.taxonomy # freq=3793973 freq=101080
-OrHighMedDayTaxoFacets: 10 returned +facets:DayOfYear.taxonomy # freq=918339 freq=141639
-OrHighMedDayTaxoFacets: 2006 02 +facets:DayOfYear.taxonomy # freq=889954 freq=319783
-OrHighMedDayTaxoFacets: 2011 daughter +facets:DayOfYear.taxonomy # freq=871410 freq=103883
-OrHighMedDayTaxoFacets: be independent +facets:DayOfYear.taxonomy # freq=2051702 freq=164766
-OrHighMedDayTaxoFacets: more self +facets:DayOfYear.taxonomy # freq=963533 freq=135012
-OrHighMedDayTaxoFacets: in particular +facets:DayOfYear.taxonomy # freq=7320987 freq=103643
-OrHighMedDayTaxoFacets: which non +facets:DayOfYear.taxonomy # freq=1963428 freq=348142
-OrHighMedDayTaxoFacets: his birth +facets:DayOfYear.taxonomy # freq=1777780 freq=425138
-OrHighMedDayTaxoFacets: ref stations +facets:DayOfYear.taxonomy # freq=3793973 freq=92011
-OrHighMedDayTaxoFacets: united include +facets:DayOfYear.taxonomy # freq=1196944 freq=276466
-OrHighMedDayTaxoFacets: http flight +facets:DayOfYear.taxonomy # freq=3493581 freq=84316
-OrHighMedDayTaxoFacets: http singles +facets:DayOfYear.taxonomy # freq=3493581 freq=89221
-OrHighMedDayTaxoFacets: year northern +facets:DayOfYear.taxonomy # freq=1235231 freq=194363
-OrHighMedDayTaxoFacets: been htm +facets:DayOfYear.taxonomy # freq=1041183 freq=191479
-OrHighMedDayTaxoFacets: one alone +facets:DayOfYear.taxonomy # freq=1527689 freq=93166
-OrHighMedDayTaxoFacets: their systems +facets:DayOfYear.taxonomy # freq=1158682 freq=134476
-OrHighMedDayTaxoFacets: to yet +facets:DayOfYear.taxonomy # freq=6155577 freq=100857
-OrHighMedDayTaxoFacets: see leader +facets:DayOfYear.taxonomy # freq=1044180 freq=127591
-OrHighMedDayTaxoFacets: on seen +facets:DayOfYear.taxonomy # freq=4074624 freq=173530
-OrHighMedDayTaxoFacets: has 200px +facets:DayOfYear.taxonomy # freq=1502961 freq=102661
-OrHighMedDayTaxoFacets: that 56 +facets:DayOfYear.taxonomy # freq=2931020 freq=96215
-OrHighMedDayTaxoFacets: about women +facets:DayOfYear.taxonomy # freq=850283 freq=128847
-OrHighMedDayTaxoFacets: only michael +facets:DayOfYear.taxonomy # freq=875561 freq=217311
-OrHighMedDayTaxoFacets: 2009 provided +facets:DayOfYear.taxonomy # freq=887702 freq=110088
-OrHighMedDayTaxoFacets: with show +facets:DayOfYear.taxonomy # freq=3709421 freq=293934
-OrHighMedDayTaxoFacets: 2011 utc +facets:DayOfYear.taxonomy # freq=871410 freq=450225
-OrHighMedDayTaxoFacets: which give +facets:DayOfYear.taxonomy # freq=1963428 freq=116375
-OrHighMedDayTaxoFacets: 2010 support +facets:DayOfYear.taxonomy # freq=950573 freq=236989
-OrHighMedDayTaxoFacets: 4 very +facets:DayOfYear.taxonomy # freq=986452 freq=354898
-OrHighMedDayTaxoFacets: 2 foreign +facets:DayOfYear.taxonomy # freq=1549245 freq=109174
-OrHighMedDayTaxoFacets: were 59 +facets:DayOfYear.taxonomy # freq=1524630 freq=93856
-OrHighMedDayTaxoFacets: 2010 take +facets:DayOfYear.taxonomy # freq=950573 freq=224260
-OrHighMedDayTaxoFacets: by york +facets:DayOfYear.taxonomy # freq=3826691 freq=521383
-OrHighMedDayTaxoFacets: http kingdom +facets:DayOfYear.taxonomy # freq=3493581 freq=299825
-OrHighMedDayTaxoFacets: only brother +facets:DayOfYear.taxonomy # freq=875561 freq=110146
-OrHighMedDayTaxoFacets: no died +facets:DayOfYear.taxonomy # freq=1045000 freq=202125
-OrHighMedDayTaxoFacets: other november +facets:DayOfYear.taxonomy # freq=1269961 freq=527131
-OrHighMedDayTaxoFacets: 2008 system +facets:DayOfYear.taxonomy # freq=831253 freq=412862
-OrHighMedDayTaxoFacets: 5 still +facets:DayOfYear.taxonomy # freq=891361 freq=332543
-OrHighMedDayTaxoFacets: by required +facets:DayOfYear.taxonomy # freq=3826691 freq=100578
-OrHighMedDayTaxoFacets: title era +facets:DayOfYear.taxonomy # freq=2397378 freq=95989
-OrHighMedDayTaxoFacets: 3 larger +facets:DayOfYear.taxonomy # freq=1148799 freq=87424
-OrHighMedDayTaxoFacets: into within +facets:DayOfYear.taxonomy # freq=888684 freq=291049
-OrHighMedDayTaxoFacets: http where +facets:DayOfYear.taxonomy # freq=3493581 freq=630647
-OrHighMedDayTaxoFacets: united say +facets:DayOfYear.taxonomy # freq=1196944 freq=110895
-OrHighMedDayTaxoFacets: no second +facets:DayOfYear.taxonomy # freq=1045000 freq=505575
-OrHighMedDayTaxoFacets: work 1998 +facets:DayOfYear.taxonomy # freq=853422 freq=300506
-OrHighMedDayTaxoFacets: 1 think +facets:DayOfYear.taxonomy # freq=1641090 freq=129332
-OrHighMedDayTaxoFacets: by b +facets:DayOfYear.taxonomy # freq=3826691 freq=369454
-OrHighMedDayTaxoFacets: 4 thumb +facets:DayOfYear.taxonomy # freq=986452 freq=672667
-OrHighMedDayTaxoFacets: be usa +facets:DayOfYear.taxonomy # freq=2051702 freq=191220
-OrHighMedDayTaxoFacets: not african +facets:DayOfYear.taxonomy # freq=1713264 freq=128682
-OrHighMedDayTaxoFacets: 1 president +facets:DayOfYear.taxonomy # freq=1641090 freq=263341
-OrHighMedDayTaxoFacets: 4 worked +facets:DayOfYear.taxonomy # freq=986452 freq=119896
-OrHighMedDayTaxoFacets: http added +facets:DayOfYear.taxonomy # freq=3493581 freq=138409
-OrHighMedDayTaxoFacets: s deletion +facets:DayOfYear.taxonomy # freq=1581243 freq=166633
-OrHighMedDayTaxoFacets: time nbsp +facets:DayOfYear.taxonomy # freq=1032071 freq=506054
-OrHighMedDayTaxoFacets: when 02 +facets:DayOfYear.taxonomy # freq=1027487 freq=319783
-OrHighMedDayTaxoFacets: may la +facets:DayOfYear.taxonomy # freq=1071932 freq=232610
-OrHighMedDayTaxoFacets: 2 royal +facets:DayOfYear.taxonomy # freq=1549245 freq=211710
-OrHighMedDayTaxoFacets: from office +facets:DayOfYear.taxonomy # freq=3224339 freq=225338
-OrHighMedDayTaxoFacets: and 22 +facets:DayOfYear.taxonomy # freq=7318061 freq=502778
-OrHighMedDayTaxoFacets: cite order +facets:DayOfYear.taxonomy # freq=1741194 freq=360915
-OrHighMedDayTaxoFacets: of upper +facets:DayOfYear.taxonomy # freq=8184358 freq=86379
-OrHighMedDayTaxoFacets: all htm +facets:DayOfYear.taxonomy # freq=1203572 freq=191479
-OrHighMedDayTaxoFacets: he towards +facets:DayOfYear.taxonomy # freq=1659434 freq=95574
-OrHighMedDayTaxoFacets: are traditional +facets:DayOfYear.taxonomy # freq=1877802 freq=110425
-OrHighMedDayTaxoFacets: a team +facets:DayOfYear.taxonomy # freq=6560531 freq=379028
-OrHighMedDayTaxoFacets: or imagesize +facets:DayOfYear.taxonomy # freq=1858841 freq=82746
-OrHighMedDayTaxoFacets: date regular +facets:DayOfYear.taxonomy # freq=2020626 freq=93809
-OrHighMedDayTaxoFacets: or birth_date +facets:DayOfYear.taxonomy # freq=1858841 freq=122665
-OrHighMedDayTaxoFacets: name each +facets:DayOfYear.taxonomy # freq=2827713 freq=354583
-OrHighMedDayTaxoFacets: but begin +facets:DayOfYear.taxonomy # freq=1456553 freq=104303
-OrHighMedDayTaxoFacets: 2 developed +facets:DayOfYear.taxonomy # freq=1549245 freq=151220
-OrHighMedDayTaxoFacets: ref note +facets:DayOfYear.taxonomy # freq=3793973 freq=194472
-OrHighMedDayTaxoFacets: united programs +facets:DayOfYear.taxonomy # freq=1196944 freq=83974
+MedTermDayTaxoFacets: most +facets:taxonomy:DayOfYear # freq=819634
+MedTermDayTaxoFacets: up +facets:taxonomy:DayOfYear # freq=818546
+MedTermDayTaxoFacets: world +facets:taxonomy:DayOfYear # freq=808563
+MedTermDayTaxoFacets: 2007 +facets:taxonomy:DayOfYear # freq=801586
+MedTermDayTaxoFacets: during +facets:taxonomy:DayOfYear # freq=798114
+MedTermDayTaxoFacets: people +facets:taxonomy:DayOfYear # freq=790960
+MedTermDayTaxoFacets: years +facets:taxonomy:DayOfYear # freq=789628
+MedTermDayTaxoFacets: such +facets:taxonomy:DayOfYear # freq=787877
+MedTermDayTaxoFacets: 12 +facets:taxonomy:DayOfYear # freq=774572
+MedTermDayTaxoFacets: over +facets:taxonomy:DayOfYear # freq=774312
+MedTermDayTaxoFacets: can +facets:taxonomy:DayOfYear # freq=765163
+MedTermDayTaxoFacets: references +facets:taxonomy:DayOfYear # freq=760306
+MedTermDayTaxoFacets: city +facets:taxonomy:DayOfYear # freq=760272
+MedTermDayTaxoFacets: 6 +facets:taxonomy:DayOfYear # freq=759234
+MedTermDayTaxoFacets: american +facets:taxonomy:DayOfYear # freq=758337
+MedTermDayTaxoFacets: news +facets:taxonomy:DayOfYear # freq=756063
+MedTermDayTaxoFacets: history +facets:taxonomy:DayOfYear # freq=755471
+MedTermDayTaxoFacets: 0 +facets:taxonomy:DayOfYear # freq=754451
+MedTermDayTaxoFacets: made +facets:taxonomy:DayOfYear # freq=742313
+MedTermDayTaxoFacets: out +facets:taxonomy:DayOfYear # freq=733775
+MedTermDayTaxoFacets: 11 +facets:taxonomy:DayOfYear # freq=730505
+MedTermDayTaxoFacets: used +facets:taxonomy:DayOfYear # freq=708455
+MedTermDayTaxoFacets: links +facets:taxonomy:DayOfYear # freq=703350
+MedTermDayTaxoFacets: state +facets:taxonomy:DayOfYear # freq=702598
+MedTermDayTaxoFacets: many +facets:taxonomy:DayOfYear # freq=694439
+MedTermDayTaxoFacets: would +facets:taxonomy:DayOfYear # freq=690480
+MedTermDayTaxoFacets: page +facets:taxonomy:DayOfYear # freq=681036
+MedTermDayTaxoFacets: national +facets:taxonomy:DayOfYear # freq=677281
+MedTermDayTaxoFacets: than +facets:taxonomy:DayOfYear # freq=676864
+MedTermDayTaxoFacets: thumb +facets:taxonomy:DayOfYear # freq=672667
+MedTermDayTaxoFacets: 7 +facets:taxonomy:DayOfYear # freq=660220
+MedTermDayTaxoFacets: place +facets:taxonomy:DayOfYear # freq=654158
+MedTermDayTaxoFacets: de +facets:taxonomy:DayOfYear # freq=652242
+MedTermDayTaxoFacets: if +facets:taxonomy:DayOfYear # freq=640551
+MedTermDayTaxoFacets: university +facets:taxonomy:DayOfYear # freq=636959
+MedTermDayTaxoFacets: 8 +facets:taxonomy:DayOfYear # freq=635822
+MedTermDayTaxoFacets: external +facets:taxonomy:DayOfYear # freq=635450
+MedTermDayTaxoFacets: between +facets:taxonomy:DayOfYear # freq=630650
+MedTermDayTaxoFacets: where +facets:taxonomy:DayOfYear # freq=630647
+MedTermDayTaxoFacets: right +facets:taxonomy:DayOfYear # freq=630423
+MedTermDayTaxoFacets: 20 +facets:taxonomy:DayOfYear # freq=624967
+MedTermDayTaxoFacets: under +facets:taxonomy:DayOfYear # freq=623872
+MedTermDayTaxoFacets: these +facets:taxonomy:DayOfYear # freq=623267
+MedTermDayTaxoFacets: march +facets:taxonomy:DayOfYear # freq=620393
+MedTermDayTaxoFacets: br +facets:taxonomy:DayOfYear # freq=617824
+MedTermDayTaxoFacets: book +facets:taxonomy:DayOfYear # freq=617297
+MedTermDayTaxoFacets: p +facets:taxonomy:DayOfYear # freq=616159
+MedTermDayTaxoFacets: article +facets:taxonomy:DayOfYear # freq=610650
+MedTermDayTaxoFacets: known +facets:taxonomy:DayOfYear # freq=607158
+MedTermDayTaxoFacets: then +facets:taxonomy:DayOfYear # freq=606159
+MedTermDayTaxoFacets: style +facets:taxonomy:DayOfYear # freq=606000
+MedTermDayTaxoFacets: later +facets:taxonomy:DayOfYear # freq=604921
+MedTermDayTaxoFacets: three +facets:taxonomy:DayOfYear # freq=598349
+MedTermDayTaxoFacets: use +facets:taxonomy:DayOfYear # freq=597053
+MedTermDayTaxoFacets: category +facets:taxonomy:DayOfYear # freq=595446
+MedTermDayTaxoFacets: john +facets:taxonomy:DayOfYear # freq=594461
+MedTermDayTaxoFacets: part +facets:taxonomy:DayOfYear # freq=594224
+MedTermDayTaxoFacets: left +facets:taxonomy:DayOfYear # freq=593967
+MedTermDayTaxoFacets: 2004 +facets:taxonomy:DayOfYear # freq=593934
+MedTermDayTaxoFacets: 15 +facets:taxonomy:DayOfYear # freq=592407
+MedTermDayTaxoFacets: december +facets:taxonomy:DayOfYear # freq=590171
+MedTermDayTaxoFacets: april +facets:taxonomy:DayOfYear # freq=587542
+MedTermDayTaxoFacets: list +facets:taxonomy:DayOfYear # freq=585922
+MedTermDayTaxoFacets: 18 +facets:taxonomy:DayOfYear # freq=585631
+MedTermDayTaxoFacets: small +facets:taxonomy:DayOfYear # freq=581643
+MedTermDayTaxoFacets: january +facets:taxonomy:DayOfYear # freq=581309
+MedTermDayTaxoFacets: before +facets:taxonomy:DayOfYear # freq=580481
+MedTermDayTaxoFacets: being +facets:taxonomy:DayOfYear # freq=580185
+MedTermDayTaxoFacets: well +facets:taxonomy:DayOfYear # freq=580011
+MedTermDayTaxoFacets: id +facets:taxonomy:DayOfYear # freq=579566
+MedTermDayTaxoFacets: while +facets:taxonomy:DayOfYear # freq=579117
+MedTermDayTaxoFacets: 9 +facets:taxonomy:DayOfYear # freq=574434
+MedTermDayTaxoFacets: death +facets:taxonomy:DayOfYear # freq=568895
+MedTermDayTaxoFacets: author +facets:taxonomy:DayOfYear # freq=567768
+MedTermDayTaxoFacets: however +facets:taxonomy:DayOfYear # freq=566494
+MedTermDayTaxoFacets: october +facets:taxonomy:DayOfYear # freq=566229
+MedTermDayTaxoFacets: north +facets:taxonomy:DayOfYear # freq=564195
+MedTermDayTaxoFacets: so +facets:taxonomy:DayOfYear # freq=562598
+MedTermDayTaxoFacets: reflist +facets:taxonomy:DayOfYear # freq=561253
+MedTermDayTaxoFacets: south +facets:taxonomy:DayOfYear # freq=560468
+MedTermDayTaxoFacets: area +facets:taxonomy:DayOfYear # freq=559023
+MedTermDayTaxoFacets: class +facets:taxonomy:DayOfYear # freq=556838
+MedTermDayTaxoFacets: september +facets:taxonomy:DayOfYear # freq=553409
+MedTermDayTaxoFacets: war +facets:taxonomy:DayOfYear # freq=547417
+MedTermDayTaxoFacets: image +facets:taxonomy:DayOfYear # freq=541747
+MedTermDayTaxoFacets: 16 +facets:taxonomy:DayOfYear # freq=540539
+MedTermDayTaxoFacets: both +facets:taxonomy:DayOfYear # freq=534900
+MedTermDayTaxoFacets: 14 +facets:taxonomy:DayOfYear # freq=534005
+MedTermDayTaxoFacets: 13 +facets:taxonomy:DayOfYear # freq=530419
+MedTermDayTaxoFacets: july +facets:taxonomy:DayOfYear # freq=529655
+MedTermDayTaxoFacets: august +facets:taxonomy:DayOfYear # freq=527806
+MedTermDayTaxoFacets: november +facets:taxonomy:DayOfYear # freq=527131
+MedTermDayTaxoFacets: end +facets:taxonomy:DayOfYear # freq=526636
+MedTermDayTaxoFacets: february +facets:taxonomy:DayOfYear # freq=524886
+MedTermDayTaxoFacets: infobox +facets:taxonomy:DayOfYear # freq=524810
+MedTermDayTaxoFacets: june +facets:taxonomy:DayOfYear # freq=522519
+MedTermDayTaxoFacets: series +facets:taxonomy:DayOfYear # freq=521861
+MedTermDayTaxoFacets: york +facets:taxonomy:DayOfYear # freq=521383
+MedTermDayTaxoFacets: including +facets:taxonomy:DayOfYear # freq=521324
+MedTermDayTaxoFacets: county +facets:taxonomy:DayOfYear # freq=521126
+MedTermDayTaxoFacets: them +facets:taxonomy:DayOfYear # freq=520298
+MedTermDayTaxoFacets: her +facets:taxonomy:DayOfYear # freq=518717
+MedTermDayTaxoFacets: through +facets:taxonomy:DayOfYear # freq=514966
+MedTermDayTaxoFacets: do +facets:taxonomy:DayOfYear # freq=511178
+MedTermDayTaxoFacets: 17 +facets:taxonomy:DayOfYear # freq=507396
+MedTermDayTaxoFacets: him +facets:taxonomy:DayOfYear # freq=507350
+MedTermDayTaxoFacets: nbsp +facets:taxonomy:DayOfYear # freq=506054
+MedTermDayTaxoFacets: second +facets:taxonomy:DayOfYear # freq=505575
+MedTermDayTaxoFacets: 22 +facets:taxonomy:DayOfYear # freq=502778
+MedTermDayTaxoFacets: html +facets:taxonomy:DayOfYear # freq=500198
+MedTermDayTaxoFacets: 2000 +facets:taxonomy:DayOfYear # freq=499639
+MedTermDayTaxoFacets: 25 +facets:taxonomy:DayOfYear # freq=491957
+MedTermDayTaxoFacets: location +facets:taxonomy:DayOfYear # freq=489791
+MedTermDayTaxoFacets: will +facets:taxonomy:DayOfYear # freq=489711
+MedTermDayTaxoFacets: center +facets:taxonomy:DayOfYear # freq=489673
+MedTermDayTaxoFacets: 30 +facets:taxonomy:DayOfYear # freq=488930
+MedTermDayTaxoFacets: since +facets:taxonomy:DayOfYear # freq=485325
+MedTermDayTaxoFacets: 19 +facets:taxonomy:DayOfYear # freq=484187
+MedTermDayTaxoFacets: now +facets:taxonomy:DayOfYear # freq=484114
+MedTermDayTaxoFacets: any +facets:taxonomy:DayOfYear # freq=483514
+MedTermDayTaxoFacets: early +facets:taxonomy:DayOfYear # freq=482793
+MedTermDayTaxoFacets: 21 +facets:taxonomy:DayOfYear # freq=482314
+MedTermDayTaxoFacets: high +facets:taxonomy:DayOfYear # freq=482152
+MedTermDayTaxoFacets: like +facets:taxonomy:DayOfYear # freq=479390
+MedTermDayTaxoFacets: life +facets:taxonomy:DayOfYear # freq=477007
+MedTermDayTaxoFacets: general +facets:taxonomy:DayOfYear # freq=476690
+MedTermDayTaxoFacets: music +facets:taxonomy:DayOfYear # freq=473240
+MedTermDayTaxoFacets: number +facets:taxonomy:DayOfYear # freq=473154
+MedTermDayTaxoFacets: 24 +facets:taxonomy:DayOfYear # freq=470708
+MedTermDayTaxoFacets: main +facets:taxonomy:DayOfYear # freq=470429
+MedTermDayTaxoFacets: isbn +facets:taxonomy:DayOfYear # freq=467574
+MedTermDayTaxoFacets: pages +facets:taxonomy:DayOfYear # freq=466290
+MedTermDayTaxoFacets: became +facets:taxonomy:DayOfYear # freq=465594
+MedTermDayTaxoFacets: short +facets:taxonomy:DayOfYear # freq=465205
+MedTermDayTaxoFacets: school +facets:taxonomy:DayOfYear # freq=462166
+MedTermDayTaxoFacets: you +facets:taxonomy:DayOfYear # freq=461587
+MedTermDayTaxoFacets: 23 +facets:taxonomy:DayOfYear # freq=457097
+MedTermDayTaxoFacets: 2003 +facets:taxonomy:DayOfYear # freq=456990
+MedTermDayTaxoFacets: called +facets:taxonomy:DayOfYear # freq=454580
+MedTermDayTaxoFacets: utc +facets:taxonomy:DayOfYear # freq=450225
+MedTermDayTaxoFacets: n +facets:taxonomy:DayOfYear # freq=449994
+MedTermDayTaxoFacets: c +facets:taxonomy:DayOfYear # freq=444247
+MedTermDayTaxoFacets: group +facets:taxonomy:DayOfYear # freq=442503
+MedTermDayTaxoFacets: m +facets:taxonomy:DayOfYear # freq=441232
+MedTermDayTaxoFacets: several +facets:taxonomy:DayOfYear # freq=436129
+MedTermDayTaxoFacets: website +facets:taxonomy:DayOfYear # freq=435941
+MedTermDayTaxoFacets: film +facets:taxonomy:DayOfYear # freq=432758
+MedTermDayTaxoFacets: west +facets:taxonomy:DayOfYear # freq=431006
+MedTermDayTaxoFacets: u.s +facets:taxonomy:DayOfYear # freq=428534
+MedTermDayTaxoFacets: she +facets:taxonomy:DayOfYear # freq=426267
+MedTermDayTaxoFacets: until +facets:taxonomy:DayOfYear # freq=425389
+MedTermDayTaxoFacets: birth +facets:taxonomy:DayOfYear # freq=425138
+MedTermDayTaxoFacets: us +facets:taxonomy:DayOfYear # freq=421210
+MedTermDayTaxoFacets: same +facets:taxonomy:DayOfYear # freq=420741
+MedTermDayTaxoFacets: country +facets:taxonomy:DayOfYear # freq=420052
+MedTermDayTaxoFacets: international +facets:taxonomy:DayOfYear # freq=418261
+MedTermDayTaxoFacets: british +facets:taxonomy:DayOfYear # freq=417307
+MedTermDayTaxoFacets: language +facets:taxonomy:DayOfYear # freq=416771
+MedTermDayTaxoFacets: following +facets:taxonomy:DayOfYear # freq=416515
+MedTermDayTaxoFacets: because +facets:taxonomy:DayOfYear # freq=413003
+MedTermDayTaxoFacets: system +facets:taxonomy:DayOfYear # freq=412862
+MedTermDayTaxoFacets: english +facets:taxonomy:DayOfYear # freq=412061
+MedTermDayTaxoFacets: 2001 +facets:taxonomy:DayOfYear # freq=410364
+MedTermDayTaxoFacets: e +facets:taxonomy:DayOfYear # freq=408741
+MedTermDayTaxoFacets: times +facets:taxonomy:DayOfYear # freq=407155
+MedTermDayTaxoFacets: 2002 +facets:taxonomy:DayOfYear # freq=406953
+MedTermDayTaxoFacets: names +facets:taxonomy:DayOfYear # freq=404796
+MedTermDayTaxoFacets: w +facets:taxonomy:DayOfYear # freq=404764
+MedTermDayTaxoFacets: day +facets:taxonomy:DayOfYear # freq=402096
+MedTermDayTaxoFacets: should +facets:taxonomy:DayOfYear # freq=401379
+MedTermDayTaxoFacets: against +facets:taxonomy:DayOfYear # freq=399228
+MedTermDayTaxoFacets: press +facets:taxonomy:DayOfYear # freq=398988
+MedTermDayTaxoFacets: based +facets:taxonomy:DayOfYear # freq=398415
+MedTermDayTaxoFacets: age +facets:taxonomy:DayOfYear # freq=395368
+MedTermDayTaxoFacets: what +facets:taxonomy:DayOfYear # freq=394675
+MedTermDayTaxoFacets: party +facets:taxonomy:DayOfYear # freq=394410
+MedTermDayTaxoFacets: company +facets:taxonomy:DayOfYear # freq=391520
+MedTermDayTaxoFacets: four +facets:taxonomy:DayOfYear # freq=389818
+MedTermDayTaxoFacets: 28 +facets:taxonomy:DayOfYear # freq=389552
+MedTermDayTaxoFacets: 26 +facets:taxonomy:DayOfYear # freq=389026
+MedTermDayTaxoFacets: family +facets:taxonomy:DayOfYear # freq=387175
+MedTermDayTaxoFacets: long +facets:taxonomy:DayOfYear # freq=385787
+MedTermDayTaxoFacets: century +facets:taxonomy:DayOfYear # freq=385541
+MedTermDayTaxoFacets: government +facets:taxonomy:DayOfYear # freq=384004
+MedTermDayTaxoFacets: 27 +facets:taxonomy:DayOfYear # freq=383042
+MedTermDayTaxoFacets: old +facets:taxonomy:DayOfYear # freq=381809
+MedTermDayTaxoFacets: team +facets:taxonomy:DayOfYear # freq=379028
+MedTermDayTaxoFacets: house +facets:taxonomy:DayOfYear # freq=377336
+MedTermDayTaxoFacets: population +facets:taxonomy:DayOfYear # freq=374481
+MedTermDayTaxoFacets: 29 +facets:taxonomy:DayOfYear # freq=372091
+MedTermDayTaxoFacets: b +facets:taxonomy:DayOfYear # freq=369454
+MedTermDayTaxoFacets: public +facets:taxonomy:DayOfYear # freq=368868
+MedTermDayTaxoFacets: home +facets:taxonomy:DayOfYear # freq=367819
+MedTermDayTaxoFacets: top +facets:taxonomy:DayOfYear # freq=364628
+MedTermDayTaxoFacets: east +facets:taxonomy:DayOfYear # freq=364582
+MedTermDayTaxoFacets: talk +facets:taxonomy:DayOfYear # freq=364194
+MedTermDayTaxoFacets: order +facets:taxonomy:DayOfYear # freq=360915
+MedTermDayTaxoFacets: line +facets:taxonomy:DayOfYear # freq=360442
+MedTermDayTaxoFacets: could +facets:taxonomy:DayOfYear # freq=356679
+MedTermDayTaxoFacets: 2012 +facets:taxonomy:DayOfYear # freq=355641
+MedTermDayTaxoFacets: description +facets:taxonomy:DayOfYear # freq=355070
+MedTermDayTaxoFacets: very +facets:taxonomy:DayOfYear # freq=354898
+MedTermDayTaxoFacets: each +facets:taxonomy:DayOfYear # freq=354583
+MedTermDayTaxoFacets: information +facets:taxonomy:DayOfYear # freq=353153
+MedTermDayTaxoFacets: another +facets:taxonomy:DayOfYear # freq=352496
+MedTermDayTaxoFacets: born +facets:taxonomy:DayOfYear # freq=352196
+MedTermDayTaxoFacets: back +facets:taxonomy:DayOfYear # freq=349276
+MedTermDayTaxoFacets: london +facets:taxonomy:DayOfYear # freq=348918
+MedTermDayTaxoFacets: just +facets:taxonomy:DayOfYear # freq=348911
+MedTermDayTaxoFacets: town +facets:taxonomy:DayOfYear # freq=348598
+MedTermDayTaxoFacets: journal +facets:taxonomy:DayOfYear # freq=348162
+MedTermDayTaxoFacets: non +facets:taxonomy:DayOfYear # freq=348142
+MedTermDayTaxoFacets: color +facets:taxonomy:DayOfYear # freq=347941
+MedTermDayTaxoFacets: 01 +facets:taxonomy:DayOfYear # freq=347922
+MedTermDayTaxoFacets: great +facets:taxonomy:DayOfYear # freq=347499
+MedTermDayTaxoFacets: although +facets:taxonomy:DayOfYear # freq=341432
+MedTermDayTaxoFacets: books +facets:taxonomy:DayOfYear # freq=341376
+MedTermDayTaxoFacets: ii +facets:taxonomy:DayOfYear # freq=340800
+MedTermDayTaxoFacets: major +facets:taxonomy:DayOfYear # freq=340345
+MedTermDayTaxoFacets: further +facets:taxonomy:DayOfYear # freq=339350
+MedTermDayTaxoFacets: 1999 +facets:taxonomy:DayOfYear # freq=334887
+MedTermDayTaxoFacets: around +facets:taxonomy:DayOfYear # freq=334840
+MedTermDayTaxoFacets: best +facets:taxonomy:DayOfYear # freq=334550
+MedTermDayTaxoFacets: former +facets:taxonomy:DayOfYear # freq=332750
+MedTermDayTaxoFacets: still +facets:taxonomy:DayOfYear # freq=332543
+MedTermDayTaxoFacets: album +facets:taxonomy:DayOfYear # freq=331360
+MedTermDayTaxoFacets: stub +facets:taxonomy:DayOfYear # freq=329768
+MedTermDayTaxoFacets: did +facets:taxonomy:DayOfYear # freq=328303
+MedTermDayTaxoFacets: j +facets:taxonomy:DayOfYear # freq=327713
+MedTermDayTaxoFacets: even +facets:taxonomy:DayOfYear # freq=326231
+MedTermDayTaxoFacets: official +facets:taxonomy:DayOfYear # freq=326177
+MedTermDayTaxoFacets: original +facets:taxonomy:DayOfYear # freq=323521
+MedTermDayTaxoFacets: user +facets:taxonomy:DayOfYear # freq=323242
+MedTermDayTaxoFacets: alternative +facets:taxonomy:DayOfYear # freq=322536
+MedTermDayTaxoFacets: released +facets:taxonomy:DayOfYear # freq=322473
+MedTermDayTaxoFacets: jpg +facets:taxonomy:DayOfYear # freq=322278
+MedTermDayTaxoFacets: issue +facets:taxonomy:DayOfYear # freq=322106
+MedTermDayTaxoFacets: own +facets:taxonomy:DayOfYear # freq=321703
+MedTermDayTaxoFacets: season +facets:taxonomy:DayOfYear # freq=320228
+MedTermDayTaxoFacets: those +facets:taxonomy:DayOfYear # freq=320013
+MedTermDayTaxoFacets: 02 +facets:taxonomy:DayOfYear # freq=319783
+MedTermDayTaxoFacets: uk +facets:taxonomy:DayOfYear # freq=319211
+MedTermDayTaxoFacets: way +facets:taxonomy:DayOfYear # freq=318344
+MedTermDayTaxoFacets: type +facets:taxonomy:DayOfYear # freq=318210
+MedTermDayTaxoFacets: 03 +facets:taxonomy:DayOfYear # freq=318112
+MedTermDayTaxoFacets: england +facets:taxonomy:DayOfYear # freq=317884
+MedTermDayTaxoFacets: much +facets:taxonomy:DayOfYear # freq=317670
+MedTermDayTaxoFacets: off +facets:taxonomy:DayOfYear # freq=315473
+MedTermDayTaxoFacets: game +facets:taxonomy:DayOfYear # freq=315157
+MedTermDayTaxoFacets: background +facets:taxonomy:DayOfYear # freq=314229
+MedTermDayTaxoFacets: 04 +facets:taxonomy:DayOfYear # freq=313827
+MedTermDayTaxoFacets: found +facets:taxonomy:DayOfYear # freq=313247
+MedTermDayTaxoFacets: volume +facets:taxonomy:DayOfYear # freq=312846
+MedTermDayTaxoFacets: named +facets:taxonomy:DayOfYear # freq=310150
+MedTermDayTaxoFacets: service +facets:taxonomy:DayOfYear # freq=309976
+MedTermDayTaxoFacets: d +facets:taxonomy:DayOfYear # freq=309729
+MedTermDayTaxoFacets: st +facets:taxonomy:DayOfYear # freq=309092
+MedTermDayTaxoFacets: large +facets:taxonomy:DayOfYear # freq=308888
+MedTermDayTaxoFacets: often +facets:taxonomy:DayOfYear # freq=307684
+MedTermDayTaxoFacets: 06 +facets:taxonomy:DayOfYear # freq=305698
+MedTermDayTaxoFacets: 05 +facets:taxonomy:DayOfYear # freq=302860
+MedTermDayTaxoFacets: 1998 +facets:taxonomy:DayOfYear # freq=300506
+MedTermDayTaxoFacets: align +facets:taxonomy:DayOfYear # freq=300455
+MedTermDayTaxoFacets: kingdom +facets:taxonomy:DayOfYear # freq=299825
+MedTermDayTaxoFacets: using +facets:taxonomy:DayOfYear # freq=299474
+MedTermDayTaxoFacets: white +facets:taxonomy:DayOfYear # freq=299411
+MedTermDayTaxoFacets: 07 +facets:taxonomy:DayOfYear # freq=299351
+MedTermDayTaxoFacets: district +facets:taxonomy:DayOfYear # freq=299108
+MedTermDayTaxoFacets: local +facets:taxonomy:DayOfYear # freq=299012
+MedTermDayTaxoFacets: metadata +facets:taxonomy:DayOfYear # freq=298533
+MedTermDayTaxoFacets: 31 +facets:taxonomy:DayOfYear # freq=298349
+MedTermDayTaxoFacets: 08 +facets:taxonomy:DayOfYear # freq=297258
+MedTermDayTaxoFacets: 09 +facets:taxonomy:DayOfYear # freq=296300
+MedTermDayTaxoFacets: r +facets:taxonomy:DayOfYear # freq=296283
+MedTermDayTaxoFacets: set +facets:taxonomy:DayOfYear # freq=294255
+MedTermDayTaxoFacets: show +facets:taxonomy:DayOfYear # freq=293934
+MedTermDayTaxoFacets: david +facets:taxonomy:DayOfYear # freq=292847
+MedTermDayTaxoFacets: make +facets:taxonomy:DayOfYear # freq=292607
+MedTermDayTaxoFacets: story +facets:taxonomy:DayOfYear # freq=292404
+MedTermDayTaxoFacets: citation +facets:taxonomy:DayOfYear # freq=291478
+MedTermDayTaxoFacets: within +facets:taxonomy:DayOfYear # freq=291049
+MedTermDayTaxoFacets: due +facets:taxonomy:DayOfYear # freq=290531
+MedTermDayTaxoFacets: link +facets:taxonomy:DayOfYear # freq=287552
+MedTermDayTaxoFacets: 1997 +facets:taxonomy:DayOfYear # freq=286789
+MedTermDayTaxoFacets: members +facets:taxonomy:DayOfYear # freq=286028
+MedTermDayTaxoFacets: william +facets:taxonomy:DayOfYear # freq=284592
+MedTermDayTaxoFacets: along +facets:taxonomy:DayOfYear # freq=284442
+MedTermDayTaxoFacets: v +facets:taxonomy:DayOfYear # freq=284318
+MedTermDayTaxoFacets: located +facets:taxonomy:DayOfYear # freq=283899
+MedTermDayTaxoFacets: single +facets:taxonomy:DayOfYear # freq=283824
+MedTermDayTaxoFacets: per +facets:taxonomy:DayOfYear # freq=283568
+MedTermDayTaxoFacets: established +facets:taxonomy:DayOfYear # freq=282471
+MedTermDayTaxoFacets: james +facets:taxonomy:DayOfYear # freq=281597
+MedTermDayTaxoFacets: needed +facets:taxonomy:DayOfYear # freq=281051
+MedTermDayTaxoFacets: down +facets:taxonomy:DayOfYear # freq=280662
+MedTermDayTaxoFacets: present +facets:taxonomy:DayOfYear # freq=278449
+MedTermDayTaxoFacets: man +facets:taxonomy:DayOfYear # freq=278112
+MedTermDayTaxoFacets: college +facets:taxonomy:DayOfYear # freq=278094
+MedTermDayTaxoFacets: f +facets:taxonomy:DayOfYear # freq=278015
+MedTermDayTaxoFacets: site +facets:taxonomy:DayOfYear # freq=277788
+MedTermDayTaxoFacets: football +facets:taxonomy:DayOfYear # freq=277738
+MedTermDayTaxoFacets: en +facets:taxonomy:DayOfYear # freq=277463
+MedTermDayTaxoFacets: result +facets:taxonomy:DayOfYear # freq=276803
+MedTermDayTaxoFacets: include +facets:taxonomy:DayOfYear # freq=276466
+MedTermDayTaxoFacets: began +facets:taxonomy:DayOfYear # freq=276036
+MedTermDayTaxoFacets: my +facets:taxonomy:DayOfYear # freq=274256
+MedTermDayTaxoFacets: x +facets:taxonomy:DayOfYear # freq=272695
+MedTermDayTaxoFacets: central +facets:taxonomy:DayOfYear # freq=272531
+MedTermDayTaxoFacets: band +facets:taxonomy:DayOfYear # freq=272207
+MedTermDayTaxoFacets: 1996 +facets:taxonomy:DayOfYear # freq=271980
+MedTermDayTaxoFacets: form +facets:taxonomy:DayOfYear # freq=271966
+MedTermDayTaxoFacets: member +facets:taxonomy:DayOfYear # freq=271607
+MedTermDayTaxoFacets: television +facets:taxonomy:DayOfYear # freq=271426
+MedTermDayTaxoFacets: league +facets:taxonomy:DayOfYear # freq=270223
+MedTermDayTaxoFacets: free +facets:taxonomy:DayOfYear # freq=270199
+MedTermDayTaxoFacets: political +facets:taxonomy:DayOfYear # freq=269665
+MedTermDayTaxoFacets: font +facets:taxonomy:DayOfYear # freq=269439
+MedTermDayTaxoFacets: 100 +facets:taxonomy:DayOfYear # freq=268978
+MedTermDayTaxoFacets: convert +facets:taxonomy:DayOfYear # freq=267974
+MedTermDayTaxoFacets: red +facets:taxonomy:DayOfYear # freq=266177
+MedTermDayTaxoFacets: president +facets:taxonomy:DayOfYear # freq=263341
+MedTermDayTaxoFacets: five +facets:taxonomy:DayOfYear # freq=262923
+MedTermDayTaxoFacets: t +facets:taxonomy:DayOfYear # freq=262832
+MedTermDayTaxoFacets: power +facets:taxonomy:DayOfYear # freq=262586
+MedTermDayTaxoFacets: river +facets:taxonomy:DayOfYear # freq=262231
+MedTermDayTaxoFacets: we +facets:taxonomy:DayOfYear # freq=261001
+MedTermDayTaxoFacets: song +facets:taxonomy:DayOfYear # freq=260741
+MedTermDayTaxoFacets: next +facets:taxonomy:DayOfYear # freq=259039
+MedTermDayTaxoFacets: articles +facets:taxonomy:DayOfYear # freq=258949
+MedTermDayTaxoFacets: point +facets:taxonomy:DayOfYear # freq=258471
+MedTermDayTaxoFacets: text +facets:taxonomy:DayOfYear # freq=257803
+MedTermDayTaxoFacets: according +facets:taxonomy:DayOfYear # freq=256949
+MedTermDayTaxoFacets: black +facets:taxonomy:DayOfYear # freq=256526
+MedTermDayTaxoFacets: george +facets:taxonomy:DayOfYear # freq=256196
+MedTermDayTaxoFacets: different +facets:taxonomy:DayOfYear # freq=255951
+MedTermDayTaxoFacets: ndash +facets:taxonomy:DayOfYear # freq=255747
+MedTermDayTaxoFacets: third +facets:taxonomy:DayOfYear # freq=255690
+MedTermDayTaxoFacets: tv +facets:taxonomy:DayOfYear # freq=255429
+MedTermDayTaxoFacets: law +facets:taxonomy:DayOfYear # freq=255248
+MedTermDayTaxoFacets: canada +facets:taxonomy:DayOfYear # freq=254867
+MedTermDayTaxoFacets: near +facets:taxonomy:DayOfYear # freq=254492
+MedTermDayTaxoFacets: built +facets:taxonomy:DayOfYear # freq=254491
+MedTermDayTaxoFacets: 1995 +facets:taxonomy:DayOfYear # freq=252837
+MedTermDayTaxoFacets: how +facets:taxonomy:DayOfYear # freq=252284
+MedTermDayTaxoFacets: record +facets:taxonomy:DayOfYear # freq=250484
+MedTermDayTaxoFacets: french +facets:taxonomy:DayOfYear # freq=250453
+MedTermDayTaxoFacets: air +facets:taxonomy:DayOfYear # freq=250411
+MedTermDayTaxoFacets: king +facets:taxonomy:DayOfYear # freq=250321
+MedTermDayTaxoFacets: without +facets:taxonomy:DayOfYear # freq=249926
+MedTermDayTaxoFacets: though +facets:taxonomy:DayOfYear # freq=248968
+MedTermDayTaxoFacets: played +facets:taxonomy:DayOfYear # freq=248191
+MedTermDayTaxoFacets: park +facets:taxonomy:DayOfYear # freq=247801
+MedTermDayTaxoFacets: took +facets:taxonomy:DayOfYear # freq=247388
+MedTermDayTaxoFacets: association +facets:taxonomy:DayOfYear # freq=247156
+MedTermDayTaxoFacets: military +facets:taxonomy:DayOfYear # freq=246727
+MedTermDayTaxoFacets: robert +facets:taxonomy:DayOfYear # freq=246405
+MedTermDayTaxoFacets: above +facets:taxonomy:DayOfYear # freq=246135
+MedTermDayTaxoFacets: persondata +facets:taxonomy:DayOfYear # freq=246119
+MedTermDayTaxoFacets: career +facets:taxonomy:DayOfYear # freq=245439
+MedTermDayTaxoFacets: version +facets:taxonomy:DayOfYear # freq=244541
+MedTermDayTaxoFacets: again +facets:taxonomy:DayOfYear # freq=244255
+MedTermDayTaxoFacets: late +facets:taxonomy:DayOfYear # freq=243636
+MedTermDayTaxoFacets: published +facets:taxonomy:DayOfYear # freq=243548
+MedTermDayTaxoFacets: live +facets:taxonomy:DayOfYear # freq=242147
+MedTermDayTaxoFacets: h +facets:taxonomy:DayOfYear # freq=241946
+MedTermDayTaxoFacets: good +facets:taxonomy:DayOfYear # freq=241649
+MedTermDayTaxoFacets: player +facets:taxonomy:DayOfYear # freq=241451
+MedTermDayTaxoFacets: others +facets:taxonomy:DayOfYear # freq=240487
+MedTermDayTaxoFacets: america +facets:taxonomy:DayOfYear # freq=240374
+MedTermDayTaxoFacets: review +facets:taxonomy:DayOfYear # freq=240157
+MedTermDayTaxoFacets: station +facets:taxonomy:DayOfYear # freq=239572
+MedTermDayTaxoFacets: among +facets:taxonomy:DayOfYear # freq=238986
+MedTermDayTaxoFacets: section +facets:taxonomy:DayOfYear # freq=238874
+MedTermDayTaxoFacets: border +facets:taxonomy:DayOfYear # freq=238540
+MedTermDayTaxoFacets: your +facets:taxonomy:DayOfYear # freq=237723
+MedTermDayTaxoFacets: size +facets:taxonomy:DayOfYear # freq=237662
+MedTermDayTaxoFacets: births +facets:taxonomy:DayOfYear # freq=237033
+MedTermDayTaxoFacets: support +facets:taxonomy:DayOfYear # freq=236989
+MedTermDayTaxoFacets: german +facets:taxonomy:DayOfYear # freq=236721
+MedTermDayTaxoFacets: california +facets:taxonomy:DayOfYear # freq=236086
+MedTermDayTaxoFacets: given +facets:taxonomy:DayOfYear # freq=235719
+MedTermDayTaxoFacets: commons +facets:taxonomy:DayOfYear # freq=235235
+MedTermDayTaxoFacets: 1994 +facets:taxonomy:DayOfYear # freq=235100
+MedTermDayTaxoFacets: start +facets:taxonomy:DayOfYear # freq=233925
+MedTermDayTaxoFacets: km +facets:taxonomy:DayOfYear # freq=233831
+MedTermDayTaxoFacets: said +facets:taxonomy:DayOfYear # freq=233066
+MedTermDayTaxoFacets: western +facets:taxonomy:DayOfYear # freq=232781
+MedTermDayTaxoFacets: won +facets:taxonomy:DayOfYear # freq=232751
+MedTermDayTaxoFacets: la +facets:taxonomy:DayOfYear # freq=232610
+MedTermDayTaxoFacets: held +facets:taxonomy:DayOfYear # freq=232354
+MedTermDayTaxoFacets: children +facets:taxonomy:DayOfYear # freq=232342
+MedTermDayTaxoFacets: does +facets:taxonomy:DayOfYear # freq=232202
+MedTermDayTaxoFacets: club +facets:taxonomy:DayOfYear # freq=232173
+MedTermDayTaxoFacets: source +facets:taxonomy:DayOfYear # freq=231838
+MedTermDayTaxoFacets: church +facets:taxonomy:DayOfYear # freq=231667
+MedTermDayTaxoFacets: format +facets:taxonomy:DayOfYear # freq=231300
+MedTermDayTaxoFacets: example +facets:taxonomy:DayOfYear # freq=230457
+MedTermDayTaxoFacets: development +facets:taxonomy:DayOfYear # freq=230286
+MedTermDayTaxoFacets: land +facets:taxonomy:DayOfYear # freq=230284
+MedTermDayTaxoFacets: total +facets:taxonomy:DayOfYear # freq=230013
+MedTermDayTaxoFacets: final +facets:taxonomy:DayOfYear # freq=230006
+MedTermDayTaxoFacets: 50 +facets:taxonomy:DayOfYear # freq=229614
+MedTermDayTaxoFacets: please +facets:taxonomy:DayOfYear # freq=229602
+MedTermDayTaxoFacets: region +facets:taxonomy:DayOfYear # freq=229561
+MedTermDayTaxoFacets: here +facets:taxonomy:DayOfYear # freq=229505
+MedTermDayTaxoFacets: me +facets:taxonomy:DayOfYear # freq=229204
+MedTermDayTaxoFacets: caption +facets:taxonomy:DayOfYear # freq=229172
+MedTermDayTaxoFacets: must +facets:taxonomy:DayOfYear # freq=228491
+MedTermDayTaxoFacets: army +facets:taxonomy:DayOfYear # freq=228105
+MedTermDayTaxoFacets: l +facets:taxonomy:DayOfYear # freq=227974
+MedTermDayTaxoFacets: side +facets:taxonomy:DayOfYear # freq=227747
+MedTermDayTaxoFacets: society +facets:taxonomy:DayOfYear # freq=226742
+MedTermDayTaxoFacets: full +facets:taxonomy:DayOfYear # freq=226457
+MedTermDayTaxoFacets: few +facets:taxonomy:DayOfYear # freq=226422
+MedTermDayTaxoFacets: records +facets:taxonomy:DayOfYear # freq=225886
+MedTermDayTaxoFacets: below +facets:taxonomy:DayOfYear # freq=225843
+MedTermDayTaxoFacets: community +facets:taxonomy:DayOfYear # freq=225571
+MedTermDayTaxoFacets: office +facets:taxonomy:DayOfYear # freq=225338
+MedTermDayTaxoFacets: 1992 +facets:taxonomy:DayOfYear # freq=225200
+MedTermDayTaxoFacets: road +facets:taxonomy:DayOfYear # freq=225050
+MedTermDayTaxoFacets: research +facets:taxonomy:DayOfYear # freq=224925
+MedTermDayTaxoFacets: various +facets:taxonomy:DayOfYear # freq=224593
+MedTermDayTaxoFacets: take +facets:taxonomy:DayOfYear # freq=224260
+MedTermDayTaxoFacets: wikipedia:persondata +facets:taxonomy:DayOfYear # freq=222385
+MedTermDayTaxoFacets: 1990 +facets:taxonomy:DayOfYear # freq=222154
+MedTermDayTaxoFacets: 40 +facets:taxonomy:DayOfYear # freq=221687
+MedTermDayTaxoFacets: created +facets:taxonomy:DayOfYear # freq=220831
+MedTermDayTaxoFacets: 1993 +facets:taxonomy:DayOfYear # freq=220776
+MedTermDayTaxoFacets: france +facets:taxonomy:DayOfYear # freq=220058
+MedTermDayTaxoFacets: science +facets:taxonomy:DayOfYear # freq=219988
+MedTermDayTaxoFacets: every +facets:taxonomy:DayOfYear # freq=219884
+MedTermDayTaxoFacets: become +facets:taxonomy:DayOfYear # freq=219753
+MedTermDayTaxoFacets: modern +facets:taxonomy:DayOfYear # freq=218831
+MedTermDayTaxoFacets: post +facets:taxonomy:DayOfYear # freq=218570
+MedTermDayTaxoFacets: games +facets:taxonomy:DayOfYear # freq=218434
+MedTermDayTaxoFacets: michael +facets:taxonomy:DayOfYear # freq=217311
+MedTermDayTaxoFacets: current +facets:taxonomy:DayOfYear # freq=217174
+MedTermDayTaxoFacets: included +facets:taxonomy:DayOfYear # freq=216978
+MedTermDayTaxoFacets: ja +facets:taxonomy:DayOfYear # freq=216549
+MedTermDayTaxoFacets: magazine +facets:taxonomy:DayOfYear # freq=215725
+MedTermDayTaxoFacets: position +facets:taxonomy:DayOfYear # freq=215493
+MedTermDayTaxoFacets: australia +facets:taxonomy:DayOfYear # freq=215391
+MedTermDayTaxoFacets: archive +facets:taxonomy:DayOfYear # freq=215381
+MedTermDayTaxoFacets: union +facets:taxonomy:DayOfYear # freq=214164
+MedTermDayTaxoFacets: having +facets:taxonomy:DayOfYear # freq=213416
+MedTermDayTaxoFacets: g +facets:taxonomy:DayOfYear # freq=212936
+MedTermDayTaxoFacets: popular +facets:taxonomy:DayOfYear # freq=212493
+MedTermDayTaxoFacets: royal +facets:taxonomy:DayOfYear # freq=211710
+MedTermDayTaxoFacets: period +facets:taxonomy:DayOfYear # freq=211690
+MedTermDayTaxoFacets: little +facets:taxonomy:DayOfYear # freq=211124
+MedTermDayTaxoFacets: wikitable +facets:taxonomy:DayOfYear # freq=210990
+MedTermDayTaxoFacets: rock +facets:taxonomy:DayOfYear # freq=210815
+MedTermDayTaxoFacets: artist +facets:taxonomy:DayOfYear # freq=210591
+MedTermDayTaxoFacets: play +facets:taxonomy:DayOfYear # freq=210199
+MedTermDayTaxoFacets: led +facets:taxonomy:DayOfYear # freq=210033
+MedTermDayTaxoFacets: notes +facets:taxonomy:DayOfYear # freq=210029
+MedTermDayTaxoFacets: water +facets:taxonomy:DayOfYear # freq=209444
+MedTermDayTaxoFacets: business +facets:taxonomy:DayOfYear # freq=209353
+MedTermDayTaxoFacets: art +facets:taxonomy:DayOfYear # freq=209322
+MedTermDayTaxoFacets: common +facets:taxonomy:DayOfYear # freq=209310
+MedTermDayTaxoFacets: co +facets:taxonomy:DayOfYear # freq=209086
+MedTermDayTaxoFacets: education +facets:taxonomy:DayOfYear # freq=208909
+MedTermDayTaxoFacets: role +facets:taxonomy:DayOfYear # freq=208579
+MedTermDayTaxoFacets: 1991 +facets:taxonomy:DayOfYear # freq=207589
+MedTermDayTaxoFacets: case +facets:taxonomy:DayOfYear # freq=207307
+MedTermDayTaxoFacets: paul +facets:taxonomy:DayOfYear # freq=207229
+MedTermDayTaxoFacets: media +facets:taxonomy:DayOfYear # freq=206574
+MedTermDayTaxoFacets: div +facets:taxonomy:DayOfYear # freq=206057
+MedTermDayTaxoFacets: census +facets:taxonomy:DayOfYear # freq=205166
+MedTermDayTaxoFacets: charles +facets:taxonomy:DayOfYear # freq=204987
+MedTermDayTaxoFacets: written +facets:taxonomy:DayOfYear # freq=204891
+MedTermDayTaxoFacets: pp +facets:taxonomy:DayOfYear # freq=204742
+MedTermDayTaxoFacets: green +facets:taxonomy:DayOfYear # freq=203371
+MedTermDayTaxoFacets: island +facets:taxonomy:DayOfYear # freq=203023
+MedTermDayTaxoFacets: never +facets:taxonomy:DayOfYear # freq=203017
+MedTermDayTaxoFacets: making +facets:taxonomy:DayOfYear # freq=203003
+MedTermDayTaxoFacets: term +facets:taxonomy:DayOfYear # freq=202691
+MedTermDayTaxoFacets: video +facets:taxonomy:DayOfYear # freq=202380
+MedTermDayTaxoFacets: son +facets:taxonomy:DayOfYear # freq=202340
+MedTermDayTaxoFacets: discussion +facets:taxonomy:DayOfYear # freq=202145
+MedTermDayTaxoFacets: died +facets:taxonomy:DayOfYear # freq=202125
+MedTermDayTaxoFacets: view +facets:taxonomy:DayOfYear # freq=201593
+MedTermDayTaxoFacets: street +facets:taxonomy:DayOfYear # freq=200985
+MedTermDayTaxoFacets: council +facets:taxonomy:DayOfYear # freq=200706
+MedTermDayTaxoFacets: re +facets:taxonomy:DayOfYear # freq=199632
+MedTermDayTaxoFacets: award +facets:taxonomy:DayOfYear # freq=199318
+MedTermDayTaxoFacets: works +facets:taxonomy:DayOfYear # freq=199177
+MedTermDayTaxoFacets: special +facets:taxonomy:DayOfYear # freq=198917
+MedTermDayTaxoFacets: force +facets:taxonomy:DayOfYear # freq=198556
+MedTermDayTaxoFacets: six +facets:taxonomy:DayOfYear # freq=197970
+MedTermDayTaxoFacets: came +facets:taxonomy:DayOfYear # freq=197126
+MedTermDayTaxoFacets: building +facets:taxonomy:DayOfYear # freq=196508
+MedTermDayTaxoFacets: young +facets:taxonomy:DayOfYear # freq=196428
+MedTermDayTaxoFacets: together +facets:taxonomy:DayOfYear # freq=195949
+MedTermDayTaxoFacets: important +facets:taxonomy:DayOfYear # freq=195851
+MedTermDayTaxoFacets: star +facets:taxonomy:DayOfYear # freq=195768
+MedTermDayTaxoFacets: similar +facets:taxonomy:DayOfYear # freq=195171
+MedTermDayTaxoFacets: received +facets:taxonomy:DayOfYear # freq=194983
+MedTermDayTaxoFacets: sup +facets:taxonomy:DayOfYear # freq=194723
+MedTermDayTaxoFacets: head +facets:taxonomy:DayOfYear # freq=194682
+AndHighHighDayTaxoFacets: +of +s +facets:taxonomy:DayOfYear # freq=8184358 freq=1581243
+AndHighHighDayTaxoFacets: +date +he +facets:taxonomy:DayOfYear # freq=2020626 freq=1659434
+AndHighHighDayTaxoFacets: +cite +2005 +facets:taxonomy:DayOfYear # freq=1741194 freq=835460
+AndHighHighDayTaxoFacets: +i +10 +facets:taxonomy:DayOfYear # freq=956148 freq=918339
+AndHighHighDayTaxoFacets: +date +2009 +facets:taxonomy:DayOfYear # freq=2020626 freq=887702
+AndHighHighDayTaxoFacets: +for +cite +facets:taxonomy:DayOfYear # freq=4380011 freq=1741194
+AndHighHighDayTaxoFacets: +as +its +facets:taxonomy:DayOfYear # freq=3925535 freq=1173450
+AndHighHighDayTaxoFacets: +which +2011 +facets:taxonomy:DayOfYear # freq=1963428 freq=871410
+AndHighHighDayTaxoFacets: +have +see +facets:taxonomy:DayOfYear # freq=1297121 freq=1044180
+AndHighHighDayTaxoFacets: +first +accessdate +facets:taxonomy:DayOfYear # freq=1933372 freq=1228887
+AndHighHighDayTaxoFacets: +also +no +facets:taxonomy:DayOfYear # freq=1959419 freq=1045000
+AndHighHighDayTaxoFacets: +first +new +facets:taxonomy:DayOfYear # freq=1933372 freq=1657293
+AndHighHighDayTaxoFacets: +publisher +web +facets:taxonomy:DayOfYear # freq=1289029 freq=1118334
+AndHighHighDayTaxoFacets: +states +work +facets:taxonomy:DayOfYear # freq=1034872 freq=853422
+AndHighHighDayTaxoFacets: +more +work +facets:taxonomy:DayOfYear # freq=963533 freq=853422
+AndHighHighDayTaxoFacets: +1 +their +facets:taxonomy:DayOfYear # freq=1641090 freq=1158682
+AndHighHighDayTaxoFacets: +http +an +facets:taxonomy:DayOfYear # freq=3493581 freq=2628056
+AndHighHighDayTaxoFacets: +year +5 +facets:taxonomy:DayOfYear # freq=1235231 freq=891361
+AndHighHighDayTaxoFacets: +4 +there +facets:taxonomy:DayOfYear # freq=986452 freq=956153
+AndHighHighDayTaxoFacets: +s +who +facets:taxonomy:DayOfYear # freq=1581243 freq=1196171
+AndHighHighDayTaxoFacets: +who +may +facets:taxonomy:DayOfYear # freq=1196171 freq=1071932
+AndHighHighDayTaxoFacets: +united +time +facets:taxonomy:DayOfYear # freq=1196944 freq=1032071
+AndHighHighDayTaxoFacets: +other +no +facets:taxonomy:DayOfYear # freq=1269961 freq=1045000
+AndHighHighDayTaxoFacets: +time +when +facets:taxonomy:DayOfYear # freq=1032071 freq=1027487
+AndHighHighDayTaxoFacets: +that +cite +facets:taxonomy:DayOfYear # freq=2931020 freq=1741194
+AndHighHighDayTaxoFacets: +to +its +facets:taxonomy:DayOfYear # freq=6155577 freq=1173450
+AndHighHighDayTaxoFacets: +2011 +2008 +facets:taxonomy:DayOfYear # freq=871410 freq=831253
+AndHighHighDayTaxoFacets: +been +2005 +facets:taxonomy:DayOfYear # freq=1041183 freq=835460
+AndHighHighDayTaxoFacets: +1 +year +facets:taxonomy:DayOfYear # freq=1641090 freq=1235231
+AndHighHighDayTaxoFacets: +was +more +facets:taxonomy:DayOfYear # freq=3763623 freq=963533
+AndHighHighDayTaxoFacets: +3 +2005 +facets:taxonomy:DayOfYear # freq=1148799 freq=835460
+AndHighHighDayTaxoFacets: +a +they +facets:taxonomy:DayOfYear # freq=6560531 freq=1021945
+AndHighHighDayTaxoFacets: +s +time +facets:taxonomy:DayOfYear # freq=1581243 freq=1032071
+AndHighHighDayTaxoFacets: +in +2011 +facets:taxonomy:DayOfYear # freq=7320987 freq=871410
+AndHighHighDayTaxoFacets: +a +work +facets:taxonomy:DayOfYear # freq=6560531 freq=853422
+AndHighHighDayTaxoFacets: +they +4 +facets:taxonomy:DayOfYear # freq=1021945 freq=986452
+AndHighHighDayTaxoFacets: +and +2 +facets:taxonomy:DayOfYear # freq=7318061 freq=1549245
+AndHighHighDayTaxoFacets: +to +an +facets:taxonomy:DayOfYear # freq=6155577 freq=2628056
+AndHighHighDayTaxoFacets: +an +which +facets:taxonomy:DayOfYear # freq=2628056 freq=1963428
+AndHighHighDayTaxoFacets: +was +also +facets:taxonomy:DayOfYear # freq=3763623 freq=1959419
+AndHighHighDayTaxoFacets: +this +see +facets:taxonomy:DayOfYear # freq=2224932 freq=1044180
+AndHighHighDayTaxoFacets: +all +2010 +facets:taxonomy:DayOfYear # freq=1203572 freq=950573
+AndHighHighDayTaxoFacets: +2 +2010 +facets:taxonomy:DayOfYear # freq=1549245 freq=950573
+AndHighHighDayTaxoFacets: +first +work +facets:taxonomy:DayOfYear # freq=1933372 freq=853422
+AndHighHighDayTaxoFacets: +he +10 +facets:taxonomy:DayOfYear # freq=1659434 freq=918339
+AndHighHighDayTaxoFacets: +http +that +facets:taxonomy:DayOfYear # freq=3493581 freq=2931020
+AndHighHighDayTaxoFacets: +new +2011 +facets:taxonomy:DayOfYear # freq=1657293 freq=871410
+AndHighHighDayTaxoFacets: +as +by +facets:taxonomy:DayOfYear # freq=3925535 freq=3826691
+AndHighHighDayTaxoFacets: +there +2008 +facets:taxonomy:DayOfYear # freq=956153 freq=831253
+AndHighHighDayTaxoFacets: +is +they +facets:taxonomy:DayOfYear # freq=4074455 freq=1021945
+AndHighHighDayTaxoFacets: +2010 +2011 +facets:taxonomy:DayOfYear # freq=950573 freq=871410
+AndHighHighDayTaxoFacets: +accessdate +2005 +facets:taxonomy:DayOfYear # freq=1228887 freq=835460
+AndHighHighDayTaxoFacets: +at +this +facets:taxonomy:DayOfYear # freq=2857534 freq=2224932
+AndHighHighDayTaxoFacets: +as +some +facets:taxonomy:DayOfYear # freq=3925535 freq=839919
+AndHighHighDayTaxoFacets: +after +all +facets:taxonomy:DayOfYear # freq=1247398 freq=1203572
+AndHighHighDayTaxoFacets: +year +they +facets:taxonomy:DayOfYear # freq=1235231 freq=1021945
+AndHighHighDayTaxoFacets: +1 +accessdate +facets:taxonomy:DayOfYear # freq=1641090 freq=1228887
+AndHighHighDayTaxoFacets: +on +web +facets:taxonomy:DayOfYear # freq=4074624 freq=1118334
+AndHighHighDayTaxoFacets: +first +5 +facets:taxonomy:DayOfYear # freq=1933372 freq=891361
+AndHighHighDayTaxoFacets: +he +but +facets:taxonomy:DayOfYear # freq=1659434 freq=1456553
+AndHighHighDayTaxoFacets: +title +when +facets:taxonomy:DayOfYear # freq=2397378 freq=1027487
+AndHighHighDayTaxoFacets: +who +two +facets:taxonomy:DayOfYear # freq=1196171 freq=1104053
+AndHighHighDayTaxoFacets: +last +2006 +facets:taxonomy:DayOfYear # freq=958437 freq=889954
+AndHighHighDayTaxoFacets: +from +name +facets:taxonomy:DayOfYear # freq=3224339 freq=2827713
+AndHighHighDayTaxoFacets: +new +i +facets:taxonomy:DayOfYear # freq=1657293 freq=956148
+AndHighHighDayTaxoFacets: +was +publisher +facets:taxonomy:DayOfYear # freq=3763623 freq=1289029
+AndHighHighDayTaxoFacets: +and +not +facets:taxonomy:DayOfYear # freq=7318061 freq=1713264
+AndHighHighDayTaxoFacets: +is +their +facets:taxonomy:DayOfYear # freq=4074455 freq=1158682
+AndHighHighDayTaxoFacets: +ref +that +facets:taxonomy:DayOfYear # freq=3793973 freq=2931020
+AndHighHighDayTaxoFacets: +of +for +facets:taxonomy:DayOfYear # freq=8184358 freq=4380011
+AndHighHighDayTaxoFacets: +name +which +facets:taxonomy:DayOfYear # freq=2827713 freq=1963428
+AndHighHighDayTaxoFacets: +after +2008 +facets:taxonomy:DayOfYear # freq=1247398 freq=831253
+AndHighHighDayTaxoFacets: +that +an +facets:taxonomy:DayOfYear # freq=2931020 freq=2628056
+AndHighHighDayTaxoFacets: +by +2006 +facets:taxonomy:DayOfYear # freq=3826691 freq=889954
+AndHighHighDayTaxoFacets: +that +or +facets:taxonomy:DayOfYear # freq=2931020 freq=1858841
+AndHighHighDayTaxoFacets: +be +which +facets:taxonomy:DayOfYear # freq=2051702 freq=1963428
+AndHighHighDayTaxoFacets: +with +2010 +facets:taxonomy:DayOfYear # freq=3709421 freq=950573
+AndHighHighDayTaxoFacets: +by +with +facets:taxonomy:DayOfYear # freq=3826691 freq=3709421
+AndHighHighDayTaxoFacets: +by +4 +facets:taxonomy:DayOfYear # freq=3826691 freq=986452
+AndHighHighDayTaxoFacets: +was +cite +facets:taxonomy:DayOfYear # freq=3763623 freq=1741194
+AndHighHighDayTaxoFacets: +was +they +facets:taxonomy:DayOfYear # freq=3763623 freq=1021945
+AndHighHighDayTaxoFacets: +on +was +facets:taxonomy:DayOfYear # freq=4074624 freq=3763623
+AndHighHighDayTaxoFacets: +is +time +facets:taxonomy:DayOfYear # freq=4074455 freq=1032071
+AndHighHighDayTaxoFacets: +the +be +facets:taxonomy:DayOfYear # freq=8217362 freq=2051702
+AndHighHighDayTaxoFacets: +were +2010 +facets:taxonomy:DayOfYear # freq=1524630 freq=950573
+AndHighHighDayTaxoFacets: +they +2006 +facets:taxonomy:DayOfYear # freq=1021945 freq=889954
+AndHighHighDayTaxoFacets: +he +may +facets:taxonomy:DayOfYear # freq=1659434 freq=1071932
+AndHighHighDayTaxoFacets: +an +title +facets:taxonomy:DayOfYear # freq=2628056 freq=2397378
+AndHighHighDayTaxoFacets: +into +some +facets:taxonomy:DayOfYear # freq=888684 freq=839919
+AndHighHighDayTaxoFacets: +first +some +facets:taxonomy:DayOfYear # freq=1933372 freq=839919
+AndHighHighDayTaxoFacets: +name +new +facets:taxonomy:DayOfYear # freq=2827713 freq=1657293
+AndHighHighDayTaxoFacets: +cite +3 +facets:taxonomy:DayOfYear # freq=1741194 freq=1148799
+AndHighHighDayTaxoFacets: +to +web +facets:taxonomy:DayOfYear # freq=6155577 freq=1118334
+AndHighHighDayTaxoFacets: +for +it +facets:taxonomy:DayOfYear # freq=4380011 freq=2675552
+AndHighHighDayTaxoFacets: +year +there +facets:taxonomy:DayOfYear # freq=1235231 freq=956153
+AndHighHighDayTaxoFacets: +but +been +facets:taxonomy:DayOfYear # freq=1456553 freq=1041183
+AndHighHighDayTaxoFacets: +this +who +facets:taxonomy:DayOfYear # freq=2224932 freq=1196171
+AndHighHighDayTaxoFacets: +ref +web +facets:taxonomy:DayOfYear # freq=3793973 freq=1118334
+AndHighHighDayTaxoFacets: +cite +2011 +facets:taxonomy:DayOfYear # freq=1741194 freq=871410
+AndHighHighDayTaxoFacets: +by +he +facets:taxonomy:DayOfYear # freq=3826691 freq=1659434
+AndHighHighDayTaxoFacets: +name +first +facets:taxonomy:DayOfYear # freq=2827713 freq=1933372
+AndHighHighDayTaxoFacets: +has +about +facets:taxonomy:DayOfYear # freq=1502961 freq=850283
+AndHighHighDayTaxoFacets: +were +two +facets:taxonomy:DayOfYear # freq=1524630 freq=1104053
+AndHighHighDayTaxoFacets: +two +work +facets:taxonomy:DayOfYear # freq=1104053 freq=853422
+AndHighHighDayTaxoFacets: +he +been +facets:taxonomy:DayOfYear # freq=1659434 freq=1041183
+AndHighHighDayTaxoFacets: +from +2 +facets:taxonomy:DayOfYear # freq=3224339 freq=1549245
+AndHighHighDayTaxoFacets: +all +some +facets:taxonomy:DayOfYear # freq=1203572 freq=839919
+AndHighHighDayTaxoFacets: +on +only +facets:taxonomy:DayOfYear # freq=4074624 freq=875561
+AndHighHighDayTaxoFacets: +was +no +facets:taxonomy:DayOfYear # freq=3763623 freq=1045000
+AndHighHighDayTaxoFacets: +name +see +facets:taxonomy:DayOfYear # freq=2827713 freq=1044180
+AndHighHighDayTaxoFacets: +of +as +facets:taxonomy:DayOfYear # freq=8184358 freq=3925535
+AndHighHighDayTaxoFacets: +be +has +facets:taxonomy:DayOfYear # freq=2051702 freq=1502961
+AndHighHighDayTaxoFacets: +url +into +facets:taxonomy:DayOfYear # freq=1513595 freq=888684
+AndHighHighDayTaxoFacets: +of +2006 +facets:taxonomy:DayOfYear # freq=8184358 freq=889954
+AndHighHighDayTaxoFacets: +ref +or +facets:taxonomy:DayOfYear # freq=3793973 freq=1858841
+AndHighHighDayTaxoFacets: +by +url +facets:taxonomy:DayOfYear # freq=3826691 freq=1513595
+AndHighHighDayTaxoFacets: +3 +into +facets:taxonomy:DayOfYear # freq=1148799 freq=888684
+AndHighHighDayTaxoFacets: +which +year +facets:taxonomy:DayOfYear # freq=1963428 freq=1235231
+AndHighHighDayTaxoFacets: +at +only +facets:taxonomy:DayOfYear # freq=2857534 freq=875561
+AndHighHighDayTaxoFacets: +http +publisher +facets:taxonomy:DayOfYear # freq=3493581 freq=1289029
+AndHighHighDayTaxoFacets: +with +accessdate +facets:taxonomy:DayOfYear # freq=3709421 freq=1228887
+AndHighHighDayTaxoFacets: +had +work +facets:taxonomy:DayOfYear # freq=1246743 freq=853422
+AndHighHighDayTaxoFacets: +as +they +facets:taxonomy:DayOfYear # freq=3925535 freq=1021945
+AndHighHighDayTaxoFacets: +the +2009 +facets:taxonomy:DayOfYear # freq=8217362 freq=887702
+AndHighHighDayTaxoFacets: +are +but +facets:taxonomy:DayOfYear # freq=1877802 freq=1456553
+AndHighHighDayTaxoFacets: +other +10 +facets:taxonomy:DayOfYear # freq=1269961 freq=918339
+AndHighHighDayTaxoFacets: +two +they +facets:taxonomy:DayOfYear # freq=1104053 freq=1021945
+AndHighHighDayTaxoFacets: +all +they +facets:taxonomy:DayOfYear # freq=1203572 freq=1021945
+AndHighHighDayTaxoFacets: +2011 +about +facets:taxonomy:DayOfYear # freq=871410 freq=850283
+AndHighHighDayTaxoFacets: +name +states +facets:taxonomy:DayOfYear # freq=2827713 freq=1034872
+AndHighHighDayTaxoFacets: +were +may +facets:taxonomy:DayOfYear # freq=1524630 freq=1071932
+AndHighHighDayTaxoFacets: +the +into +facets:taxonomy:DayOfYear # freq=8217362 freq=888684
+AndHighHighDayTaxoFacets: +new +united +facets:taxonomy:DayOfYear # freq=1657293 freq=1196944
+AndHighHighDayTaxoFacets: +their +only +facets:taxonomy:DayOfYear # freq=1158682 freq=875561
+AndHighHighDayTaxoFacets: +be +10 +facets:taxonomy:DayOfYear # freq=2051702 freq=918339
+AndHighHighDayTaxoFacets: +that +not +facets:taxonomy:DayOfYear # freq=2931020 freq=1713264
+AndHighHighDayTaxoFacets: +title +all +facets:taxonomy:DayOfYear # freq=2397378 freq=1203572
+AndHighHighDayTaxoFacets: +with +have +facets:taxonomy:DayOfYear # freq=3709421 freq=1297121
+AndHighHighDayTaxoFacets: +as +been +facets:taxonomy:DayOfYear # freq=3925535 freq=1041183
+AndHighHighDayTaxoFacets: +it +more +facets:taxonomy:DayOfYear # freq=2675552 freq=963533
+AndHighHighDayTaxoFacets: +all +united +facets:taxonomy:DayOfYear # freq=1203572 freq=1196944
+AndHighHighDayTaxoFacets: +other +two +facets:taxonomy:DayOfYear # freq=1269961 freq=1104053
+AndHighHighDayTaxoFacets: +he +url +facets:taxonomy:DayOfYear # freq=1659434 freq=1513595
+AndHighHighDayTaxoFacets: +to +3 +facets:taxonomy:DayOfYear # freq=6155577 freq=1148799
+AndHighHighDayTaxoFacets: +in +from +facets:taxonomy:DayOfYear # freq=7320987 freq=3224339
+AndHighHighDayTaxoFacets: +not +there +facets:taxonomy:DayOfYear # freq=1713264 freq=956153
+AndHighHighDayTaxoFacets: +other +see +facets:taxonomy:DayOfYear # freq=1269961 freq=1044180
+AndHighHighDayTaxoFacets: +its +i +facets:taxonomy:DayOfYear # freq=1173450 freq=956148
+AndHighHighDayTaxoFacets: +as +2008 +facets:taxonomy:DayOfYear # freq=3925535 freq=831253
+AndHighHighDayTaxoFacets: +http +s +facets:taxonomy:DayOfYear # freq=3493581 freq=1581243
+AndHighHighDayTaxoFacets: +or +web +facets:taxonomy:DayOfYear # freq=1858841 freq=1118334
+AndHighHighDayTaxoFacets: +new +publisher +facets:taxonomy:DayOfYear # freq=1657293 freq=1289029
+AndHighHighDayTaxoFacets: +of +who +facets:taxonomy:DayOfYear # freq=8184358 freq=1196171
+AndHighHighDayTaxoFacets: +10 +2009 +facets:taxonomy:DayOfYear # freq=918339 freq=887702
+AndHighHighDayTaxoFacets: +that +he +facets:taxonomy:DayOfYear # freq=2931020 freq=1659434
+AndHighHighDayTaxoFacets: +url +2005 +facets:taxonomy:DayOfYear # freq=1513595 freq=835460
+AndHighHighDayTaxoFacets: +the +a +facets:taxonomy:DayOfYear # freq=8217362 freq=6560531
+AndHighHighDayTaxoFacets: +more +there +facets:taxonomy:DayOfYear # freq=963533 freq=956153
+AndHighHighDayTaxoFacets: +and +an +facets:taxonomy:DayOfYear # freq=7318061 freq=2628056
+AndHighHighDayTaxoFacets: +with +they +facets:taxonomy:DayOfYear # freq=3709421 freq=1021945
+AndHighHighDayTaxoFacets: +title +time +facets:taxonomy:DayOfYear # freq=2397378 freq=1032071
+AndHighHighDayTaxoFacets: +states +4 +facets:taxonomy:DayOfYear # freq=1034872 freq=986452
+AndHighHighDayTaxoFacets: +united +when +facets:taxonomy:DayOfYear # freq=1196944 freq=1027487
+AndHighHighDayTaxoFacets: +is +title +facets:taxonomy:DayOfYear # freq=4074455 freq=2397378
+AndHighHighDayTaxoFacets: +from +who +facets:taxonomy:DayOfYear # freq=3224339 freq=1196171
+AndHighHighDayTaxoFacets: +more +some +facets:taxonomy:DayOfYear # freq=963533 freq=839919
+AndHighHighDayTaxoFacets: +title +year +facets:taxonomy:DayOfYear # freq=2397378 freq=1235231
+AndHighHighDayTaxoFacets: +one +after +facets:taxonomy:DayOfYear # freq=1527689 freq=1247398
+AndHighHighDayTaxoFacets: +with +title +facets:taxonomy:DayOfYear # freq=3709421 freq=2397378
+AndHighHighDayTaxoFacets: +in +first +facets:taxonomy:DayOfYear # freq=7320987 freq=1933372
+AndHighHighDayTaxoFacets: +are +i +facets:taxonomy:DayOfYear # freq=1877802 freq=956148
+AndHighHighDayTaxoFacets: +the +two +facets:taxonomy:DayOfYear # freq=8217362 freq=1104053
+AndHighHighDayTaxoFacets: +but +there +facets:taxonomy:DayOfYear # freq=1456553 freq=956153
+AndHighHighDayTaxoFacets: +from +all +facets:taxonomy:DayOfYear # freq=3224339 freq=1203572
+AndHighHighDayTaxoFacets: +2 +more +facets:taxonomy:DayOfYear # freq=1549245 freq=963533
+AndHighHighDayTaxoFacets: +had +its +facets:taxonomy:DayOfYear # freq=1246743 freq=1173450
+AndHighHighDayTaxoFacets: +in +no +facets:taxonomy:DayOfYear # freq=7320987 freq=1045000
+AndHighHighDayTaxoFacets: +other +more +facets:taxonomy:DayOfYear # freq=1269961 freq=963533
+AndHighHighDayTaxoFacets: +his +united +facets:taxonomy:DayOfYear # freq=1777780 freq=1196944
+AndHighHighDayTaxoFacets: +more +last +facets:taxonomy:DayOfYear # freq=963533 freq=958437
+AndHighHighDayTaxoFacets: +ref +more +facets:taxonomy:DayOfYear # freq=3793973 freq=963533
+AndHighHighDayTaxoFacets: +ref +been +facets:taxonomy:DayOfYear # freq=3793973 freq=1041183
+AndHighHighDayTaxoFacets: +cite +time +facets:taxonomy:DayOfYear # freq=1741194 freq=1032071
+AndHighHighDayTaxoFacets: +http +3 +facets:taxonomy:DayOfYear # freq=3493581 freq=1148799
+AndHighHighDayTaxoFacets: +has +they +facets:taxonomy:DayOfYear # freq=1502961 freq=1021945
+AndHighHighDayTaxoFacets: +and +2011 +facets:taxonomy:DayOfYear # freq=7318061 freq=871410
+AndHighHighDayTaxoFacets: +be +accessdate +facets:taxonomy:DayOfYear # freq=2051702 freq=1228887
+AndHighHighDayTaxoFacets: +are +2010 +facets:taxonomy:DayOfYear # freq=1877802 freq=950573
+AndHighHighDayTaxoFacets: +at +2009 +facets:taxonomy:DayOfYear # freq=2857534 freq=887702
+AndHighHighDayTaxoFacets: +also +united +facets:taxonomy:DayOfYear # freq=1959419 freq=1196944
+AndHighHighDayTaxoFacets: +united +been +facets:taxonomy:DayOfYear # freq=1196944 freq=1041183
+AndHighHighDayTaxoFacets: +also +1 +facets:taxonomy:DayOfYear # freq=1959419 freq=1641090
+AndHighHighDayTaxoFacets: +he +last +facets:taxonomy:DayOfYear # freq=1659434 freq=958437
+AndHighHighDayTaxoFacets: +was +from +facets:taxonomy:DayOfYear # freq=3763623 freq=3224339
+AndHighHighDayTaxoFacets: +ref +when +facets:taxonomy:DayOfYear # freq=3793973 freq=1027487
+AndHighHighDayTaxoFacets: +not +they +facets:taxonomy:DayOfYear # freq=1713264 freq=1021945
+AndHighHighDayTaxoFacets: +the +other +facets:taxonomy:DayOfYear # freq=8217362 freq=1269961
+AndHighHighDayTaxoFacets: +cite +work +facets:taxonomy:DayOfYear # freq=1741194 freq=853422
+AndHighHighDayTaxoFacets: +was +were +facets:taxonomy:DayOfYear # freq=3763623 freq=1524630
+AndHighHighDayTaxoFacets: +in +after +facets:taxonomy:DayOfYear # freq=7320987 freq=1247398
+AndHighHighDayTaxoFacets: +and +first +facets:taxonomy:DayOfYear # freq=7318061 freq=1933372
+AndHighHighDayTaxoFacets: +have +their +facets:taxonomy:DayOfYear # freq=1297121 freq=1158682
+AndHighHighDayTaxoFacets: +also +4 +facets:taxonomy:DayOfYear # freq=1959419 freq=986452
+AndHighHighDayTaxoFacets: +he +2006 +facets:taxonomy:DayOfYear # freq=1659434 freq=889954
+AndHighHighDayTaxoFacets: +may +time +facets:taxonomy:DayOfYear # freq=1071932 freq=1032071
+AndHighHighDayTaxoFacets: +is +url +facets:taxonomy:DayOfYear # freq=4074455 freq=1513595
+AndHighHighDayTaxoFacets: +for +has +facets:taxonomy:DayOfYear # freq=4380011 freq=1502961
+AndHighHighDayTaxoFacets: +and +be +facets:taxonomy:DayOfYear # freq=7318061 freq=2051702
+AndHighHighDayTaxoFacets: +url +had +facets:taxonomy:DayOfYear # freq=1513595 freq=1246743
+AndHighHighDayTaxoFacets: +his +5 +facets:taxonomy:DayOfYear # freq=1777780 freq=891361
+AndHighHighDayTaxoFacets: +on +he +facets:taxonomy:DayOfYear # freq=4074624 freq=1659434
+AndHighHighDayTaxoFacets: +this +first +facets:taxonomy:DayOfYear # freq=2224932 freq=1933372
+AndHighHighDayTaxoFacets: +new +its +facets:taxonomy:DayOfYear # freq=1657293 freq=1173450
+AndHighHighDayTaxoFacets: +s +2009 +facets:taxonomy:DayOfYear # freq=1581243 freq=887702
+AndHighHighDayTaxoFacets: +see +2010 +facets:taxonomy:DayOfYear # freq=1044180 freq=950573
+AndHighHighDayTaxoFacets: +or +but +facets:taxonomy:DayOfYear # freq=1858841 freq=1456553
+AndHighHighDayTaxoFacets: +its +into +facets:taxonomy:DayOfYear # freq=1173450 freq=888684
+AndHighHighDayTaxoFacets: +on +accessdate +facets:taxonomy:DayOfYear # freq=4074624 freq=1228887
+AndHighHighDayTaxoFacets: +are +accessdate +facets:taxonomy:DayOfYear # freq=1877802 freq=1228887
+AndHighHighDayTaxoFacets: +2 +there +facets:taxonomy:DayOfYear # freq=1549245 freq=956153
+AndHighHighDayTaxoFacets: +united +3 +facets:taxonomy:DayOfYear # freq=1196944 freq=1148799
+AndHighHighDayTaxoFacets: +which +no +facets:taxonomy:DayOfYear # freq=1963428 freq=1045000
+AndHighHighDayTaxoFacets: +s +2006 +facets:taxonomy:DayOfYear # freq=1581243 freq=889954
+AndHighHighDayTaxoFacets: +ref +there +facets:taxonomy:DayOfYear # freq=3793973 freq=956153
+AndHighHighDayTaxoFacets: +he +more +facets:taxonomy:DayOfYear # freq=1659434 freq=963533
+AndHighHighDayTaxoFacets: +had +two +facets:taxonomy:DayOfYear # freq=1246743 freq=1104053
+AndHighHighDayTaxoFacets: +the +only +facets:taxonomy:DayOfYear # freq=8217362 freq=875561
+AndHighHighDayTaxoFacets: +be +about +facets:taxonomy:DayOfYear # freq=2051702 freq=850283
+AndHighHighDayTaxoFacets: +in +has +facets:taxonomy:DayOfYear # freq=7320987 freq=1502961
+AndHighHighDayTaxoFacets: +2009 +work +facets:taxonomy:DayOfYear # freq=887702 freq=853422
+AndHighHighDayTaxoFacets: +on +10 +facets:taxonomy:DayOfYear # freq=4074624 freq=918339
+AndHighHighDayTaxoFacets: +ref +2010 +facets:taxonomy:DayOfYear # freq=3793973 freq=950573
+AndHighHighDayTaxoFacets: +other +2006 +facets:taxonomy:DayOfYear # freq=1269961 freq=889954
+AndHighHighDayTaxoFacets: +with +all +facets:taxonomy:DayOfYear # freq=3709421 freq=1203572
+AndHighHighDayTaxoFacets: +in +work +facets:taxonomy:DayOfYear # freq=7320987 freq=853422
+AndHighHighDayTaxoFacets: +url +about +facets:taxonomy:DayOfYear # freq=1513595 freq=850283
+AndHighHighDayTaxoFacets: +after +some +facets:taxonomy:DayOfYear # freq=1247398 freq=839919
+AndHighHighDayTaxoFacets: +this +when +facets:taxonomy:DayOfYear # freq=2224932 freq=1027487
+AndHighHighDayTaxoFacets: +not +1 +facets:taxonomy:DayOfYear # freq=1713264 freq=1641090
+AndHighHighDayTaxoFacets: +1 +more +facets:taxonomy:DayOfYear # freq=1641090 freq=963533
+AndHighHighDayTaxoFacets: +not +2 +facets:taxonomy:DayOfYear # freq=1713264 freq=1549245
+AndHighHighDayTaxoFacets: +publisher +2005 +facets:taxonomy:DayOfYear # freq=1289029 freq=835460
+AndHighHighDayTaxoFacets: +in +at +facets:taxonomy:DayOfYear # freq=7320987 freq=2857534
+AndHighHighDayTaxoFacets: +1 +some +facets:taxonomy:DayOfYear # freq=1641090 freq=839919
+AndHighHighDayTaxoFacets: +s +its +facets:taxonomy:DayOfYear # freq=1581243 freq=1173450
+AndHighHighDayTaxoFacets: +date +more +facets:taxonomy:DayOfYear # freq=2020626 freq=963533
+AndHighHighDayTaxoFacets: +from +his +facets:taxonomy:DayOfYear # freq=3224339 freq=1777780
+AndHighHighDayTaxoFacets: +was +when +facets:taxonomy:DayOfYear # freq=3763623 freq=1027487
+AndHighHighDayTaxoFacets: +time +2010 +facets:taxonomy:DayOfYear # freq=1032071 freq=950573
+AndHighHighDayTaxoFacets: +it +2 +facets:taxonomy:DayOfYear # freq=2675552 freq=1549245
+AndHighHighDayTaxoFacets: +of +http +facets:taxonomy:DayOfYear # freq=8184358 freq=3493581
+AndHighHighDayTaxoFacets: +2 +2011 +facets:taxonomy:DayOfYear # freq=1549245 freq=871410
+AndHighHighDayTaxoFacets: +who +2009 +facets:taxonomy:DayOfYear # freq=1196171 freq=887702
+AndHighHighDayTaxoFacets: +in +2009 +facets:taxonomy:DayOfYear # freq=7320987 freq=887702
+AndHighHighDayTaxoFacets: +by +3 +facets:taxonomy:DayOfYear # freq=3826691 freq=1148799
+AndHighHighDayTaxoFacets: +when +2011 +facets:taxonomy:DayOfYear # freq=1027487 freq=871410
+AndHighHighDayTaxoFacets: +not +have +facets:taxonomy:DayOfYear # freq=1713264 freq=1297121
+AndHighHighDayTaxoFacets: +all +their +facets:taxonomy:DayOfYear # freq=1203572 freq=1158682
+AndHighHighDayTaxoFacets: +an +2005 +facets:taxonomy:DayOfYear # freq=2628056 freq=835460
+AndHighHighDayTaxoFacets: +of +is +facets:taxonomy:DayOfYear # freq=8184358 freq=4074455
+AndHighHighDayTaxoFacets: +of +url +facets:taxonomy:DayOfYear # freq=8184358 freq=1513595
+AndHighHighDayTaxoFacets: +also +year +facets:taxonomy:DayOfYear # freq=1959419 freq=1235231
+AndHighHighDayTaxoFacets: +is +new +facets:taxonomy:DayOfYear # freq=4074455 freq=1657293
+AndHighHighDayTaxoFacets: +http +name +facets:taxonomy:DayOfYear # freq=3493581 freq=2827713
+AndHighHighDayTaxoFacets: +i +into +facets:taxonomy:DayOfYear # freq=956148 freq=888684
+AndHighHighDayTaxoFacets: +are +united +facets:taxonomy:DayOfYear # freq=1877802 freq=1196944
+AndHighHighDayTaxoFacets: +or +only +facets:taxonomy:DayOfYear # freq=1858841 freq=875561
+AndHighHighDayTaxoFacets: +who +their +facets:taxonomy:DayOfYear # freq=1196171 freq=1158682
+AndHighHighDayTaxoFacets: +name +been +facets:taxonomy:DayOfYear # freq=2827713 freq=1041183
+AndHighHighDayTaxoFacets: +last +2009 +facets:taxonomy:DayOfYear # freq=958437 freq=887702
+AndHighHighDayTaxoFacets: +they +2005 +facets:taxonomy:DayOfYear # freq=1021945 freq=835460
+AndHighHighDayTaxoFacets: +new +1 +facets:taxonomy:DayOfYear # freq=1657293 freq=1641090
+AndHighHighDayTaxoFacets: +title +some +facets:taxonomy:DayOfYear # freq=2397378 freq=839919
+AndHighHighDayTaxoFacets: +name +5 +facets:taxonomy:DayOfYear # freq=2827713 freq=891361
+AndHighHighDayTaxoFacets: +and +or +facets:taxonomy:DayOfYear # freq=7318061 freq=1858841
+AndHighHighDayTaxoFacets: +3 +2006 +facets:taxonomy:DayOfYear # freq=1148799 freq=889954
+AndHighHighDayTaxoFacets: +of +has +facets:taxonomy:DayOfYear # freq=8184358 freq=1502961
+AndHighHighDayTaxoFacets: +which +i +facets:taxonomy:DayOfYear # freq=1963428 freq=956148
+AndHighHighDayTaxoFacets: +see +5 +facets:taxonomy:DayOfYear # freq=1044180 freq=891361
+AndHighHighDayTaxoFacets: +has +2011 +facets:taxonomy:DayOfYear # freq=1502961 freq=871410
+AndHighHighDayTaxoFacets: +new +accessdate +facets:taxonomy:DayOfYear # freq=1657293 freq=1228887
+AndHighHighDayTaxoFacets: +united +i +facets:taxonomy:DayOfYear # freq=1196944 freq=956148
+AndHighHighDayTaxoFacets: +are +10 +facets:taxonomy:DayOfYear # freq=1877802 freq=918339
+AndHighHighDayTaxoFacets: +the +is +facets:taxonomy:DayOfYear # freq=8217362 freq=4074455
+AndHighHighDayTaxoFacets: +other +web +facets:taxonomy:DayOfYear # freq=1269961 freq=1118334
+AndHighHighDayTaxoFacets: +i +2006 +facets:taxonomy:DayOfYear # freq=956148 freq=889954
+AndHighHighDayTaxoFacets: +were +publisher +facets:taxonomy:DayOfYear # freq=1524630 freq=1289029
+AndHighHighDayTaxoFacets: +be +when +facets:taxonomy:DayOfYear # freq=2051702 freq=1027487
+AndHighHighDayTaxoFacets: +to +date +facets:taxonomy:DayOfYear # freq=6155577 freq=2020626
+AndHighHighDayTaxoFacets: +for +2006 +facets:taxonomy:DayOfYear # freq=4380011 freq=889954
+AndHighHighDayTaxoFacets: +for +at +facets:taxonomy:DayOfYear # freq=4380011 freq=2857534
+AndHighHighDayTaxoFacets: +his +s +facets:taxonomy:DayOfYear # freq=1777780 freq=1581243
+AndHighHighDayTaxoFacets: +from +or +facets:taxonomy:DayOfYear # freq=3224339 freq=1858841
+AndHighHighDayTaxoFacets: +ref +an +facets:taxonomy:DayOfYear # freq=3793973 freq=2628056
+AndHighHighDayTaxoFacets: +which +had +facets:taxonomy:DayOfYear # freq=1963428 freq=1246743
+AndHighHighDayTaxoFacets: +an +were +facets:taxonomy:DayOfYear # freq=2628056 freq=1524630
+AndHighHighDayTaxoFacets: +web +only +facets:taxonomy:DayOfYear # freq=1118334 freq=875561
+AndHighHighDayTaxoFacets: +ref +one +facets:taxonomy:DayOfYear # freq=3793973 freq=1527689
+AndHighHighDayTaxoFacets: +a +one +facets:taxonomy:DayOfYear # freq=6560531 freq=1527689
+AndHighHighDayTaxoFacets: +they +into +facets:taxonomy:DayOfYear # freq=1021945 freq=888684
+AndHighHighDayTaxoFacets: +of +2008 +facets:taxonomy:DayOfYear # freq=8184358 freq=831253
+AndHighHighDayTaxoFacets: +in +which +facets:taxonomy:DayOfYear # freq=7320987 freq=1963428
+AndHighHighDayTaxoFacets: +united +2010 +facets:taxonomy:DayOfYear # freq=1196944 freq=950573
+AndHighHighDayTaxoFacets: +after +i +facets:taxonomy:DayOfYear # freq=1247398 freq=956148
+AndHighHighDayTaxoFacets: +he +web +facets:taxonomy:DayOfYear # freq=1659434 freq=1118334
+AndHighHighDayTaxoFacets: +are +states +facets:taxonomy:DayOfYear # freq=1877802 freq=1034872
+AndHighHighDayTaxoFacets: +after +time +facets:taxonomy:DayOfYear # freq=1247398 freq=1032071
+AndHighHighDayTaxoFacets: +its +web +facets:taxonomy:DayOfYear # freq=1173450 freq=1118334
+AndHighHighDayTaxoFacets: +for +when +facets:taxonomy:DayOfYear # freq=4380011 freq=1027487
+AndHighHighDayTaxoFacets: +has +states +facets:taxonomy:DayOfYear # freq=1502961 freq=1034872
+AndHighHighDayTaxoFacets: +the +no +facets:taxonomy:DayOfYear # freq=8217362 freq=1045000
+AndHighHighDayTaxoFacets: +title +one +facets:taxonomy:DayOfYear # freq=2397378 freq=1527689
+AndHighHighDayTaxoFacets: +i +2009 +facets:taxonomy:DayOfYear # freq=956148 freq=887702
+AndHighHighDayTaxoFacets: +1 +states +facets:taxonomy:DayOfYear # freq=1641090 freq=1034872
+AndHighHighDayTaxoFacets: +other +only +facets:taxonomy:DayOfYear # freq=1269961 freq=875561
+AndHighHighDayTaxoFacets: +by +they +facets:taxonomy:DayOfYear # freq=3826691 freq=1021945
+AndHighHighDayTaxoFacets: +http +its +facets:taxonomy:DayOfYear # freq=3493581 freq=1173450
+AndHighHighDayTaxoFacets: +for +two +facets:taxonomy:DayOfYear # freq=4380011 freq=1104053
+AndHighHighDayTaxoFacets: +all +may +facets:taxonomy:DayOfYear # freq=1203572 freq=1071932
+AndHighHighDayTaxoFacets: +after +last +facets:taxonomy:DayOfYear # freq=1247398 freq=958437
+AndHighHighDayTaxoFacets: +there +only +facets:taxonomy:DayOfYear # freq=956153 freq=875561
+AndHighHighDayTaxoFacets: +2 +no +facets:taxonomy:DayOfYear # freq=1549245 freq=1045000
+AndHighHighDayTaxoFacets: +an +he +facets:taxonomy:DayOfYear # freq=2628056 freq=1659434
+AndHighHighDayTaxoFacets: +his +i +facets:taxonomy:DayOfYear # freq=1777780 freq=956148
+AndHighHighDayTaxoFacets: +first +not +facets:taxonomy:DayOfYear # freq=1933372 freq=1713264
+AndHighHighDayTaxoFacets: +a +5 +facets:taxonomy:DayOfYear # freq=6560531 freq=891361
+AndHighHighDayTaxoFacets: +from +2005 +facets:taxonomy:DayOfYear # freq=3224339 freq=835460
+AndHighHighDayTaxoFacets: +after +web +facets:taxonomy:DayOfYear # freq=1247398 freq=1118334
+AndHighHighDayTaxoFacets: +to +which +facets:taxonomy:DayOfYear # freq=6155577 freq=1963428
+AndHighHighDayTaxoFacets: +this +into +facets:taxonomy:DayOfYear # freq=2224932 freq=888684
+AndHighHighDayTaxoFacets: +its +last +facets:taxonomy:DayOfYear # freq=1173450 freq=958437
+AndHighHighDayTaxoFacets: +it +there +facets:taxonomy:DayOfYear # freq=2675552 freq=956153
+AndHighHighDayTaxoFacets: +name +are +facets:taxonomy:DayOfYear # freq=2827713 freq=1877802
+AndHighHighDayTaxoFacets: +are +4 +facets:taxonomy:DayOfYear # freq=1877802 freq=986452
+AndHighHighDayTaxoFacets: +name +cite +facets:taxonomy:DayOfYear # freq=2827713 freq=1741194
+AndHighHighDayTaxoFacets: +more +2008 +facets:taxonomy:DayOfYear # freq=963533 freq=831253
+AndHighHighDayTaxoFacets: +of +that +facets:taxonomy:DayOfYear # freq=8184358 freq=2931020
+AndHighHighDayTaxoFacets: +ref +at +facets:taxonomy:DayOfYear # freq=3793973 freq=2857534
+AndHighHighDayTaxoFacets: +new +web +facets:taxonomy:DayOfYear # freq=1657293 freq=1118334
+AndHighHighDayTaxoFacets: +the +2 +facets:taxonomy:DayOfYear # freq=8217362 freq=1549245
+AndHighHighDayTaxoFacets: +for +1 +facets:taxonomy:DayOfYear # freq=4380011 freq=1641090
+AndHighHighDayTaxoFacets: +by +no +facets:taxonomy:DayOfYear # freq=3826691 freq=1045000
+AndHighHighDayTaxoFacets: +all +i +facets:taxonomy:DayOfYear # freq=1203572 freq=956148
+AndHighHighDayTaxoFacets: +5 +2006 +facets:taxonomy:DayOfYear # freq=891361 freq=889954
+AndHighHighDayTaxoFacets: +4 +work +facets:taxonomy:DayOfYear # freq=986452 freq=853422
+AndHighHighDayTaxoFacets: +was +new +facets:taxonomy:DayOfYear # freq=3763623 freq=1657293
+AndHighHighDayTaxoFacets: +year +see +facets:taxonomy:DayOfYear # freq=1235231 freq=1044180
+AndHighHighDayTaxoFacets: +s +had +facets:taxonomy:DayOfYear # freq=1581243 freq=1246743
+AndHighHighDayTaxoFacets: +an +last +facets:taxonomy:DayOfYear # freq=2628056 freq=958437
+AndHighHighDayTaxoFacets: +had +4 +facets:taxonomy:DayOfYear # freq=1246743 freq=986452
+AndHighHighDayTaxoFacets: +from +publisher +facets:taxonomy:DayOfYear # freq=3224339 freq=1289029
+AndHighHighDayTaxoFacets: +new +url +facets:taxonomy:DayOfYear # freq=1657293 freq=1513595
+AndHighHighDayTaxoFacets: +4 +5 +facets:taxonomy:DayOfYear # freq=986452 freq=891361
+AndHighHighDayTaxoFacets: +by +cite +facets:taxonomy:DayOfYear # freq=3826691 freq=1741194
+AndHighHighDayTaxoFacets: +2010 +2009 +facets:taxonomy:DayOfYear # freq=950573 freq=887702
+AndHighHighDayTaxoFacets: +their +4 +facets:taxonomy:DayOfYear # freq=1158682 freq=986452
+AndHighHighDayTaxoFacets: +publisher +who +facets:taxonomy:DayOfYear # freq=1289029 freq=1196171
+AndHighHighDayTaxoFacets: +that +more +facets:taxonomy:DayOfYear # freq=2931020 freq=963533
+AndHighHighDayTaxoFacets: +ref +see +facets:taxonomy:DayOfYear # freq=3793973 freq=1044180
+AndHighHighDayTaxoFacets: +publisher +last +facets:taxonomy:DayOfYear # freq=1289029 freq=958437
+AndHighHighDayTaxoFacets: +but +their +facets:taxonomy:DayOfYear # freq=1456553 freq=1158682
+AndHighHighDayTaxoFacets: +is +1 +facets:taxonomy:DayOfYear # freq=4074455 freq=1641090
+AndHighHighDayTaxoFacets: +new +have +facets:taxonomy:DayOfYear # freq=1657293 freq=1297121
+AndHighHighDayTaxoFacets: +title +also +facets:taxonomy:DayOfYear # freq=2397378 freq=1959419
+AndHighHighDayTaxoFacets: +also +i +facets:taxonomy:DayOfYear # freq=1959419 freq=956148
+AndHighHighDayTaxoFacets: +had +into +facets:taxonomy:DayOfYear # freq=1246743 freq=888684
+AndHighHighDayTaxoFacets: +first +when +facets:taxonomy:DayOfYear # freq=1933372 freq=1027487
+AndHighHighDayTaxoFacets: +in +be +facets:taxonomy:DayOfYear # freq=7320987 freq=2051702
+AndHighHighDayTaxoFacets: +are +2008 +facets:taxonomy:DayOfYear # freq=1877802 freq=831253
+AndHighHighDayTaxoFacets: +two +2006 +facets:taxonomy:DayOfYear # freq=1104053 freq=889954
+AndHighHighDayTaxoFacets: +date +about +facets:taxonomy:DayOfYear # freq=2020626 freq=850283
+AndHighHighDayTaxoFacets: +its +only +facets:taxonomy:DayOfYear # freq=1173450 freq=875561
+AndHighHighDayTaxoFacets: +title +new +facets:taxonomy:DayOfYear # freq=2397378 freq=1657293
+AndHighHighDayTaxoFacets: +2 +10 +facets:taxonomy:DayOfYear # freq=1549245 freq=918339
+AndHighHighDayTaxoFacets: +2 +one +facets:taxonomy:DayOfYear # freq=1549245 freq=1527689
+AndHighHighDayTaxoFacets: +is +an +facets:taxonomy:DayOfYear # freq=4074455 freq=2628056
+AndHighHighDayTaxoFacets: +at +no +facets:taxonomy:DayOfYear # freq=2857534 freq=1045000
+AndHighHighDayTaxoFacets: +has +its +facets:taxonomy:DayOfYear # freq=1502961 freq=1173450
+AndHighHighDayTaxoFacets: +were +there +facets:taxonomy:DayOfYear # freq=1524630 freq=956153
+AndHighHighDayTaxoFacets: +with +were +facets:taxonomy:DayOfYear # freq=3709421 freq=1524630
+AndHighHighDayTaxoFacets: +on +i +facets:taxonomy:DayOfYear # freq=4074624 freq=956148
+AndHighHighDayTaxoFacets: +as +was +facets:taxonomy:DayOfYear # freq=3925535 freq=3763623
+AndHighHighDayTaxoFacets: +date +cite +facets:taxonomy:DayOfYear # freq=2020626 freq=1741194
+AndHighHighDayTaxoFacets: +or +united +facets:taxonomy:DayOfYear # freq=1858841 freq=1196944
+AndHighHighDayTaxoFacets: +to +http +facets:taxonomy:DayOfYear # freq=6155577 freq=3493581
+AndHighHighDayTaxoFacets: +he +have +facets:taxonomy:DayOfYear # freq=1659434 freq=1297121
+AndHighHighDayTaxoFacets: +s +about +facets:taxonomy:DayOfYear # freq=1581243 freq=850283
+AndHighHighDayTaxoFacets: +this +s +facets:taxonomy:DayOfYear # freq=2224932 freq=1581243
+AndHighHighDayTaxoFacets: +is +but +facets:taxonomy:DayOfYear # freq=4074455 freq=1456553
+AndHighHighDayTaxoFacets: +web +2010 +facets:taxonomy:DayOfYear # freq=1118334 freq=950573
+AndHighHighDayTaxoFacets: +first +are +facets:taxonomy:DayOfYear # freq=1933372 freq=1877802
+AndHighHighDayTaxoFacets: +have +2008 +facets:taxonomy:DayOfYear # freq=1297121 freq=831253
+AndHighHighDayTaxoFacets: +to +no +facets:taxonomy:DayOfYear # freq=6155577 freq=1045000
+AndHighHighDayTaxoFacets: +or +2 +facets:taxonomy:DayOfYear # freq=1858841 freq=1549245
+AndHighHighDayTaxoFacets: +was +about +facets:taxonomy:DayOfYear # freq=3763623 freq=850283
+AndHighHighDayTaxoFacets: +cite +more +facets:taxonomy:DayOfYear # freq=1741194 freq=963533
+AndHighHighDayTaxoFacets: +date +their +facets:taxonomy:DayOfYear # freq=2020626 freq=1158682
+AndHighHighDayTaxoFacets: +from +work +facets:taxonomy:DayOfYear # freq=3224339 freq=853422
+AndHighHighDayTaxoFacets: +at +2010 +facets:taxonomy:DayOfYear # freq=2857534 freq=950573
+AndHighHighDayTaxoFacets: +other +last +facets:taxonomy:DayOfYear # freq=1269961 freq=958437
+AndHighHighDayTaxoFacets: +date +into +facets:taxonomy:DayOfYear # freq=2020626 freq=888684
+AndHighHighDayTaxoFacets: +they +more +facets:taxonomy:DayOfYear # freq=1021945 freq=963533
+AndHighHighDayTaxoFacets: +to +ref +facets:taxonomy:DayOfYear # freq=6155577 freq=3793973
+AndHighHighDayTaxoFacets: +be +but +facets:taxonomy:DayOfYear # freq=2051702 freq=1456553
+AndHighHighDayTaxoFacets: +or +into +facets:taxonomy:DayOfYear # freq=1858841 freq=888684
+AndHighHighDayTaxoFacets: +has +last +facets:taxonomy:DayOfYear # freq=1502961 freq=958437
+AndHighHighDayTaxoFacets: +to +time +facets:taxonomy:DayOfYear # freq=6155577 freq=1032071
+AndHighHighDayTaxoFacets: +the +some +facets:taxonomy:DayOfYear # freq=8217362 freq=839919
+AndHighHighDayTaxoFacets: +ref +united +facets:taxonomy:DayOfYear # freq=3793973 freq=1196944
+AndHighHighDayTaxoFacets: +all +last +facets:taxonomy:DayOfYear # freq=1203572 freq=958437
+AndHighHighDayTaxoFacets: +url +all +facets:taxonomy:DayOfYear # freq=1513595 freq=1203572
+AndHighHighDayTaxoFacets: +other +some +facets:taxonomy:DayOfYear # freq=1269961 freq=839919
+AndHighHighDayTaxoFacets: +cite +new +facets:taxonomy:DayOfYear # freq=1741194 freq=1657293
+AndHighHighDayTaxoFacets: +and +by +facets:taxonomy:DayOfYear # freq=7318061 freq=3826691
+AndHighHighDayTaxoFacets: +publisher +i +facets:taxonomy:DayOfYear # freq=1289029 freq=956148
+AndHighHighDayTaxoFacets: +to +publisher +facets:taxonomy:DayOfYear # freq=6155577 freq=1289029
+AndHighHighDayTaxoFacets: +the +about +facets:taxonomy:DayOfYear # freq=8217362 freq=850283
+AndHighHighDayTaxoFacets: +as +are +facets:taxonomy:DayOfYear # freq=3925535 freq=1877802
+AndHighHighDayTaxoFacets: +it +title +facets:taxonomy:DayOfYear # freq=2675552 freq=2397378
+AndHighHighDayTaxoFacets: +by +are +facets:taxonomy:DayOfYear # freq=3826691 freq=1877802
+AndHighHighDayTaxoFacets: +has +have +facets:taxonomy:DayOfYear # freq=1502961 freq=1297121
+AndHighHighDayTaxoFacets: +one +2011 +facets:taxonomy:DayOfYear # freq=1527689 freq=871410
+AndHighHighDayTaxoFacets: +are +2005 +facets:taxonomy:DayOfYear # freq=1877802 freq=835460
+AndHighHighDayTaxoFacets: +had +some +facets:taxonomy:DayOfYear # freq=1246743 freq=839919
+AndHighHighDayTaxoFacets: +by +when +facets:taxonomy:DayOfYear # freq=3826691 freq=1027487
+AndHighHighDayTaxoFacets: +it +2011 +facets:taxonomy:DayOfYear # freq=2675552 freq=871410
+AndHighHighDayTaxoFacets: +1 +they +facets:taxonomy:DayOfYear # freq=1641090 freq=1021945
+AndHighHighDayTaxoFacets: +on +their +facets:taxonomy:DayOfYear # freq=4074624 freq=1158682
+AndHighHighDayTaxoFacets: +been +10 +facets:taxonomy:DayOfYear # freq=1041183 freq=918339
+AndHighHighDayTaxoFacets: +was +only +facets:taxonomy:DayOfYear # freq=3763623 freq=875561
+AndHighHighDayTaxoFacets: +also +other +facets:taxonomy:DayOfYear # freq=1959419 freq=1269961
+AndHighHighDayTaxoFacets: +who +its +facets:taxonomy:DayOfYear # freq=1196171 freq=1173450
+AndHighHighDayTaxoFacets: +3 +may +facets:taxonomy:DayOfYear # freq=1148799 freq=1071932
+AndHighHighDayTaxoFacets: +with +2006 +facets:taxonomy:DayOfYear # freq=3709421 freq=889954
+AndHighHighDayTaxoFacets: +from +but +facets:taxonomy:DayOfYear # freq=3224339 freq=1456553
+AndHighHighDayTaxoFacets: +was +work +facets:taxonomy:DayOfYear # freq=3763623 freq=853422
+AndHighHighDayTaxoFacets: +as +also +facets:taxonomy:DayOfYear # freq=3925535 freq=1959419
+AndHighHighDayTaxoFacets: +which +into +facets:taxonomy:DayOfYear # freq=1963428 freq=888684
+AndHighHighDayTaxoFacets: +see +i +facets:taxonomy:DayOfYear # freq=1044180 freq=956148
+AndHighHighDayTaxoFacets: +have +more +facets:taxonomy:DayOfYear # freq=1297121 freq=963533
+AndHighHighDayTaxoFacets: +were +after +facets:taxonomy:DayOfYear # freq=1524630 freq=1247398
+AndHighHighDayTaxoFacets: +on +2010 +facets:taxonomy:DayOfYear # freq=4074624 freq=950573
+AndHighHighDayTaxoFacets: +is +had +facets:taxonomy:DayOfYear # freq=4074455 freq=1246743
+AndHighHighDayTaxoFacets: +he +5 +facets:taxonomy:DayOfYear # freq=1659434 freq=891361
+AndHighHighDayTaxoFacets: +first +year +facets:taxonomy:DayOfYear # freq=1933372 freq=1235231
+AndHighHighDayTaxoFacets: +not +url +facets:taxonomy:DayOfYear # freq=1713264 freq=1513595
+AndHighHighDayTaxoFacets: +first +his +facets:taxonomy:DayOfYear # freq=1933372 freq=1777780
+AndHighHighDayTaxoFacets: +date +10 +facets:taxonomy:DayOfYear # freq=2020626 freq=918339
+AndHighHighDayTaxoFacets: +was +not +facets:taxonomy:DayOfYear # freq=3763623 freq=1713264
+AndHighHighDayTaxoFacets: +and +may +facets:taxonomy:DayOfYear # freq=7318061 freq=1071932
+AndHighHighDayTaxoFacets: +no +more +facets:taxonomy:DayOfYear # freq=1045000 freq=963533
+AndHighHighDayTaxoFacets: +it +url +facets:taxonomy:DayOfYear # freq=2675552 freq=1513595
+AndHighHighDayTaxoFacets: +as +no +facets:taxonomy:DayOfYear # freq=3925535 freq=1045000
+AndHighHighDayTaxoFacets: +other +all +facets:taxonomy:DayOfYear # freq=1269961 freq=1203572
+AndHighHighDayTaxoFacets: +as +2 +facets:taxonomy:DayOfYear # freq=3925535 freq=1549245
+AndHighHighDayTaxoFacets: +for +as +facets:taxonomy:DayOfYear # freq=4380011 freq=3925535
+AndHighHighDayTaxoFacets: +for +there +facets:taxonomy:DayOfYear # freq=4380011 freq=956153
+AndHighHighDayTaxoFacets: +the +new +facets:taxonomy:DayOfYear # freq=8217362 freq=1657293
+AndHighHighDayTaxoFacets: +is +no +facets:taxonomy:DayOfYear # freq=4074455 freq=1045000
+AndHighHighDayTaxoFacets: +also +their +facets:taxonomy:DayOfYear # freq=1959419 freq=1158682
+AndHighHighDayTaxoFacets: +that +2010 +facets:taxonomy:DayOfYear # freq=2931020 freq=950573
+AndHighHighDayTaxoFacets: +s +2008 +facets:taxonomy:DayOfYear # freq=1581243 freq=831253
+AndHighHighDayTaxoFacets: +were +2009 +facets:taxonomy:DayOfYear # freq=1524630 freq=887702
+AndHighHighDayTaxoFacets: +of +after +facets:taxonomy:DayOfYear # freq=8184358 freq=1247398
+AndHighHighDayTaxoFacets: +of +an +facets:taxonomy:DayOfYear # freq=8184358 freq=2628056
+AndHighHighDayTaxoFacets: +the +10 +facets:taxonomy:DayOfYear # freq=8217362 freq=918339
+AndHighHighDayTaxoFacets: +title +web +facets:taxonomy:DayOfYear # freq=2397378 freq=1118334
+AndHighHighDayTaxoFacets: +on +they +facets:taxonomy:DayOfYear # freq=4074624 freq=1021945
+AndHighHighDayTaxoFacets: +to +have +facets:taxonomy:DayOfYear # freq=6155577 freq=1297121
+AndHighHighDayTaxoFacets: +was +its +facets:taxonomy:DayOfYear # freq=3763623 freq=1173450
+AndHighHighDayTaxoFacets: +at +time +facets:taxonomy:DayOfYear # freq=2857534 freq=1032071
+AndHighHighDayTaxoFacets: +2 +accessdate +facets:taxonomy:DayOfYear # freq=1549245 freq=1228887
+AndHighHighDayTaxoFacets: +with +united +facets:taxonomy:DayOfYear # freq=3709421 freq=1196944
+AndHighHighDayTaxoFacets: +in +about +facets:taxonomy:DayOfYear # freq=7320987 freq=850283
+AndHighHighDayTaxoFacets: +in +2005 +facets:taxonomy:DayOfYear # freq=7320987 freq=835460
+AndHighHighDayTaxoFacets: +for +last +facets:taxonomy:DayOfYear # freq=4380011 freq=958437
+AndHighHighDayTaxoFacets: +and +when +facets:taxonomy:DayOfYear # freq=7318061 freq=1027487
+AndHighHighDayTaxoFacets: +an +their +facets:taxonomy:DayOfYear # freq=2628056 freq=1158682
+AndHighHighDayTaxoFacets: +2010 +into +facets:taxonomy:DayOfYear # freq=950573 freq=888684
+AndHighHighDayTaxoFacets: +web +two +facets:taxonomy:DayOfYear # freq=1118334 freq=1104053
+AndHighHighDayTaxoFacets: +two +4 +facets:taxonomy:DayOfYear # freq=1104053 freq=986452
+AndHighHighDayTaxoFacets: +1 +there +facets:taxonomy:DayOfYear # freq=1641090 freq=956153
+AndHighHighDayTaxoFacets: +name +url +facets:taxonomy:DayOfYear # freq=2827713 freq=1513595
+AndHighHighDayTaxoFacets: +united +who +facets:taxonomy:DayOfYear # freq=1196944 freq=1196171
+AndHighHighDayTaxoFacets: +they +there +facets:taxonomy:DayOfYear # freq=1021945 freq=956153
+AndHighHighDayTaxoFacets: +http +5 +facets:taxonomy:DayOfYear # freq=3493581 freq=891361
+AndHighHighDayTaxoFacets: +not +2008 +facets:taxonomy:DayOfYear # freq=1713264 freq=831253
+AndHighHighDayTaxoFacets: +are +2009 +facets:taxonomy:DayOfYear # freq=1877802 freq=887702
+AndHighHighDayTaxoFacets: +on +may +facets:taxonomy:DayOfYear # freq=4074624 freq=1071932
+AndHighHighDayTaxoFacets: +is +are +facets:taxonomy:DayOfYear # freq=4074455 freq=1877802
+AndHighHighDayTaxoFacets: +been +there +facets:taxonomy:DayOfYear # freq=1041183 freq=956153
+AndHighHighDayTaxoFacets: +other +into +facets:taxonomy:DayOfYear # freq=1269961 freq=888684
+AndHighHighDayTaxoFacets: +be +their +facets:taxonomy:DayOfYear # freq=2051702 freq=1158682
+AndHighHighDayTaxoFacets: +new +other +facets:taxonomy:DayOfYear # freq=1657293 freq=1269961
+AndHighHighDayTaxoFacets: +its +2011 +facets:taxonomy:DayOfYear # freq=1173450 freq=871410
+AndHighHighDayTaxoFacets: +ref +3 +facets:taxonomy:DayOfYear # freq=3793973 freq=1148799
+AndHighHighDayTaxoFacets: +name +be +facets:taxonomy:DayOfYear # freq=2827713 freq=2051702
+AndHighHighDayTaxoFacets: +had +see +facets:taxonomy:DayOfYear # freq=1246743 freq=1044180
+AndHighHighDayTaxoFacets: +also +or +facets:taxonomy:DayOfYear # freq=1959419 freq=1858841
+AndHighHighDayTaxoFacets: +but +4 +facets:taxonomy:DayOfYear # freq=1456553 freq=986452
+AndHighMedDayTaxoFacets: +has +please +facets:taxonomy:DayOfYear # freq=1502961 freq=229602
+AndHighMedDayTaxoFacets: +he +battle +facets:taxonomy:DayOfYear # freq=1659434 freq=192357
+AndHighMedDayTaxoFacets: +be +century +facets:taxonomy:DayOfYear # freq=2051702 freq=385541
+AndHighMedDayTaxoFacets: +may +studio +facets:taxonomy:DayOfYear # freq=1071932 freq=101979
+AndHighMedDayTaxoFacets: +have +level +facets:taxonomy:DayOfYear # freq=1297121 freq=175382
+AndHighMedDayTaxoFacets: +web +place +facets:taxonomy:DayOfYear # freq=1118334 freq=654158
+AndHighMedDayTaxoFacets: +all +close +facets:taxonomy:DayOfYear # freq=1203572 freq=136706
+AndHighMedDayTaxoFacets: +as +chart +facets:taxonomy:DayOfYear # freq=3925535 freq=84194
+AndHighMedDayTaxoFacets: +ref +appropriate +facets:taxonomy:DayOfYear # freq=3793973 freq=135343
+AndHighMedDayTaxoFacets: +be +put +facets:taxonomy:DayOfYear # freq=2051702 freq=139882
+AndHighMedDayTaxoFacets: +and +called +facets:taxonomy:DayOfYear # freq=7318061 freq=454580
+AndHighMedDayTaxoFacets: +been +four +facets:taxonomy:DayOfYear # freq=1041183 freq=389818
+AndHighMedDayTaxoFacets: +url +whether +facets:taxonomy:DayOfYear # freq=1513595 freq=93965
+AndHighMedDayTaxoFacets: +with +day +facets:taxonomy:DayOfYear # freq=3709421 freq=402096
+AndHighMedDayTaxoFacets: +a +famous +facets:taxonomy:DayOfYear # freq=6560531 freq=139092
+AndHighMedDayTaxoFacets: +it +nature +facets:taxonomy:DayOfYear # freq=2675552 freq=107428
+AndHighMedDayTaxoFacets: +his +although +facets:taxonomy:DayOfYear # freq=1777780 freq=341432
+AndHighMedDayTaxoFacets: +1 +artists +facets:taxonomy:DayOfYear # freq=1641090 freq=107145
+AndHighMedDayTaxoFacets: +title +digital +facets:taxonomy:DayOfYear # freq=2397378 freq=82650
+AndHighMedDayTaxoFacets: +that +37 +facets:taxonomy:DayOfYear # freq=2931020 freq=126429
+AndHighMedDayTaxoFacets: +was +free +facets:taxonomy:DayOfYear # freq=3763623 freq=270199
+AndHighMedDayTaxoFacets: +5 +west +facets:taxonomy:DayOfYear # freq=891361 freq=431006
+AndHighMedDayTaxoFacets: +had +reference +facets:taxonomy:DayOfYear # freq=1246743 freq=111493
+AndHighMedDayTaxoFacets: +in +sports +facets:taxonomy:DayOfYear # freq=7320987 freq=178542
+AndHighMedDayTaxoFacets: +its +interview +facets:taxonomy:DayOfYear # freq=1173450 freq=98846
+AndHighMedDayTaxoFacets: +url +took +facets:taxonomy:DayOfYear # freq=1513595 freq=247388
+AndHighMedDayTaxoFacets: +and +los +facets:taxonomy:DayOfYear # freq=7318061 freq=145404
+AndHighMedDayTaxoFacets: +last +english +facets:taxonomy:DayOfYear # freq=958437 freq=412061
+AndHighMedDayTaxoFacets: +not +lee +facets:taxonomy:DayOfYear # freq=1713264 freq=90461
+AndHighMedDayTaxoFacets: +their +few +facets:taxonomy:DayOfYear # freq=1158682 freq=226422
+AndHighMedDayTaxoFacets: +they +round +facets:taxonomy:DayOfYear # freq=1021945 freq=122499
+AndHighMedDayTaxoFacets: +cite +area +facets:taxonomy:DayOfYear # freq=1741194 freq=559023
+AndHighMedDayTaxoFacets: +two +lake +facets:taxonomy:DayOfYear # freq=1104053 freq=131603
+AndHighMedDayTaxoFacets: +time +8 +facets:taxonomy:DayOfYear # freq=1032071 freq=635822
+AndHighMedDayTaxoFacets: +this +winning +facets:taxonomy:DayOfYear # freq=2224932 freq=95704
+AndHighMedDayTaxoFacets: +only +performed +facets:taxonomy:DayOfYear # freq=875561 freq=104044
+AndHighMedDayTaxoFacets: +when +books.google.com +facets:taxonomy:DayOfYear # freq=1027487 freq=119391
+AndHighMedDayTaxoFacets: +who +legal +facets:taxonomy:DayOfYear # freq=1196171 freq=90645
+AndHighMedDayTaxoFacets: +2009 +keep +facets:taxonomy:DayOfYear # freq=887702 freq=177996
+AndHighMedDayTaxoFacets: +http +running +facets:taxonomy:DayOfYear # freq=3493581 freq=101764
+AndHighMedDayTaxoFacets: +5 +grand +facets:taxonomy:DayOfYear # freq=891361 freq=139202
+AndHighMedDayTaxoFacets: +it +man +facets:taxonomy:DayOfYear # freq=2675552 freq=278112
+AndHighMedDayTaxoFacets: +had +entertainment +facets:taxonomy:DayOfYear # freq=1246743 freq=117931
+AndHighMedDayTaxoFacets: +with +200px +facets:taxonomy:DayOfYear # freq=3709421 freq=102661
+AndHighMedDayTaxoFacets: +had +van +facets:taxonomy:DayOfYear # freq=1246743 freq=116920
+AndHighMedDayTaxoFacets: +was +track +facets:taxonomy:DayOfYear # freq=3763623 freq=148840
+AndHighMedDayTaxoFacets: +10 +corporation +facets:taxonomy:DayOfYear # freq=918339 freq=107425
+AndHighMedDayTaxoFacets: +other +make +facets:taxonomy:DayOfYear # freq=1269961 freq=292607
+AndHighMedDayTaxoFacets: +first +results +facets:taxonomy:DayOfYear # freq=1933372 freq=137248
+AndHighMedDayTaxoFacets: +2010 +unreferenced +facets:taxonomy:DayOfYear # freq=950573 freq=107803
+AndHighMedDayTaxoFacets: +first +top +facets:taxonomy:DayOfYear # freq=1933372 freq=364628
+AndHighMedDayTaxoFacets: +his +en +facets:taxonomy:DayOfYear # freq=1777780 freq=277463
+AndHighMedDayTaxoFacets: +other +airport +facets:taxonomy:DayOfYear # freq=1269961 freq=88205
+AndHighMedDayTaxoFacets: +10 +march +facets:taxonomy:DayOfYear # freq=918339 freq=620393
+AndHighMedDayTaxoFacets: +all +recently +facets:taxonomy:DayOfYear # freq=1203572 freq=90249
+AndHighMedDayTaxoFacets: +were +genre +facets:taxonomy:DayOfYear # freq=1524630 freq=121233
+AndHighMedDayTaxoFacets: +and +program +facets:taxonomy:DayOfYear # freq=7318061 freq=173553
+AndHighMedDayTaxoFacets: +i +09 +facets:taxonomy:DayOfYear # freq=956148 freq=296300
+AndHighMedDayTaxoFacets: +to +ended +facets:taxonomy:DayOfYear # freq=6155577 freq=84664
+AndHighMedDayTaxoFacets: +not +playing +facets:taxonomy:DayOfYear # freq=1713264 freq=133330
+AndHighMedDayTaxoFacets: +time +companies +facets:taxonomy:DayOfYear # freq=1032071 freq=98905
+AndHighMedDayTaxoFacets: +to +living +facets:taxonomy:DayOfYear # freq=6155577 freq=181427
+AndHighMedDayTaxoFacets: +of +silver +facets:taxonomy:DayOfYear # freq=8184358 freq=85967
+AndHighMedDayTaxoFacets: +in +images +facets:taxonomy:DayOfYear # freq=7320987 freq=125154
+AndHighMedDayTaxoFacets: +2008 +debate +facets:taxonomy:DayOfYear # freq=831253 freq=177827
+AndHighMedDayTaxoFacets: +some +los +facets:taxonomy:DayOfYear # freq=839919 freq=145404
+AndHighMedDayTaxoFacets: +2008 +simply +facets:taxonomy:DayOfYear # freq=831253 freq=84090
+AndHighMedDayTaxoFacets: +first +producer +facets:taxonomy:DayOfYear # freq=1933372 freq=137098
+AndHighMedDayTaxoFacets: +last +seven +facets:taxonomy:DayOfYear # freq=958437 freq=134402
+AndHighMedDayTaxoFacets: +more +soon +facets:taxonomy:DayOfYear # freq=963533 freq=123657
+AndHighMedDayTaxoFacets: +date +talk +facets:taxonomy:DayOfYear # freq=2020626 freq=364194
+AndHighMedDayTaxoFacets: +its +49 +facets:taxonomy:DayOfYear # freq=1173450 freq=103612
+AndHighMedDayTaxoFacets: +publisher +car +facets:taxonomy:DayOfYear # freq=1289029 freq=121250
+AndHighMedDayTaxoFacets: +were +v +facets:taxonomy:DayOfYear # freq=1524630 freq=284318
+AndHighMedDayTaxoFacets: +more +says +facets:taxonomy:DayOfYear # freq=963533 freq=84589
+AndHighMedDayTaxoFacets: +3 +man +facets:taxonomy:DayOfYear # freq=1148799 freq=278112
+AndHighMedDayTaxoFacets: +but +1974 +facets:taxonomy:DayOfYear # freq=1456553 freq=132835
+AndHighMedDayTaxoFacets: +but +02 +facets:taxonomy:DayOfYear # freq=1456553 freq=319783
+AndHighMedDayTaxoFacets: +see +historic +facets:taxonomy:DayOfYear # freq=1044180 freq=112292
+AndHighMedDayTaxoFacets: +which +wife +facets:taxonomy:DayOfYear # freq=1963428 freq=130807
+AndHighMedDayTaxoFacets: +1 +grand +facets:taxonomy:DayOfYear # freq=1641090 freq=139202
+AndHighMedDayTaxoFacets: +it +real +facets:taxonomy:DayOfYear # freq=2675552 freq=151505
+AndHighMedDayTaxoFacets: +its +development +facets:taxonomy:DayOfYear # freq=1173450 freq=230286
+AndHighMedDayTaxoFacets: +3 +office +facets:taxonomy:DayOfYear # freq=1148799 freq=225338
+AndHighMedDayTaxoFacets: +10 +class +facets:taxonomy:DayOfYear # freq=918339 freq=556838
+AndHighMedDayTaxoFacets: +not +abbr +facets:taxonomy:DayOfYear # freq=1713264 freq=96135
+AndHighMedDayTaxoFacets: +accessdate +hand +facets:taxonomy:DayOfYear # freq=1228887 freq=119947
+AndHighMedDayTaxoFacets: +2011 +trade +facets:taxonomy:DayOfYear # freq=871410 freq=106384
+AndHighMedDayTaxoFacets: +that +love +facets:taxonomy:DayOfYear # freq=2931020 freq=177242
+AndHighMedDayTaxoFacets: +from +took +facets:taxonomy:DayOfYear # freq=3224339 freq=247388
+AndHighMedDayTaxoFacets: +united +id +facets:taxonomy:DayOfYear # freq=1196944 freq=579566
+AndHighMedDayTaxoFacets: +s +mi +facets:taxonomy:DayOfYear # freq=1581243 freq=97131
+AndHighMedDayTaxoFacets: +as +young +facets:taxonomy:DayOfYear # freq=3925535 freq=196428
+AndHighMedDayTaxoFacets: +3 +opening +facets:taxonomy:DayOfYear # freq=1148799 freq=84576
+AndHighMedDayTaxoFacets: +other +european +facets:taxonomy:DayOfYear # freq=1269961 freq=193975
+AndHighMedDayTaxoFacets: +ref +chart +facets:taxonomy:DayOfYear # freq=3793973 freq=84194
+AndHighMedDayTaxoFacets: +about +thought +facets:taxonomy:DayOfYear # freq=850283 freq=108963
+AndHighMedDayTaxoFacets: +for +should +facets:taxonomy:DayOfYear # freq=4380011 freq=401379
+AndHighMedDayTaxoFacets: +united +lead +facets:taxonomy:DayOfYear # freq=1196944 freq=141336
+AndHighMedDayTaxoFacets: +this +movie +facets:taxonomy:DayOfYear # freq=2224932 freq=133291
+AndHighMedDayTaxoFacets: +2011 +winning +facets:taxonomy:DayOfYear # freq=871410 freq=95704
+AndHighMedDayTaxoFacets: +new +shows +facets:taxonomy:DayOfYear # freq=1657293 freq=131923
+AndHighMedDayTaxoFacets: +no +him +facets:taxonomy:DayOfYear # freq=1045000 freq=507350
+AndHighMedDayTaxoFacets: +has +always +facets:taxonomy:DayOfYear # freq=1502961 freq=112388
+AndHighMedDayTaxoFacets: +ref +above +facets:taxonomy:DayOfYear # freq=3793973 freq=246135
+AndHighMedDayTaxoFacets: +have +uses +facets:taxonomy:DayOfYear # freq=1297121 freq=134331
+AndHighMedDayTaxoFacets: +who +80 +facets:taxonomy:DayOfYear # freq=1196171 freq=104865
+AndHighMedDayTaxoFacets: +2008 +series +facets:taxonomy:DayOfYear # freq=831253 freq=521861
+AndHighMedDayTaxoFacets: +ref +40 +facets:taxonomy:DayOfYear # freq=3793973 freq=221687
+AndHighMedDayTaxoFacets: +when +second +facets:taxonomy:DayOfYear # freq=1027487 freq=505575
+AndHighMedDayTaxoFacets: +at +parliament +facets:taxonomy:DayOfYear # freq=2857534 freq=127008
+AndHighMedDayTaxoFacets: +were +pacific +facets:taxonomy:DayOfYear # freq=1524630 freq=107648
+AndHighMedDayTaxoFacets: +2 +recent +facets:taxonomy:DayOfYear # freq=1549245 freq=113385
+AndHighMedDayTaxoFacets: +http +close +facets:taxonomy:DayOfYear # freq=3493581 freq=136706
+AndHighMedDayTaxoFacets: +has +power +facets:taxonomy:DayOfYear # freq=1502961 freq=262586
+AndHighMedDayTaxoFacets: +or +words +facets:taxonomy:DayOfYear # freq=1858841 freq=104783
+AndHighMedDayTaxoFacets: +after +mary +facets:taxonomy:DayOfYear # freq=1247398 freq=96445
+AndHighMedDayTaxoFacets: +3 +state +facets:taxonomy:DayOfYear # freq=1148799 freq=702598
+AndHighMedDayTaxoFacets: +its +directed +facets:taxonomy:DayOfYear # freq=1173450 freq=86592
+AndHighMedDayTaxoFacets: +more +army +facets:taxonomy:DayOfYear # freq=963533 freq=228105
+AndHighMedDayTaxoFacets: +see +genre +facets:taxonomy:DayOfYear # freq=1044180 freq=121233
+AndHighMedDayTaxoFacets: +5 +natural +facets:taxonomy:DayOfYear # freq=891361 freq=125503
+AndHighMedDayTaxoFacets: +into +ship +facets:taxonomy:DayOfYear # freq=888684 freq=113012
+AndHighMedDayTaxoFacets: +2005 +construction +facets:taxonomy:DayOfYear # freq=835460 freq=124179
+AndHighMedDayTaxoFacets: +some +found +facets:taxonomy:DayOfYear # freq=839919 freq=313247
+AndHighMedDayTaxoFacets: +2 +actor +facets:taxonomy:DayOfYear # freq=1549245 freq=144573
+AndHighMedDayTaxoFacets: +and +owned +facets:taxonomy:DayOfYear # freq=7318061 freq=93981
+AndHighMedDayTaxoFacets: +which +authority +facets:taxonomy:DayOfYear # freq=1963428 freq=85540
+AndHighMedDayTaxoFacets: +have +r +facets:taxonomy:DayOfYear # freq=1297121 freq=296283
+AndHighMedDayTaxoFacets: +is +approximately +facets:taxonomy:DayOfYear # freq=4074455 freq=88426
+AndHighMedDayTaxoFacets: +he +deletion +facets:taxonomy:DayOfYear # freq=1659434 freq=166633
+AndHighMedDayTaxoFacets: +and +jean +facets:taxonomy:DayOfYear # freq=7318061 freq=84299
+AndHighMedDayTaxoFacets: +have +43 +facets:taxonomy:DayOfYear # freq=1297121 freq=115496
+AndHighMedDayTaxoFacets: +only +daily +facets:taxonomy:DayOfYear # freq=875561 freq=111717
+AndHighMedDayTaxoFacets: +united +zealand +facets:taxonomy:DayOfYear # freq=1196944 freq=92761
+AndHighMedDayTaxoFacets: +also +read +facets:taxonomy:DayOfYear # freq=1959419 freq=86513
+AndHighMedDayTaxoFacets: +are +division +facets:taxonomy:DayOfYear # freq=1877802 freq=182624
+AndHighMedDayTaxoFacets: +for +seat +facets:taxonomy:DayOfYear # freq=4380011 freq=91288
+AndHighMedDayTaxoFacets: +2005 +hand +facets:taxonomy:DayOfYear # freq=835460 freq=119947
+AndHighMedDayTaxoFacets: +publisher +usually +facets:taxonomy:DayOfYear # freq=1289029 freq=176058
+AndHighMedDayTaxoFacets: +from +teams +facets:taxonomy:DayOfYear # freq=3224339 freq=105245
+AndHighMedDayTaxoFacets: +in +wife +facets:taxonomy:DayOfYear # freq=7320987 freq=130807
+AndHighMedDayTaxoFacets: +2006 +james +facets:taxonomy:DayOfYear # freq=889954 freq=281597
+AndHighMedDayTaxoFacets: +2005 +found +facets:taxonomy:DayOfYear # freq=835460 freq=313247
+AndHighMedDayTaxoFacets: +after +replaced +facets:taxonomy:DayOfYear # freq=1247398 freq=112506
+AndHighMedDayTaxoFacets: +5 +played +facets:taxonomy:DayOfYear # freq=891361 freq=248191
+AndHighMedDayTaxoFacets: +last +1945 +facets:taxonomy:DayOfYear # freq=958437 freq=106881
+AndHighMedDayTaxoFacets: +not +william +facets:taxonomy:DayOfYear # freq=1713264 freq=284592
+AndHighMedDayTaxoFacets: +may +changed +facets:taxonomy:DayOfYear # freq=1071932 freq=112032
+AndHighMedDayTaxoFacets: +one +might +facets:taxonomy:DayOfYear # freq=1527689 freq=114290
+AndHighMedDayTaxoFacets: +one +1966 +facets:taxonomy:DayOfYear # freq=1527689 freq=106672
+AndHighMedDayTaxoFacets: +2006 +mother +facets:taxonomy:DayOfYear # freq=889954 freq=122930
+AndHighMedDayTaxoFacets: +no +hi +facets:taxonomy:DayOfYear # freq=1045000 freq=91593
+AndHighMedDayTaxoFacets: +they +my +facets:taxonomy:DayOfYear # freq=1021945 freq=274256
+AndHighMedDayTaxoFacets: +it +london +facets:taxonomy:DayOfYear # freq=2675552 freq=348918
+AndHighMedDayTaxoFacets: +but +according +facets:taxonomy:DayOfYear # freq=1456553 freq=256949
+AndHighMedDayTaxoFacets: +an +results +facets:taxonomy:DayOfYear # freq=2628056 freq=137248
+AndHighMedDayTaxoFacets: +from +you +facets:taxonomy:DayOfYear # freq=3224339 freq=461587
+AndHighMedDayTaxoFacets: +web +single +facets:taxonomy:DayOfYear # freq=1118334 freq=283824
+AndHighMedDayTaxoFacets: +two +old +facets:taxonomy:DayOfYear # freq=1104053 freq=381809
+AndHighMedDayTaxoFacets: +some +daughter +facets:taxonomy:DayOfYear # freq=839919 freq=103883
+AndHighMedDayTaxoFacets: +url +various +facets:taxonomy:DayOfYear # freq=1513595 freq=224593
+AndHighMedDayTaxoFacets: +have +would +facets:taxonomy:DayOfYear # freq=1297121 freq=690480
+AndHighMedDayTaxoFacets: +to +released +facets:taxonomy:DayOfYear # freq=6155577 freq=322473
+AndHighMedDayTaxoFacets: +had +refer +facets:taxonomy:DayOfYear # freq=1246743 freq=110259
+AndHighMedDayTaxoFacets: +url +article +facets:taxonomy:DayOfYear # freq=1513595 freq=610650
+AndHighMedDayTaxoFacets: +when +designed +facets:taxonomy:DayOfYear # freq=1027487 freq=118748
+AndHighMedDayTaxoFacets: +which +party +facets:taxonomy:DayOfYear # freq=1963428 freq=394410
+AndHighMedDayTaxoFacets: +a +florida +facets:taxonomy:DayOfYear # freq=6560531 freq=92166
+AndHighMedDayTaxoFacets: +the +image_caption +facets:taxonomy:DayOfYear # freq=8217362 freq=87977
+AndHighMedDayTaxoFacets: +last +width +facets:taxonomy:DayOfYear # freq=958437 freq=172609
+AndHighMedDayTaxoFacets: +may +r +facets:taxonomy:DayOfYear # freq=1071932 freq=296283
+AndHighMedDayTaxoFacets: +at +inside +facets:taxonomy:DayOfYear # freq=2857534 freq=84712
+AndHighMedDayTaxoFacets: +3 +p +facets:taxonomy:DayOfYear # freq=1148799 freq=616159
+AndHighMedDayTaxoFacets: +2009 +imperial +facets:taxonomy:DayOfYear # freq=887702 freq=86508
+AndHighMedDayTaxoFacets: +for +access +facets:taxonomy:DayOfYear # freq=4380011 freq=100041
+AndHighMedDayTaxoFacets: +some +former +facets:taxonomy:DayOfYear # freq=839919 freq=332750
+AndHighMedDayTaxoFacets: +url +important +facets:taxonomy:DayOfYear # freq=1513595 freq=195851
+AndHighMedDayTaxoFacets: +which +recorded +facets:taxonomy:DayOfYear # freq=1963428 freq=160249
+AndHighMedDayTaxoFacets: +of +family +facets:taxonomy:DayOfYear # freq=8184358 freq=387175
+AndHighMedDayTaxoFacets: +2 +family +facets:taxonomy:DayOfYear # freq=1549245 freq=387175
+AndHighMedDayTaxoFacets: +was +old +facets:taxonomy:DayOfYear # freq=3763623 freq=381809
+AndHighMedDayTaxoFacets: +more +jpg +facets:taxonomy:DayOfYear # freq=963533 freq=322278
+AndHighMedDayTaxoFacets: +2005 +1979 +facets:taxonomy:DayOfYear # freq=835460 freq=145407
+AndHighMedDayTaxoFacets: +are +became +facets:taxonomy:DayOfYear # freq=1877802 freq=465594
+AndHighMedDayTaxoFacets: +new +products +facets:taxonomy:DayOfYear # freq=1657293 freq=88448
+AndHighMedDayTaxoFacets: +first +mexico +facets:taxonomy:DayOfYear # freq=1933372 freq=88689
+AndHighMedDayTaxoFacets: +10 +nbsp +facets:taxonomy:DayOfYear # freq=918339 freq=506054
+AndHighMedDayTaxoFacets: +by +25 +facets:taxonomy:DayOfYear # freq=3826691 freq=491957
+AndHighMedDayTaxoFacets: +was +language +facets:taxonomy:DayOfYear # freq=3763623 freq=416771
+AndHighMedDayTaxoFacets: +and +future +facets:taxonomy:DayOfYear # freq=7318061 freq=136421
+AndHighMedDayTaxoFacets: +their +flight +facets:taxonomy:DayOfYear # freq=1158682 freq=84316
+AndHighMedDayTaxoFacets: +2011 +hold +facets:taxonomy:DayOfYear # freq=871410 freq=82579
+AndHighMedDayTaxoFacets: +there +programs +facets:taxonomy:DayOfYear # freq=956153 freq=83974
+AndHighMedDayTaxoFacets: +after +original +facets:taxonomy:DayOfYear # freq=1247398 freq=323521
+AndHighMedDayTaxoFacets: +only +ten +facets:taxonomy:DayOfYear # freq=875561 freq=114388
+AndHighMedDayTaxoFacets: +to +traditional +facets:taxonomy:DayOfYear # freq=6155577 freq=110425
+AndHighMedDayTaxoFacets: +also +centre +facets:taxonomy:DayOfYear # freq=1959419 freq=159597
+AndHighMedDayTaxoFacets: +all +isbn +facets:taxonomy:DayOfYear # freq=1203572 freq=467574
+AndHighMedDayTaxoFacets: +this +direct +facets:taxonomy:DayOfYear # freq=2224932 freq=82292
+AndHighMedDayTaxoFacets: +http +earlier +facets:taxonomy:DayOfYear # freq=3493581 freq=100372
+AndHighMedDayTaxoFacets: +cite +system +facets:taxonomy:DayOfYear # freq=1741194 freq=412862
+AndHighMedDayTaxoFacets: +were +library +facets:taxonomy:DayOfYear # freq=1524630 freq=138468
+AndHighMedDayTaxoFacets: +first +alone +facets:taxonomy:DayOfYear # freq=1933372 freq=93166
+AndHighMedDayTaxoFacets: +new +century +facets:taxonomy:DayOfYear # freq=1657293 freq=385541
+AndHighMedDayTaxoFacets: +s +reached +facets:taxonomy:DayOfYear # freq=1581243 freq=89854
+AndHighMedDayTaxoFacets: +united +le +facets:taxonomy:DayOfYear # freq=1196944 freq=84979
+AndHighMedDayTaxoFacets: +url +auto +facets:taxonomy:DayOfYear # freq=1513595 freq=103107
+AndHighMedDayTaxoFacets: +3 +practice +facets:taxonomy:DayOfYear # freq=1148799 freq=93287
+AndHighMedDayTaxoFacets: +http +working +facets:taxonomy:DayOfYear # freq=3493581 freq=144617
+AndHighMedDayTaxoFacets: +in +fire +facets:taxonomy:DayOfYear # freq=7320987 freq=133712
+AndHighMedDayTaxoFacets: +10 +52 +facets:taxonomy:DayOfYear # freq=918339 freq=108395
+AndHighMedDayTaxoFacets: +more +singer +facets:taxonomy:DayOfYear # freq=963533 freq=114006
+AndHighMedDayTaxoFacets: +new +low +facets:taxonomy:DayOfYear # freq=1657293 freq=157852
+AndHighMedDayTaxoFacets: +with +previously +facets:taxonomy:DayOfYear # freq=3709421 freq=96083
+AndHighMedDayTaxoFacets: +first +original +facets:taxonomy:DayOfYear # freq=1933372 freq=323521
+AndHighMedDayTaxoFacets: +2008 +wikitable +facets:taxonomy:DayOfYear # freq=831253 freq=210990
+AndHighMedDayTaxoFacets: +http +can +facets:taxonomy:DayOfYear # freq=3493581 freq=765163
+AndHighMedDayTaxoFacets: +year +1965 +facets:taxonomy:DayOfYear # freq=1235231 freq=104539
+AndHighMedDayTaxoFacets: +have +mother +facets:taxonomy:DayOfYear # freq=1297121 freq=122930
+AndHighMedDayTaxoFacets: +states +lived +facets:taxonomy:DayOfYear # freq=1034872 freq=91327
+AndHighMedDayTaxoFacets: +to +me +facets:taxonomy:DayOfYear # freq=6155577 freq=229204
+AndHighMedDayTaxoFacets: +4 +race +facets:taxonomy:DayOfYear # freq=986452 freq=148763
+AndHighMedDayTaxoFacets: +of +54 +facets:taxonomy:DayOfYear # freq=8184358 freq=101462
+AndHighMedDayTaxoFacets: +some +series +facets:taxonomy:DayOfYear # freq=839919 freq=521861
+AndHighMedDayTaxoFacets: +2 +big +facets:taxonomy:DayOfYear # freq=1549245 freq=163394
+AndHighMedDayTaxoFacets: +some +without +facets:taxonomy:DayOfYear # freq=839919 freq=249926
+AndHighMedDayTaxoFacets: +2011 +font +facets:taxonomy:DayOfYear # freq=871410 freq=269439
+AndHighMedDayTaxoFacets: +http +votes +facets:taxonomy:DayOfYear # freq=3493581 freq=93844
+AndHighMedDayTaxoFacets: +2009 +19th +facets:taxonomy:DayOfYear # freq=887702 freq=93290
+AndHighMedDayTaxoFacets: +an +central +facets:taxonomy:DayOfYear # freq=2628056 freq=272531
+AndHighMedDayTaxoFacets: +some +1959 +facets:taxonomy:DayOfYear # freq=839919 freq=87097
+AndHighMedDayTaxoFacets: +cite +out +facets:taxonomy:DayOfYear # freq=1741194 freq=733775
+AndHighMedDayTaxoFacets: +was +cross +facets:taxonomy:DayOfYear # freq=3763623 freq=127216
+AndHighMedDayTaxoFacets: +3 +1950 +facets:taxonomy:DayOfYear # freq=1148799 freq=89746
+AndHighMedDayTaxoFacets: +there +market +facets:taxonomy:DayOfYear # freq=956153 freq=118467
+AndHighMedDayTaxoFacets: +new +mid +facets:taxonomy:DayOfYear # freq=1657293 freq=126355
+AndHighMedDayTaxoFacets: +or +sent +facets:taxonomy:DayOfYear # freq=1858841 freq=103620
+AndHighMedDayTaxoFacets: +may +pp +facets:taxonomy:DayOfYear # freq=1071932 freq=204742
+AndHighMedDayTaxoFacets: +the +flagicon +facets:taxonomy:DayOfYear # freq=8217362 freq=107428
+AndHighMedDayTaxoFacets: +who +genre +facets:taxonomy:DayOfYear # freq=1196171 freq=121233
+AndHighMedDayTaxoFacets: +last +library +facets:taxonomy:DayOfYear # freq=958437 freq=138468
+AndHighMedDayTaxoFacets: +and +none +facets:taxonomy:DayOfYear # freq=7318061 freq=100192
+AndHighMedDayTaxoFacets: +an +majority +facets:taxonomy:DayOfYear # freq=2628056 freq=105058
+AndHighMedDayTaxoFacets: +it +religion +facets:taxonomy:DayOfYear # freq=2675552 freq=96655
+AndHighMedDayTaxoFacets: +first +brown +facets:taxonomy:DayOfYear # freq=1933372 freq=116178
+AndHighMedDayTaxoFacets: +more +standard +facets:taxonomy:DayOfYear # freq=963533 freq=185039
+AndHighMedDayTaxoFacets: +into +process +facets:taxonomy:DayOfYear # freq=888684 freq=152588
+AndHighMedDayTaxoFacets: +for +website +facets:taxonomy:DayOfYear # freq=4380011 freq=435941
+AndHighMedDayTaxoFacets: +name +parts +facets:taxonomy:DayOfYear # freq=2827713 freq=123891
+AndHighMedDayTaxoFacets: +for +few +facets:taxonomy:DayOfYear # freq=4380011 freq=226422
+AndHighMedDayTaxoFacets: +web +available +facets:taxonomy:DayOfYear # freq=1118334 freq=175514
+AndHighMedDayTaxoFacets: +other +christian +facets:taxonomy:DayOfYear # freq=1269961 freq=140312
+AndHighMedDayTaxoFacets: +2 +imperial +facets:taxonomy:DayOfYear # freq=1549245 freq=86508
+AndHighMedDayTaxoFacets: +at +space +facets:taxonomy:DayOfYear # freq=2857534 freq=163436
+AndHighMedDayTaxoFacets: +but +paul +facets:taxonomy:DayOfYear # freq=1456553 freq=207229
+AndHighMedDayTaxoFacets: +into +70 +facets:taxonomy:DayOfYear # freq=888684 freq=90305
+AndHighMedDayTaxoFacets: +s +mdash +facets:taxonomy:DayOfYear # freq=1581243 freq=111708
+AndHighMedDayTaxoFacets: +5 +brown +facets:taxonomy:DayOfYear # freq=891361 freq=116178
+AndHighMedDayTaxoFacets: +2005 +hill +facets:taxonomy:DayOfYear # freq=835460 freq=133714
+AndHighMedDayTaxoFacets: +2006 +eight +facets:taxonomy:DayOfYear # freq=889954 freq=106268
+AndHighMedDayTaxoFacets: +two +era +facets:taxonomy:DayOfYear # freq=1104053 freq=95989
+AndHighMedDayTaxoFacets: +time +100 +facets:taxonomy:DayOfYear # freq=1032071 freq=268978
+AndHighMedDayTaxoFacets: +title +70 +facets:taxonomy:DayOfYear # freq=2397378 freq=90305
+AndHighMedDayTaxoFacets: +3 +empire +facets:taxonomy:DayOfYear # freq=1148799 freq=143207
+AndHighMedDayTaxoFacets: +in +di +facets:taxonomy:DayOfYear # freq=7320987 freq=83139
+AndHighMedDayTaxoFacets: +and +included +facets:taxonomy:DayOfYear # freq=7318061 freq=216978
+AndHighMedDayTaxoFacets: +that +play +facets:taxonomy:DayOfYear # freq=2931020 freq=210199
+AndHighMedDayTaxoFacets: +an +might +facets:taxonomy:DayOfYear # freq=2628056 freq=114290
+AndHighMedDayTaxoFacets: +other +country +facets:taxonomy:DayOfYear # freq=1269961 freq=420052
+AndHighMedDayTaxoFacets: +also +success +facets:taxonomy:DayOfYear # freq=1959419 freq=112195
+AndHighMedDayTaxoFacets: +also +27 +facets:taxonomy:DayOfYear # freq=1959419 freq=383042
+AndHighMedDayTaxoFacets: +more +stations +facets:taxonomy:DayOfYear # freq=963533 freq=92011
+AndHighMedDayTaxoFacets: +they +system +facets:taxonomy:DayOfYear # freq=1021945 freq=412862
+AndHighMedDayTaxoFacets: +in +31 +facets:taxonomy:DayOfYear # freq=7320987 freq=298349
+AndHighMedDayTaxoFacets: +all +provided +facets:taxonomy:DayOfYear # freq=1203572 freq=110088
+AndHighMedDayTaxoFacets: +i +u.s +facets:taxonomy:DayOfYear # freq=956148 freq=428534
+AndHighMedDayTaxoFacets: +a +certain +facets:taxonomy:DayOfYear # freq=6560531 freq=105714
+AndHighMedDayTaxoFacets: +his +summary +facets:taxonomy:DayOfYear # freq=1777780 freq=106702
+AndHighMedDayTaxoFacets: +2009 +america +facets:taxonomy:DayOfYear # freq=887702 freq=240374
+AndHighMedDayTaxoFacets: +1 +chicago +facets:taxonomy:DayOfYear # freq=1641090 freq=117756
+AndHighMedDayTaxoFacets: +other +2000 +facets:taxonomy:DayOfYear # freq=1269961 freq=499639
+AndHighMedDayTaxoFacets: +year +men +facets:taxonomy:DayOfYear # freq=1235231 freq=182445
+AndHighMedDayTaxoFacets: +4 +upon +facets:taxonomy:DayOfYear # freq=986452 freq=169174
+AndHighMedDayTaxoFacets: +in +seems +facets:taxonomy:DayOfYear # freq=7320987 freq=83963
+AndHighMedDayTaxoFacets: +he +bank +facets:taxonomy:DayOfYear # freq=1659434 freq=88080
+AndHighMedDayTaxoFacets: +name +both +facets:taxonomy:DayOfYear # freq=2827713 freq=534900
+AndHighMedDayTaxoFacets: +publisher +e +facets:taxonomy:DayOfYear # freq=1289029 freq=408741
+AndHighMedDayTaxoFacets: +who +computer +facets:taxonomy:DayOfYear # freq=1196171 freq=126524
+AndHighMedDayTaxoFacets: +about +type +facets:taxonomy:DayOfYear # freq=850283 freq=318210
+AndHighMedDayTaxoFacets: +this +people +facets:taxonomy:DayOfYear # freq=2224932 freq=790960
+AndHighMedDayTaxoFacets: +their +1978 +facets:taxonomy:DayOfYear # freq=1158682 freq=135223
+AndHighMedDayTaxoFacets: +url +museum +facets:taxonomy:DayOfYear # freq=1513595 freq=135250
+AndHighMedDayTaxoFacets: +4 +least +facets:taxonomy:DayOfYear # freq=986452 freq=146209
+AndHighMedDayTaxoFacets: +2011 +money +facets:taxonomy:DayOfYear # freq=871410 freq=100440
+AndHighMedDayTaxoFacets: +first +referred +facets:taxonomy:DayOfYear # freq=1933372 freq=94811
+AndHighMedDayTaxoFacets: +he +20 +facets:taxonomy:DayOfYear # freq=1659434 freq=624967
+AndHighMedDayTaxoFacets: +were +events +facets:taxonomy:DayOfYear # freq=1524630 freq=158248
+AndHighMedDayTaxoFacets: +it +because +facets:taxonomy:DayOfYear # freq=2675552 freq=413003
+AndHighMedDayTaxoFacets: +accessdate +large +facets:taxonomy:DayOfYear # freq=1228887 freq=308888
+AndHighMedDayTaxoFacets: +there +usa +facets:taxonomy:DayOfYear # freq=956153 freq=191220
+AndHighMedDayTaxoFacets: +he +association +facets:taxonomy:DayOfYear # freq=1659434 freq=247156
+AndHighMedDayTaxoFacets: +2010 +rest +facets:taxonomy:DayOfYear # freq=950573 freq=95113
+AndHighMedDayTaxoFacets: +he +face +facets:taxonomy:DayOfYear # freq=1659434 freq=95144
+AndHighMedDayTaxoFacets: +title +out +facets:taxonomy:DayOfYear # freq=2397378 freq=733775
+AndHighMedDayTaxoFacets: +first +christian +facets:taxonomy:DayOfYear # freq=1933372 freq=140312
+AndHighMedDayTaxoFacets: +has +april +facets:taxonomy:DayOfYear # freq=1502961 freq=587542
+AndHighMedDayTaxoFacets: +in +very +facets:taxonomy:DayOfYear # freq=7320987 freq=354898
+AndHighMedDayTaxoFacets: +no +century +facets:taxonomy:DayOfYear # freq=1045000 freq=385541
+AndHighMedDayTaxoFacets: +accessdate +recording +facets:taxonomy:DayOfYear # freq=1228887 freq=90757
+AndHighMedDayTaxoFacets: +by +55 +facets:taxonomy:DayOfYear # freq=3826691 freq=110526
+AndHighMedDayTaxoFacets: +2005 +54 +facets:taxonomy:DayOfYear # freq=835460 freq=101462
+AndHighMedDayTaxoFacets: +this +x +facets:taxonomy:DayOfYear # freq=2224932 freq=272695
+AndHighMedDayTaxoFacets: +url +following +facets:taxonomy:DayOfYear # freq=1513595 freq=416515
+AndHighMedDayTaxoFacets: +s +per +facets:taxonomy:DayOfYear # freq=1581243 freq=283568
+AndHighMedDayTaxoFacets: +2005 +bureau +facets:taxonomy:DayOfYear # freq=835460 freq=83671
+AndHighMedDayTaxoFacets: +1 +09 +facets:taxonomy:DayOfYear # freq=1641090 freq=296300
+AndHighMedDayTaxoFacets: +title +buildings +facets:taxonomy:DayOfYear # freq=2397378 freq=89046
+AndHighMedDayTaxoFacets: +by +appears +facets:taxonomy:DayOfYear # freq=3826691 freq=104511
+AndHighMedDayTaxoFacets: +year +taken +facets:taxonomy:DayOfYear # freq=1235231 freq=166217
+AndHighMedDayTaxoFacets: +on +size +facets:taxonomy:DayOfYear # freq=4074624 freq=237662
+AndHighMedDayTaxoFacets: +2005 +thomas +facets:taxonomy:DayOfYear # freq=835460 freq=191625
+AndHighMedDayTaxoFacets: +2008 +chicago +facets:taxonomy:DayOfYear # freq=831253 freq=117756
+AndHighMedDayTaxoFacets: +2 +1991 +facets:taxonomy:DayOfYear # freq=1549245 freq=207589
+AndHighMedDayTaxoFacets: +only +2003 +facets:taxonomy:DayOfYear # freq=875561 freq=456990
+AndHighMedDayTaxoFacets: +their +found +facets:taxonomy:DayOfYear # freq=1158682 freq=313247
+AndHighMedDayTaxoFacets: +for +long +facets:taxonomy:DayOfYear # freq=4380011 freq=385787
+AndHighMedDayTaxoFacets: +2011 +low +facets:taxonomy:DayOfYear # freq=871410 freq=157852
+AndHighMedDayTaxoFacets: +for +iii +facets:taxonomy:DayOfYear # freq=4380011 freq=123618
+AndHighMedDayTaxoFacets: +is +1990s +facets:taxonomy:DayOfYear # freq=4074455 freq=83166
+AndHighMedDayTaxoFacets: +some +instead +facets:taxonomy:DayOfYear # freq=839919 freq=149345
+AndHighMedDayTaxoFacets: +publisher +historical +facets:taxonomy:DayOfYear # freq=1289029 freq=159636
+AndHighMedDayTaxoFacets: +are +please +facets:taxonomy:DayOfYear # freq=1877802 freq=229602
+AndHighMedDayTaxoFacets: +who +brown +facets:taxonomy:DayOfYear # freq=1196171 freq=116178
+AndHighMedDayTaxoFacets: +an +professional +facets:taxonomy:DayOfYear # freq=2628056 freq=138520
+AndHighMedDayTaxoFacets: +name +security +facets:taxonomy:DayOfYear # freq=2827713 freq=89382
+AndHighMedDayTaxoFacets: +name +8 +facets:taxonomy:DayOfYear # freq=2827713 freq=635822
+AndHighMedDayTaxoFacets: +from +china +facets:taxonomy:DayOfYear # freq=3224339 freq=130849
+AndHighMedDayTaxoFacets: +a +early +facets:taxonomy:DayOfYear # freq=6560531 freq=482793
+AndHighMedDayTaxoFacets: +cite +changes +facets:taxonomy:DayOfYear # freq=1741194 freq=105677
+AndHighMedDayTaxoFacets: +it +debate +facets:taxonomy:DayOfYear # freq=2675552 freq=177827
+AndHighMedDayTaxoFacets: +by +total +facets:taxonomy:DayOfYear # freq=3826691 freq=230013
+AndHighMedDayTaxoFacets: +it +event +facets:taxonomy:DayOfYear # freq=2675552 freq=114340
+AndHighMedDayTaxoFacets: +2005 +cup +facets:taxonomy:DayOfYear # freq=835460 freq=141942
+AndHighMedDayTaxoFacets: +publisher +1950 +facets:taxonomy:DayOfYear # freq=1289029 freq=89746
+AndHighMedDayTaxoFacets: +no +christian +facets:taxonomy:DayOfYear # freq=1045000 freq=140312
+AndHighMedDayTaxoFacets: +from +forces +facets:taxonomy:DayOfYear # freq=3224339 freq=152939
+AndHighMedDayTaxoFacets: +when +between +facets:taxonomy:DayOfYear # freq=1027487 freq=630650
+AndHighMedDayTaxoFacets: +its +words +facets:taxonomy:DayOfYear # freq=1173450 freq=104783
+AndHighMedDayTaxoFacets: +a +she +facets:taxonomy:DayOfYear # freq=6560531 freq=426267
+AndHighMedDayTaxoFacets: +s +align +facets:taxonomy:DayOfYear # freq=1581243 freq=300455
+AndHighMedDayTaxoFacets: +http +served +facets:taxonomy:DayOfYear # freq=3493581 freq=188351
+AndHighMedDayTaxoFacets: +of +finally +facets:taxonomy:DayOfYear # freq=8184358 freq=99185
+AndHighMedDayTaxoFacets: +some +pre +facets:taxonomy:DayOfYear # freq=839919 freq=90549
+AndHighMedDayTaxoFacets: +which +am +facets:taxonomy:DayOfYear # freq=1963428 freq=127152
+AndHighMedDayTaxoFacets: +with +governor +facets:taxonomy:DayOfYear # freq=3709421 freq=102274
+AndHighMedDayTaxoFacets: +publisher +f.c +facets:taxonomy:DayOfYear # freq=1289029 freq=83548
+AndHighMedDayTaxoFacets: +on +player +facets:taxonomy:DayOfYear # freq=4074624 freq=241451
+AndHighMedDayTaxoFacets: +time +including +facets:taxonomy:DayOfYear # freq=1032071 freq=521324
+AndHighMedDayTaxoFacets: +work +1950 +facets:taxonomy:DayOfYear # freq=853422 freq=89746
+AndHighMedDayTaxoFacets: +http +now +facets:taxonomy:DayOfYear # freq=3493581 freq=484114
+AndHighMedDayTaxoFacets: +is +separate +facets:taxonomy:DayOfYear # freq=4074455 freq=88604
+AndHighMedDayTaxoFacets: +be +having +facets:taxonomy:DayOfYear # freq=2051702 freq=213416
+AndHighMedDayTaxoFacets: +its +practice +facets:taxonomy:DayOfYear # freq=1173450 freq=93287
+AndHighMedDayTaxoFacets: +new +30 +facets:taxonomy:DayOfYear # freq=1657293 freq=488930
+AndHighMedDayTaxoFacets: +date +most +facets:taxonomy:DayOfYear # freq=2020626 freq=819634
+AndHighMedDayTaxoFacets: +by +railway +facets:taxonomy:DayOfYear # freq=3826691 freq=125543
+AndHighMedDayTaxoFacets: +that +related +facets:taxonomy:DayOfYear # freq=2931020 freq=174856
+AndHighMedDayTaxoFacets: +other +data +facets:taxonomy:DayOfYear # freq=1269961 freq=159657
+AndHighMedDayTaxoFacets: +an +daily +facets:taxonomy:DayOfYear # freq=2628056 freq=111717
+AndHighMedDayTaxoFacets: +web +performance +facets:taxonomy:DayOfYear # freq=1118334 freq=130862
+AndHighMedDayTaxoFacets: +their +engine +facets:taxonomy:DayOfYear # freq=1158682 freq=100930
+AndHighMedDayTaxoFacets: +states +found +facets:taxonomy:DayOfYear # freq=1034872 freq=313247
+AndHighMedDayTaxoFacets: +name +takes +facets:taxonomy:DayOfYear # freq=2827713 freq=95889
+AndHighMedDayTaxoFacets: +cite +editor +facets:taxonomy:DayOfYear # freq=1741194 freq=119419
+AndHighMedDayTaxoFacets: +last +canadian +facets:taxonomy:DayOfYear # freq=958437 freq=181906
+AndHighMedDayTaxoFacets: +2 +jersey +facets:taxonomy:DayOfYear # freq=1549245 freq=88847
+AndHighMedDayTaxoFacets: +5 +far +facets:taxonomy:DayOfYear # freq=891361 freq=143873
+AndHighMedDayTaxoFacets: +it +3rd +facets:taxonomy:DayOfYear # freq=2675552 freq=90723
+AndHighMedDayTaxoFacets: +ref +say +facets:taxonomy:DayOfYear # freq=3793973 freq=110895
+AndHighMedDayTaxoFacets: +be +forces +facets:taxonomy:DayOfYear # freq=2051702 freq=152939
+AndHighMedDayTaxoFacets: +2010 +where +facets:taxonomy:DayOfYear # freq=950573 freq=630647
+AndHighMedDayTaxoFacets: +states +earlier +facets:taxonomy:DayOfYear # freq=1034872 freq=100372
+AndHighMedDayTaxoFacets: +has +organization +facets:taxonomy:DayOfYear # freq=1502961 freq=119614
+AndHighMedDayTaxoFacets: +its +fiction +facets:taxonomy:DayOfYear # freq=1173450 freq=87227
+AndHighMedDayTaxoFacets: +it +star +facets:taxonomy:DayOfYear # freq=2675552 freq=195768
+AndHighMedDayTaxoFacets: +have +speed +facets:taxonomy:DayOfYear # freq=1297121 freq=99899
+AndHighMedDayTaxoFacets: +into +2nd +facets:taxonomy:DayOfYear # freq=888684 freq=167463
+AndHighMedDayTaxoFacets: +name +having +facets:taxonomy:DayOfYear # freq=2827713 freq=213416
+AndHighMedDayTaxoFacets: +his +head +facets:taxonomy:DayOfYear # freq=1777780 freq=194682
+AndHighMedDayTaxoFacets: +when +change +facets:taxonomy:DayOfYear # freq=1027487 freq=182336
+AndHighMedDayTaxoFacets: +2005 +edit +facets:taxonomy:DayOfYear # freq=835460 freq=129064
+AndHighMedDayTaxoFacets: +about +mass +facets:taxonomy:DayOfYear # freq=850283 freq=82794
+AndHighMedDayTaxoFacets: +not +profile +facets:taxonomy:DayOfYear # freq=1713264 freq=86788
+AndHighMedDayTaxoFacets: +of +mayor +facets:taxonomy:DayOfYear # freq=8184358 freq=88578
+AndHighMedDayTaxoFacets: +no +woman +facets:taxonomy:DayOfYear # freq=1045000 freq=92071
+AndHighMedDayTaxoFacets: +from +these +facets:taxonomy:DayOfYear # freq=3224339 freq=623267
+AndHighMedDayTaxoFacets: +2005 +literature +facets:taxonomy:DayOfYear # freq=835460 freq=96743
+AndHighMedDayTaxoFacets: +an +07 +facets:taxonomy:DayOfYear # freq=2628056 freq=299351
+AndHighMedDayTaxoFacets: +that +age +facets:taxonomy:DayOfYear # freq=2931020 freq=395368
+AndHighMedDayTaxoFacets: +2008 +august +facets:taxonomy:DayOfYear # freq=831253 freq=527806
+AndHighMedDayTaxoFacets: +date +type +facets:taxonomy:DayOfYear # freq=2020626 freq=318210
+AndHighMedDayTaxoFacets: +other +most +facets:taxonomy:DayOfYear # freq=1269961 freq=819634
+AndHighMedDayTaxoFacets: +his +mark +facets:taxonomy:DayOfYear # freq=1777780 freq=160033
+AndHighMedDayTaxoFacets: +was +elected +facets:taxonomy:DayOfYear # freq=3763623 freq=119941
+AndHighMedDayTaxoFacets: +title +parliament +facets:taxonomy:DayOfYear # freq=2397378 freq=127008
+AndHighMedDayTaxoFacets: +been +27 +facets:taxonomy:DayOfYear # freq=1041183 freq=383042
+AndHighMedDayTaxoFacets: +publisher +western +facets:taxonomy:DayOfYear # freq=1289029 freq=232781
+AndHighMedDayTaxoFacets: +its +done +facets:taxonomy:DayOfYear # freq=1173450 freq=102033
+AndHighMedDayTaxoFacets: +more +web.archive.org +facets:taxonomy:DayOfYear # freq=963533 freq=95902
+AndHighMedDayTaxoFacets: +date +half +facets:taxonomy:DayOfYear # freq=2020626 freq=155387
+AndHighMedDayTaxoFacets: +that +lower +facets:taxonomy:DayOfYear # freq=2931020 freq=127260
+AndHighMedDayTaxoFacets: +more +already +facets:taxonomy:DayOfYear # freq=963533 freq=126694
+AndHighMedDayTaxoFacets: +for +report +facets:taxonomy:DayOfYear # freq=4380011 freq=153204
+AndHighMedDayTaxoFacets: +5 +ed +facets:taxonomy:DayOfYear # freq=891361 freq=134224
+AndHighMedDayTaxoFacets: +http +1965 +facets:taxonomy:DayOfYear # freq=3493581 freq=104539
+AndHighMedDayTaxoFacets: +s +debate +facets:taxonomy:DayOfYear # freq=1581243 freq=177827
+AndHighMedDayTaxoFacets: +only +official +facets:taxonomy:DayOfYear # freq=875561 freq=326177
+AndHighMedDayTaxoFacets: +2006 +seat +facets:taxonomy:DayOfYear # freq=889954 freq=91288
+AndHighMedDayTaxoFacets: +in +27 +facets:taxonomy:DayOfYear # freq=7320987 freq=383042
+AndHighMedDayTaxoFacets: +cite +fields +facets:taxonomy:DayOfYear # freq=1741194 freq=86938
+AndHighMedDayTaxoFacets: +states +remained +facets:taxonomy:DayOfYear # freq=1034872 freq=107736
+AndHighMedDayTaxoFacets: +for +hold +facets:taxonomy:DayOfYear # freq=4380011 freq=82579
+AndHighMedDayTaxoFacets: +2011 +joseph +facets:taxonomy:DayOfYear # freq=871410 freq=121533
+AndHighMedDayTaxoFacets: +2009 +met +facets:taxonomy:DayOfYear # freq=887702 freq=84001
+AndHighMedDayTaxoFacets: +an +31 +facets:taxonomy:DayOfYear # freq=2628056 freq=298349
+AndHighMedDayTaxoFacets: +there +hill +facets:taxonomy:DayOfYear # freq=956153 freq=133714
+AndHighMedDayTaxoFacets: +3 +allowed +facets:taxonomy:DayOfYear # freq=1148799 freq=98720
+AndHighMedDayTaxoFacets: +4 +table +facets:taxonomy:DayOfYear # freq=986452 freq=99163
+AndHighMedDayTaxoFacets: +accessdate +later +facets:taxonomy:DayOfYear # freq=1228887 freq=604921
+AndHighMedDayTaxoFacets: +2008 +rather +facets:taxonomy:DayOfYear # freq=831253 freq=174136
+AndHighMedDayTaxoFacets: +also +late +facets:taxonomy:DayOfYear # freq=1959419 freq=243636
+AndHighMedDayTaxoFacets: +2008 +60 +facets:taxonomy:DayOfYear # freq=831253 freq=118403
+AndHighMedDayTaxoFacets: +1 +why +facets:taxonomy:DayOfYear # freq=1641090 freq=108161
+AndHighMedDayTaxoFacets: +new +winning +facets:taxonomy:DayOfYear # freq=1657293 freq=95704
+AndHighMedDayTaxoFacets: +accessdate +towards +facets:taxonomy:DayOfYear # freq=1228887 freq=95574
+AndHighMedDayTaxoFacets: +date +t +facets:taxonomy:DayOfYear # freq=2020626 freq=262832
+AndHighMedDayTaxoFacets: +2 +nbsp +facets:taxonomy:DayOfYear # freq=1549245 freq=506054
+AndHighMedDayTaxoFacets: +time +website +facets:taxonomy:DayOfYear # freq=1032071 freq=435941
+AndHighMedDayTaxoFacets: +5 +republic +facets:taxonomy:DayOfYear # freq=891361 freq=166154
+AndHighMedDayTaxoFacets: +were +hold +facets:taxonomy:DayOfYear # freq=1524630 freq=82579
+AndHighMedDayTaxoFacets: +the +whom +facets:taxonomy:DayOfYear # freq=8217362 freq=95520
+AndHighMedDayTaxoFacets: +http +free +facets:taxonomy:DayOfYear # freq=3493581 freq=270199
+AndHighMedDayTaxoFacets: +his +self +facets:taxonomy:DayOfYear # freq=1777780 freq=135012
+AndHighMedDayTaxoFacets: +with +music +facets:taxonomy:DayOfYear # freq=3709421 freq=473240
+AndHighMedDayTaxoFacets: +is +academy +facets:taxonomy:DayOfYear # freq=4074455 freq=119055
+AndHighMedDayTaxoFacets: +year +appearance +facets:taxonomy:DayOfYear # freq=1235231 freq=89229
+AndHighMedDayTaxoFacets: +year +square +facets:taxonomy:DayOfYear # freq=1235231 freq=123538
+AndHighMedDayTaxoFacets: +i +h +facets:taxonomy:DayOfYear # freq=956148 freq=241946
+AndHighMedDayTaxoFacets: +by +35 +facets:taxonomy:DayOfYear # freq=3826691 freq=155506
+AndHighMedDayTaxoFacets: +2005 +sports +facets:taxonomy:DayOfYear # freq=835460 freq=178542
+AndHighMedDayTaxoFacets: +united +series +facets:taxonomy:DayOfYear # freq=1196944 freq=521861
+AndHighMedDayTaxoFacets: +may +congress +facets:taxonomy:DayOfYear # freq=1071932 freq=92382
+AndHighMedDayTaxoFacets: +title +la +facets:taxonomy:DayOfYear # freq=2397378 freq=232610
+AndHighMedDayTaxoFacets: +its +category:american +facets:taxonomy:DayOfYear # freq=1173450 freq=107823
+AndHighMedDayTaxoFacets: +the +lake +facets:taxonomy:DayOfYear # freq=8217362 freq=131603
+AndHighMedDayTaxoFacets: +who +foundation +facets:taxonomy:DayOfYear # freq=1196171 freq=107123
+AndHighMedDayTaxoFacets: +3 +57 +facets:taxonomy:DayOfYear # freq=1148799 freq=93708
+AndHighMedDayTaxoFacets: +date +flag +facets:taxonomy:DayOfYear # freq=2020626 freq=104210
+AndHighMedDayTaxoFacets: +10 +dq +facets:taxonomy:DayOfYear # freq=918339 freq=88557
+AndHighMedDayTaxoFacets: +that +study +facets:taxonomy:DayOfYear # freq=2931020 freq=137170
+AndHighMedDayTaxoFacets: +first +france +facets:taxonomy:DayOfYear # freq=1933372 freq=220058
+AndHighMedDayTaxoFacets: +on +culture +facets:taxonomy:DayOfYear # freq=4074624 freq=157773
+AndHighMedDayTaxoFacets: +to +1984 +facets:taxonomy:DayOfYear # freq=6155577 freq=161404
+AndHighMedDayTaxoFacets: +all +u.s +facets:taxonomy:DayOfYear # freq=1203572 freq=428534
+AndHighMedDayTaxoFacets: +name +era +facets:taxonomy:DayOfYear # freq=2827713 freq=95989
+AndHighMedDayTaxoFacets: +url +02 +facets:taxonomy:DayOfYear # freq=1513595 freq=319783
+AndHighMedDayTaxoFacets: +a +teams +facets:taxonomy:DayOfYear # freq=6560531 freq=105245
+AndHighMedDayTaxoFacets: +name +paul +facets:taxonomy:DayOfYear # freq=2827713 freq=207229
+AndHighMedDayTaxoFacets: +2008 +command +facets:taxonomy:DayOfYear # freq=831253 freq=87496
+AndHighMedDayTaxoFacets: +after +today +facets:taxonomy:DayOfYear # freq=1247398 freq=168864
+AndHighMedDayTaxoFacets: +no +native +facets:taxonomy:DayOfYear # freq=1045000 freq=129103
+AndHighMedDayTaxoFacets: +into +st +facets:taxonomy:DayOfYear # freq=888684 freq=309092
+AndHighMedDayTaxoFacets: +accessdate +m +facets:taxonomy:DayOfYear # freq=1228887 freq=441232
+AndHighMedDayTaxoFacets: +a +heart +facets:taxonomy:DayOfYear # freq=6560531 freq=95365
+AndHighMedDayTaxoFacets: +2010 +1986 +facets:taxonomy:DayOfYear # freq=950573 freq=167724
+AndHighMedDayTaxoFacets: +2008 +remained +facets:taxonomy:DayOfYear # freq=831253 freq=107736
+AndHighMedDayTaxoFacets: +this +college +facets:taxonomy:DayOfYear # freq=2224932 freq=278094
+AndHighMedDayTaxoFacets: +date +note +facets:taxonomy:DayOfYear # freq=2020626 freq=194472
+AndHighMedDayTaxoFacets: +5 +coast +facets:taxonomy:DayOfYear # freq=891361 freq=119047
+AndHighMedDayTaxoFacets: +time +sometimes +facets:taxonomy:DayOfYear # freq=1032071 freq=144078
+AndHighMedDayTaxoFacets: +3 +look +facets:taxonomy:DayOfYear # freq=1148799 freq=91122
+AndHighMedDayTaxoFacets: +states +people +facets:taxonomy:DayOfYear # freq=1034872 freq=790960
+AndHighMedDayTaxoFacets: +to +specific +facets:taxonomy:DayOfYear # freq=6155577 freq=93622
+AndHighMedDayTaxoFacets: +year +between +facets:taxonomy:DayOfYear # freq=1235231 freq=630650
+AndHighMedDayTaxoFacets: +publisher +led +facets:taxonomy:DayOfYear # freq=1289029 freq=210033
+AndHighMedDayTaxoFacets: +a +given +facets:taxonomy:DayOfYear # freq=6560531 freq=235719
+AndHighMedDayTaxoFacets: +2008 +stations +facets:taxonomy:DayOfYear # freq=831253 freq=92011
+AndHighMedDayTaxoFacets: +his +england +facets:taxonomy:DayOfYear # freq=1777780 freq=317884
+AndHighMedDayTaxoFacets: +states +geo +facets:taxonomy:DayOfYear # freq=1034872 freq=83404
+AndHighMedDayTaxoFacets: +at +1960 +facets:taxonomy:DayOfYear # freq=2857534 freq=109083
+AndHighMedDayTaxoFacets: +be +60 +facets:taxonomy:DayOfYear # freq=2051702 freq=118403
+AndHighMedDayTaxoFacets: +there +schools +facets:taxonomy:DayOfYear # freq=956153 freq=141308
+AndHighMedDayTaxoFacets: +that +value +facets:taxonomy:DayOfYear # freq=2931020 freq=86806
+AndHighMedDayTaxoFacets: +no +needed +facets:taxonomy:DayOfYear # freq=1045000 freq=281051
+AndHighMedDayTaxoFacets: +2011 +31 +facets:taxonomy:DayOfYear # freq=871410 freq=298349
+AndHighMedDayTaxoFacets: +year +16 +facets:taxonomy:DayOfYear # freq=1235231 freq=540539
+AndHighMedDayTaxoFacets: +title +set +facets:taxonomy:DayOfYear # freq=2397378 freq=294255
+AndHighMedDayTaxoFacets: +work +sport +facets:taxonomy:DayOfYear # freq=853422 freq=106696
+AndHighMedDayTaxoFacets: +all +42 +facets:taxonomy:DayOfYear # freq=1203572 freq=124253
+OrHighMedDayTaxoFacets: there background +facets:taxonomy:DayOfYear # freq=956153 freq=314229
+OrHighMedDayTaxoFacets: be important +facets:taxonomy:DayOfYear # freq=2051702 freq=195851
+OrHighMedDayTaxoFacets: name cd +facets:taxonomy:DayOfYear # freq=2827713 freq=87105
+OrHighMedDayTaxoFacets: when regular +facets:taxonomy:DayOfYear # freq=1027487 freq=93809
+OrHighMedDayTaxoFacets: 1 called +facets:taxonomy:DayOfYear # freq=1641090 freq=454580
+OrHighMedDayTaxoFacets: may force +facets:taxonomy:DayOfYear # freq=1071932 freq=198556
+OrHighMedDayTaxoFacets: 1 regular +facets:taxonomy:DayOfYear # freq=1641090 freq=93809
+OrHighMedDayTaxoFacets: s 1986 +facets:taxonomy:DayOfYear # freq=1581243 freq=167724
+OrHighMedDayTaxoFacets: 2011 co +facets:taxonomy:DayOfYear # freq=871410 freq=209086
+OrHighMedDayTaxoFacets: he artist +facets:taxonomy:DayOfYear # freq=1659434 freq=210591
+OrHighMedDayTaxoFacets: 2009 him +facets:taxonomy:DayOfYear # freq=887702 freq=507350
+OrHighMedDayTaxoFacets: at interest +facets:taxonomy:DayOfYear # freq=2857534 freq=108551
+OrHighMedDayTaxoFacets: and 1959 +facets:taxonomy:DayOfYear # freq=7318061 freq=87097
+OrHighMedDayTaxoFacets: had few +facets:taxonomy:DayOfYear # freq=1246743 freq=226422
+OrHighMedDayTaxoFacets: this era +facets:taxonomy:DayOfYear # freq=2224932 freq=95989
+OrHighMedDayTaxoFacets: also video +facets:taxonomy:DayOfYear # freq=1959419 freq=202380
+OrHighMedDayTaxoFacets: into capital +facets:taxonomy:DayOfYear # freq=888684 freq=120421
+OrHighMedDayTaxoFacets: who los +facets:taxonomy:DayOfYear # freq=1196171 freq=145404
+OrHighMedDayTaxoFacets: that ii +facets:taxonomy:DayOfYear # freq=2931020 freq=340800
+OrHighMedDayTaxoFacets: as working +facets:taxonomy:DayOfYear # freq=3925535 freq=144617
+OrHighMedDayTaxoFacets: accessdate status +facets:taxonomy:DayOfYear # freq=1228887 freq=133818
+OrHighMedDayTaxoFacets: not put +facets:taxonomy:DayOfYear # freq=1713264 freq=139882
+OrHighMedDayTaxoFacets: cite soviet +facets:taxonomy:DayOfYear # freq=1741194 freq=89070
+OrHighMedDayTaxoFacets: see reading +facets:taxonomy:DayOfYear # freq=1044180 freq=101214
+OrHighMedDayTaxoFacets: all area +facets:taxonomy:DayOfYear # freq=1203572 freq=559023
+OrHighMedDayTaxoFacets: his influence +facets:taxonomy:DayOfYear # freq=1777780 freq=83101
+OrHighMedDayTaxoFacets: new less +facets:taxonomy:DayOfYear # freq=1657293 freq=170266
+OrHighMedDayTaxoFacets: states 14 +facets:taxonomy:DayOfYear # freq=1034872 freq=534005
+OrHighMedDayTaxoFacets: no april +facets:taxonomy:DayOfYear # freq=1045000 freq=587542
+OrHighMedDayTaxoFacets: http wife +facets:taxonomy:DayOfYear # freq=3493581 freq=130807
+OrHighMedDayTaxoFacets: had stories +facets:taxonomy:DayOfYear # freq=1246743 freq=110223
+OrHighMedDayTaxoFacets: this established +facets:taxonomy:DayOfYear # freq=2224932 freq=282471
+OrHighMedDayTaxoFacets: other source +facets:taxonomy:DayOfYear # freq=1269961 freq=231838
+OrHighMedDayTaxoFacets: 1 alone +facets:taxonomy:DayOfYear # freq=1641090 freq=93166
+OrHighMedDayTaxoFacets: and per +facets:taxonomy:DayOfYear # freq=7318061 freq=283568
+OrHighMedDayTaxoFacets: into larger +facets:taxonomy:DayOfYear # freq=888684 freq=87424
+OrHighMedDayTaxoFacets: to book +facets:taxonomy:DayOfYear # freq=6155577 freq=617297
+OrHighMedDayTaxoFacets: at london +facets:taxonomy:DayOfYear # freq=2857534 freq=348918
+OrHighMedDayTaxoFacets: at km +facets:taxonomy:DayOfYear # freq=2857534 freq=233831
+OrHighMedDayTaxoFacets: in convert +facets:taxonomy:DayOfYear # freq=7320987 freq=267974
+OrHighMedDayTaxoFacets: s yet +facets:taxonomy:DayOfYear # freq=1581243 freq=100857
+OrHighMedDayTaxoFacets: 1 1973 +facets:taxonomy:DayOfYear # freq=1641090 freq=125985
+OrHighMedDayTaxoFacets: 1 yet +facets:taxonomy:DayOfYear # freq=1641090 freq=100857
+OrHighMedDayTaxoFacets: 3 preserved +facets:taxonomy:DayOfYear # freq=1148799 freq=111088
+OrHighMedDayTaxoFacets: when various +facets:taxonomy:DayOfYear # freq=1027487 freq=224593
+OrHighMedDayTaxoFacets: his result +facets:taxonomy:DayOfYear # freq=1777780 freq=276803
+OrHighMedDayTaxoFacets: into film +facets:taxonomy:DayOfYear # freq=888684 freq=432758
+OrHighMedDayTaxoFacets: was leader +facets:taxonomy:DayOfYear # freq=3763623 freq=127591
+OrHighMedDayTaxoFacets: see list +facets:taxonomy:DayOfYear # freq=1044180 freq=585922
+OrHighMedDayTaxoFacets: first institute +facets:taxonomy:DayOfYear # freq=1933372 freq=136311
+OrHighMedDayTaxoFacets: work got +facets:taxonomy:DayOfYear # freq=853422 freq=92640
+OrHighMedDayTaxoFacets: had rule +facets:taxonomy:DayOfYear # freq=1246743 freq=86729
+OrHighMedDayTaxoFacets: 1 thought +facets:taxonomy:DayOfYear # freq=1641090 freq=108963
+OrHighMedDayTaxoFacets: an hard +facets:taxonomy:DayOfYear # freq=2628056 freq=90149
+OrHighMedDayTaxoFacets: only 1972 +facets:taxonomy:DayOfYear # freq=875561 freq=130791
+OrHighMedDayTaxoFacets: was american +facets:taxonomy:DayOfYear # freq=3763623 freq=758337
+OrHighMedDayTaxoFacets: 2009 lines +facets:taxonomy:DayOfYear # freq=887702 freq=96969
+OrHighMedDayTaxoFacets: no followed +facets:taxonomy:DayOfYear # freq=1045000 freq=121848
+OrHighMedDayTaxoFacets: had five +facets:taxonomy:DayOfYear # freq=1246743 freq=262923
+OrHighMedDayTaxoFacets: was q +facets:taxonomy:DayOfYear # freq=3763623 freq=149271
+OrHighMedDayTaxoFacets: cite wikipedia +facets:taxonomy:DayOfYear # freq=1741194 freq=149673
+OrHighMedDayTaxoFacets: other already +facets:taxonomy:DayOfYear # freq=1269961 freq=126694
+OrHighMedDayTaxoFacets: it keep +facets:taxonomy:DayOfYear # freq=2675552 freq=177996
+OrHighMedDayTaxoFacets: states t +facets:taxonomy:DayOfYear # freq=1034872 freq=262832
+OrHighMedDayTaxoFacets: 1 listed +facets:taxonomy:DayOfYear # freq=1641090 freq=94990
+OrHighMedDayTaxoFacets: there modify +facets:taxonomy:DayOfYear # freq=956153 freq=109819
+OrHighMedDayTaxoFacets: url win +facets:taxonomy:DayOfYear # freq=1513595 freq=121070
+OrHighMedDayTaxoFacets: may 39 +facets:taxonomy:DayOfYear # freq=1071932 freq=132689
+OrHighMedDayTaxoFacets: two charles +facets:taxonomy:DayOfYear # freq=1104053 freq=204987
+OrHighMedDayTaxoFacets: also appears +facets:taxonomy:DayOfYear # freq=1959419 freq=104511
+OrHighMedDayTaxoFacets: more rowspan +facets:taxonomy:DayOfYear # freq=963533 freq=124637
+OrHighMedDayTaxoFacets: web north +facets:taxonomy:DayOfYear # freq=1118334 freq=564195
+OrHighMedDayTaxoFacets: 1 smith +facets:taxonomy:DayOfYear # freq=1641090 freq=126344
+OrHighMedDayTaxoFacets: 2010 2000 +facets:taxonomy:DayOfYear # freq=950573 freq=499639
+OrHighMedDayTaxoFacets: they features +facets:taxonomy:DayOfYear # freq=1021945 freq=156867
+OrHighMedDayTaxoFacets: 2 project +facets:taxonomy:DayOfYear # freq=1549245 freq=180139
+OrHighMedDayTaxoFacets: http instead +facets:taxonomy:DayOfYear # freq=3493581 freq=149345
+OrHighMedDayTaxoFacets: by am +facets:taxonomy:DayOfYear # freq=3826691 freq=127152
+OrHighMedDayTaxoFacets: it pacific +facets:taxonomy:DayOfYear # freq=2675552 freq=107648
+OrHighMedDayTaxoFacets: states times +facets:taxonomy:DayOfYear # freq=1034872 freq=407155
+OrHighMedDayTaxoFacets: name middle +facets:taxonomy:DayOfYear # freq=2827713 freq=156728
+OrHighMedDayTaxoFacets: is 1988 +facets:taxonomy:DayOfYear # freq=4074455 freq=181327
+OrHighMedDayTaxoFacets: 5 c +facets:taxonomy:DayOfYear # freq=891361 freq=444247
+OrHighMedDayTaxoFacets: their court +facets:taxonomy:DayOfYear # freq=1158682 freq=169309
+OrHighMedDayTaxoFacets: they double +facets:taxonomy:DayOfYear # freq=1021945 freq=87304
+OrHighMedDayTaxoFacets: in george +facets:taxonomy:DayOfYear # freq=7320987 freq=256196
+OrHighMedDayTaxoFacets: after appears +facets:taxonomy:DayOfYear # freq=1247398 freq=104511
+OrHighMedDayTaxoFacets: is thomas +facets:taxonomy:DayOfYear # freq=4074455 freq=191625
+OrHighMedDayTaxoFacets: about specific +facets:taxonomy:DayOfYear # freq=850283 freq=93622
+OrHighMedDayTaxoFacets: be captain +facets:taxonomy:DayOfYear # freq=2051702 freq=91635
+OrHighMedDayTaxoFacets: be journal +facets:taxonomy:DayOfYear # freq=2051702 freq=348162
+OrHighMedDayTaxoFacets: this month +facets:taxonomy:DayOfYear # freq=2224932 freq=162128
+OrHighMedDayTaxoFacets: last given +facets:taxonomy:DayOfYear # freq=958437 freq=235719
+OrHighMedDayTaxoFacets: from running +facets:taxonomy:DayOfYear # freq=3224339 freq=101764
+OrHighMedDayTaxoFacets: 2008 liberal +facets:taxonomy:DayOfYear # freq=831253 freq=93070
+OrHighMedDayTaxoFacets: i island +facets:taxonomy:DayOfYear # freq=956148 freq=203023
+OrHighMedDayTaxoFacets: or pp +facets:taxonomy:DayOfYear # freq=1858841 freq=204742
+OrHighMedDayTaxoFacets: which earth +facets:taxonomy:DayOfYear # freq=1963428 freq=110512
+OrHighMedDayTaxoFacets: united school +facets:taxonomy:DayOfYear # freq=1196944 freq=462166
+OrHighMedDayTaxoFacets: at fall +facets:taxonomy:DayOfYear # freq=2857534 freq=103379
+OrHighMedDayTaxoFacets: by talk +facets:taxonomy:DayOfYear # freq=3826691 freq=364194
+OrHighMedDayTaxoFacets: title appropriate +facets:taxonomy:DayOfYear # freq=2397378 freq=135343
+OrHighMedDayTaxoFacets: first data +facets:taxonomy:DayOfYear # freq=1933372 freq=159657
+OrHighMedDayTaxoFacets: by community +facets:taxonomy:DayOfYear # freq=3826691 freq=225571
+OrHighMedDayTaxoFacets: it anti +facets:taxonomy:DayOfYear # freq=2675552 freq=99993
+OrHighMedDayTaxoFacets: 2005 would +facets:taxonomy:DayOfYear # freq=835460 freq=690480
+OrHighMedDayTaxoFacets: no archive +facets:taxonomy:DayOfYear # freq=1045000 freq=215381
+OrHighMedDayTaxoFacets: had 11 +facets:taxonomy:DayOfYear # freq=1246743 freq=730505
+OrHighMedDayTaxoFacets: which 978 +facets:taxonomy:DayOfYear # freq=1963428 freq=101276
+OrHighMedDayTaxoFacets: accessdate seems +facets:taxonomy:DayOfYear # freq=1228887 freq=83963
+OrHighMedDayTaxoFacets: 2011 commission +facets:taxonomy:DayOfYear # freq=871410 freq=91476
+OrHighMedDayTaxoFacets: that county +facets:taxonomy:DayOfYear # freq=2931020 freq=521126
+OrHighMedDayTaxoFacets: they hard +facets:taxonomy:DayOfYear # freq=1021945 freq=90149
+OrHighMedDayTaxoFacets: first historic +facets:taxonomy:DayOfYear # freq=1933372 freq=112292
+OrHighMedDayTaxoFacets: this category +facets:taxonomy:DayOfYear # freq=2224932 freq=595446
+OrHighMedDayTaxoFacets: its counties +facets:taxonomy:DayOfYear # freq=1173450 freq=87574
+OrHighMedDayTaxoFacets: year 1963 +facets:taxonomy:DayOfYear # freq=1235231 freq=96439
+OrHighMedDayTaxoFacets: this include +facets:taxonomy:DayOfYear # freq=2224932 freq=276466
+OrHighMedDayTaxoFacets: one british +facets:taxonomy:DayOfYear # freq=1527689 freq=417307
+OrHighMedDayTaxoFacets: was world +facets:taxonomy:DayOfYear # freq=3763623 freq=808563
+OrHighMedDayTaxoFacets: the references +facets:taxonomy:DayOfYear # freq=8217362 freq=760306
+OrHighMedDayTaxoFacets: its 56 +facets:taxonomy:DayOfYear # freq=1173450 freq=96215
+OrHighMedDayTaxoFacets: their son +facets:taxonomy:DayOfYear # freq=1158682 freq=202340
+OrHighMedDayTaxoFacets: the federal +facets:taxonomy:DayOfYear # freq=8217362 freq=166274
+OrHighMedDayTaxoFacets: with jpg +facets:taxonomy:DayOfYear # freq=3709421 freq=322278
+OrHighMedDayTaxoFacets: on training +facets:taxonomy:DayOfYear # freq=4074624 freq=107271
+OrHighMedDayTaxoFacets: for famous +facets:taxonomy:DayOfYear # freq=4380011 freq=139092
+OrHighMedDayTaxoFacets: work run +facets:taxonomy:DayOfYear # freq=853422 freq=183609
+OrHighMedDayTaxoFacets: which start +facets:taxonomy:DayOfYear # freq=1963428 freq=233925
+OrHighMedDayTaxoFacets: and author +facets:taxonomy:DayOfYear # freq=7318061 freq=567768
+OrHighMedDayTaxoFacets: name mother +facets:taxonomy:DayOfYear # freq=2827713 freq=122930
+OrHighMedDayTaxoFacets: who current +facets:taxonomy:DayOfYear # freq=1196171 freq=217174
+OrHighMedDayTaxoFacets: s vote +facets:taxonomy:DayOfYear # freq=1581243 freq=96871
+OrHighMedDayTaxoFacets: 4 51 +facets:taxonomy:DayOfYear # freq=986452 freq=108800
+OrHighMedDayTaxoFacets: 2011 special +facets:taxonomy:DayOfYear # freq=871410 freq=198917
+OrHighMedDayTaxoFacets: accessdate st +facets:taxonomy:DayOfYear # freq=1228887 freq=309092
+OrHighMedDayTaxoFacets: about must +facets:taxonomy:DayOfYear # freq=850283 freq=228491
+OrHighMedDayTaxoFacets: had census +facets:taxonomy:DayOfYear # freq=1246743 freq=205166
+OrHighMedDayTaxoFacets: publisher 56 +facets:taxonomy:DayOfYear # freq=1289029 freq=96215
+OrHighMedDayTaxoFacets: other 12 +facets:taxonomy:DayOfYear # freq=1269961 freq=774572
+OrHighMedDayTaxoFacets: or 22 +facets:taxonomy:DayOfYear # freq=1858841 freq=502778
+OrHighMedDayTaxoFacets: of deletion +facets:taxonomy:DayOfYear # freq=8184358 freq=166633
+OrHighMedDayTaxoFacets: as married +facets:taxonomy:DayOfYear # freq=3925535 freq=156752
+OrHighMedDayTaxoFacets: also do +facets:taxonomy:DayOfYear # freq=1959419 freq=511178
+OrHighMedDayTaxoFacets: of larger +facets:taxonomy:DayOfYear # freq=8184358 freq=87424
+OrHighMedDayTaxoFacets: the wikipedia:persondata +facets:taxonomy:DayOfYear # freq=8217362 freq=222385
+OrHighMedDayTaxoFacets: be books +facets:taxonomy:DayOfYear # freq=2051702 freq=341376
+OrHighMedDayTaxoFacets: url george +facets:taxonomy:DayOfYear # freq=1513595 freq=256196
+OrHighMedDayTaxoFacets: accessdate del +facets:taxonomy:DayOfYear # freq=1228887 freq=82614
+OrHighMedDayTaxoFacets: about command +facets:taxonomy:DayOfYear # freq=850283 freq=87496
+OrHighMedDayTaxoFacets: there soon +facets:taxonomy:DayOfYear # freq=956153 freq=123657
+OrHighMedDayTaxoFacets: url special +facets:taxonomy:DayOfYear # freq=1513595 freq=198917
+OrHighMedDayTaxoFacets: may authority +facets:taxonomy:DayOfYear # freq=1071932 freq=85540
+OrHighMedDayTaxoFacets: url ever +facets:taxonomy:DayOfYear # freq=1513595 freq=128732
+OrHighMedDayTaxoFacets: see 1987 +facets:taxonomy:DayOfYear # freq=1044180 freq=172453
+OrHighMedDayTaxoFacets: his ended +facets:taxonomy:DayOfYear # freq=1777780 freq=84664
+OrHighMedDayTaxoFacets: who prime +facets:taxonomy:DayOfYear # freq=1196171 freq=96945
+OrHighMedDayTaxoFacets: a success +facets:taxonomy:DayOfYear # freq=6560531 freq=112195
+OrHighMedDayTaxoFacets: cite elected +facets:taxonomy:DayOfYear # freq=1741194 freq=119941
+OrHighMedDayTaxoFacets: 2008 without +facets:taxonomy:DayOfYear # freq=831253 freq=249926
+OrHighMedDayTaxoFacets: after km +facets:taxonomy:DayOfYear # freq=1247398 freq=233831
+OrHighMedDayTaxoFacets: no fields +facets:taxonomy:DayOfYear # freq=1045000 freq=86938
+OrHighMedDayTaxoFacets: the financial +facets:taxonomy:DayOfYear # freq=8217362 freq=82536
+OrHighMedDayTaxoFacets: had features +facets:taxonomy:DayOfYear # freq=1246743 freq=156867
+OrHighMedDayTaxoFacets: into dead +facets:taxonomy:DayOfYear # freq=888684 freq=171386
+OrHighMedDayTaxoFacets: of caused +facets:taxonomy:DayOfYear # freq=8184358 freq=86397
+OrHighMedDayTaxoFacets: as changes +facets:taxonomy:DayOfYear # freq=3925535 freq=105677
+OrHighMedDayTaxoFacets: no president +facets:taxonomy:DayOfYear # freq=1045000 freq=263341
+OrHighMedDayTaxoFacets: one within +facets:taxonomy:DayOfYear # freq=1527689 freq=291049
+OrHighMedDayTaxoFacets: at mark +facets:taxonomy:DayOfYear # freq=2857534 freq=160033
+OrHighMedDayTaxoFacets: first down +facets:taxonomy:DayOfYear # freq=1933372 freq=280662
+OrHighMedDayTaxoFacets: be leader +facets:taxonomy:DayOfYear # freq=2051702 freq=127591
+OrHighMedDayTaxoFacets: were know +facets:taxonomy:DayOfYear # freq=1524630 freq=129655
+OrHighMedDayTaxoFacets: s england +facets:taxonomy:DayOfYear # freq=1581243 freq=317884
+OrHighMedDayTaxoFacets: one set +facets:taxonomy:DayOfYear # freq=1527689 freq=294255
+OrHighMedDayTaxoFacets: 5 flight +facets:taxonomy:DayOfYear # freq=891361 freq=84316
+OrHighMedDayTaxoFacets: i works +facets:taxonomy:DayOfYear # freq=956148 freq=199177
+OrHighMedDayTaxoFacets: was 1982 +facets:taxonomy:DayOfYear # freq=3763623 freq=153269
+OrHighMedDayTaxoFacets: but 57 +facets:taxonomy:DayOfYear # freq=1456553 freq=93708
+OrHighMedDayTaxoFacets: date coord +facets:taxonomy:DayOfYear # freq=2020626 freq=180590
+OrHighMedDayTaxoFacets: cite science +facets:taxonomy:DayOfYear # freq=1741194 freq=219988
+OrHighMedDayTaxoFacets: two past +facets:taxonomy:DayOfYear # freq=1104053 freq=126130
+OrHighMedDayTaxoFacets: first albums +facets:taxonomy:DayOfYear # freq=1933372 freq=118322
+OrHighMedDayTaxoFacets: its 14 +facets:taxonomy:DayOfYear # freq=1173450 freq=534005
+OrHighMedDayTaxoFacets: when rowspan +facets:taxonomy:DayOfYear # freq=1027487 freq=124637
+OrHighMedDayTaxoFacets: for league +facets:taxonomy:DayOfYear # freq=4380011 freq=270223
+OrHighMedDayTaxoFacets: to keep +facets:taxonomy:DayOfYear # freq=6155577 freq=177996
+OrHighMedDayTaxoFacets: a baseball +facets:taxonomy:DayOfYear # freq=6560531 freq=93326
+OrHighMedDayTaxoFacets: publisher colspan +facets:taxonomy:DayOfYear # freq=1289029 freq=134521
+OrHighMedDayTaxoFacets: when release +facets:taxonomy:DayOfYear # freq=1027487 freq=189375
+OrHighMedDayTaxoFacets: see down +facets:taxonomy:DayOfYear # freq=1044180 freq=280662
+OrHighMedDayTaxoFacets: date does +facets:taxonomy:DayOfYear # freq=2020626 freq=232202
+OrHighMedDayTaxoFacets: s boston +facets:taxonomy:DayOfYear # freq=1581243 freq=85235
+OrHighMedDayTaxoFacets: but center +facets:taxonomy:DayOfYear # freq=1456553 freq=489673
+OrHighMedDayTaxoFacets: some originally +facets:taxonomy:DayOfYear # freq=839919 freq=168282
+OrHighMedDayTaxoFacets: all movement +facets:taxonomy:DayOfYear # freq=1203572 freq=131692
+OrHighMedDayTaxoFacets: an human +facets:taxonomy:DayOfYear # freq=2628056 freq=182617
+OrHighMedDayTaxoFacets: time life +facets:taxonomy:DayOfYear # freq=1032071 freq=477007
+OrHighMedDayTaxoFacets: first bridge +facets:taxonomy:DayOfYear # freq=1933372 freq=92398
+OrHighMedDayTaxoFacets: one comments +facets:taxonomy:DayOfYear # freq=1527689 freq=185637
+OrHighMedDayTaxoFacets: he background +facets:taxonomy:DayOfYear # freq=1659434 freq=314229
+OrHighMedDayTaxoFacets: 2006 1988 +facets:taxonomy:DayOfYear # freq=889954 freq=181327
+OrHighMedDayTaxoFacets: http fiction +facets:taxonomy:DayOfYear # freq=3493581 freq=87227
+OrHighMedDayTaxoFacets: 4 case +facets:taxonomy:DayOfYear # freq=986452 freq=207307
+OrHighMedDayTaxoFacets: there mike +facets:taxonomy:DayOfYear # freq=956153 freq=91795
+OrHighMedDayTaxoFacets: there 29 +facets:taxonomy:DayOfYear # freq=956153 freq=372091
+OrHighMedDayTaxoFacets: 2010 near +facets:taxonomy:DayOfYear # freq=950573 freq=254492
+OrHighMedDayTaxoFacets: url channel +facets:taxonomy:DayOfYear # freq=1513595 freq=101401
+OrHighMedDayTaxoFacets: two robert +facets:taxonomy:DayOfYear # freq=1104053 freq=246405
+OrHighMedDayTaxoFacets: or public +facets:taxonomy:DayOfYear # freq=1858841 freq=368868
+OrHighMedDayTaxoFacets: other robert +facets:taxonomy:DayOfYear # freq=1269961 freq=246405
+OrHighMedDayTaxoFacets: ref germany +facets:taxonomy:DayOfYear # freq=3793973 freq=190478
+OrHighMedDayTaxoFacets: one english +facets:taxonomy:DayOfYear # freq=1527689 freq=412061
+OrHighMedDayTaxoFacets: no cd +facets:taxonomy:DayOfYear # freq=1045000 freq=87105
+OrHighMedDayTaxoFacets: publisher what +facets:taxonomy:DayOfYear # freq=1289029 freq=394675
+OrHighMedDayTaxoFacets: their win +facets:taxonomy:DayOfYear # freq=1158682 freq=121070
+OrHighMedDayTaxoFacets: an 1959 +facets:taxonomy:DayOfYear # freq=2628056 freq=87097
+OrHighMedDayTaxoFacets: but digital +facets:taxonomy:DayOfYear # freq=1456553 freq=82650
+OrHighMedDayTaxoFacets: but 30 +facets:taxonomy:DayOfYear # freq=1456553 freq=488930
+OrHighMedDayTaxoFacets: work information +facets:taxonomy:DayOfYear # freq=853422 freq=353153
+OrHighMedDayTaxoFacets: by population +facets:taxonomy:DayOfYear # freq=3826691 freq=374481
+OrHighMedDayTaxoFacets: in post +facets:taxonomy:DayOfYear # freq=7320987 freq=218570
+OrHighMedDayTaxoFacets: who birth +facets:taxonomy:DayOfYear # freq=1196171 freq=425138
+OrHighMedDayTaxoFacets: who multiple +facets:taxonomy:DayOfYear # freq=1196171 freq=89684
+OrHighMedDayTaxoFacets: ref trade +facets:taxonomy:DayOfYear # freq=3793973 freq=106384
+OrHighMedDayTaxoFacets: after lord +facets:taxonomy:DayOfYear # freq=1247398 freq=106633
+OrHighMedDayTaxoFacets: to significant +facets:taxonomy:DayOfYear # freq=6155577 freq=111574
+OrHighMedDayTaxoFacets: also 1976 +facets:taxonomy:DayOfYear # freq=1959419 freq=134555
+OrHighMedDayTaxoFacets: which awards +facets:taxonomy:DayOfYear # freq=1963428 freq=159679
+OrHighMedDayTaxoFacets: by blue +facets:taxonomy:DayOfYear # freq=3826691 freq=156658
+OrHighMedDayTaxoFacets: that cause +facets:taxonomy:DayOfYear # freq=2931020 freq=83898
+OrHighMedDayTaxoFacets: about began +facets:taxonomy:DayOfYear # freq=850283 freq=276036
+OrHighMedDayTaxoFacets: other entire +facets:taxonomy:DayOfYear # freq=1269961 freq=97485
+OrHighMedDayTaxoFacets: has internet +facets:taxonomy:DayOfYear # freq=1502961 freq=85510
+OrHighMedDayTaxoFacets: url highest +facets:taxonomy:DayOfYear # freq=1513595 freq=91072
+OrHighMedDayTaxoFacets: an stage +facets:taxonomy:DayOfYear # freq=2628056 freq=113041
+OrHighMedDayTaxoFacets: title imagesize +facets:taxonomy:DayOfYear # freq=2397378 freq=82746
+OrHighMedDayTaxoFacets: see span +facets:taxonomy:DayOfYear # freq=1044180 freq=146676
+OrHighMedDayTaxoFacets: states 2007 +facets:taxonomy:DayOfYear # freq=1034872 freq=801586
+OrHighMedDayTaxoFacets: in clear +facets:taxonomy:DayOfYear # freq=7320987 freq=109812
+OrHighMedDayTaxoFacets: with jean +facets:taxonomy:DayOfYear # freq=3709421 freq=84299
+OrHighMedDayTaxoFacets: other dq +facets:taxonomy:DayOfYear # freq=1269961 freq=88557
+OrHighMedDayTaxoFacets: from chris +facets:taxonomy:DayOfYear # freq=3224339 freq=85523
+OrHighMedDayTaxoFacets: no next +facets:taxonomy:DayOfYear # freq=1045000 freq=259039
+OrHighMedDayTaxoFacets: for musical +facets:taxonomy:DayOfYear # freq=4380011 freq=132600
+OrHighMedDayTaxoFacets: see came +facets:taxonomy:DayOfYear # freq=1044180 freq=197126
+OrHighMedDayTaxoFacets: two wales +facets:taxonomy:DayOfYear # freq=1104053 freq=103595
+OrHighMedDayTaxoFacets: new eastern +facets:taxonomy:DayOfYear # freq=1657293 freq=176853
+OrHighMedDayTaxoFacets: 2 marriage +facets:taxonomy:DayOfYear # freq=1549245 freq=97658
+OrHighMedDayTaxoFacets: 2009 forces +facets:taxonomy:DayOfYear # freq=887702 freq=152939
+OrHighMedDayTaxoFacets: at any +facets:taxonomy:DayOfYear # freq=2857534 freq=483514
+OrHighMedDayTaxoFacets: as live +facets:taxonomy:DayOfYear # freq=3925535 freq=242147
+OrHighMedDayTaxoFacets: see academy +facets:taxonomy:DayOfYear # freq=1044180 freq=119055
+OrHighMedDayTaxoFacets: their get +facets:taxonomy:DayOfYear # freq=1158682 freq=187847
+OrHighMedDayTaxoFacets: about via +facets:taxonomy:DayOfYear # freq=850283 freq=109090
+OrHighMedDayTaxoFacets: only fields +facets:taxonomy:DayOfYear # freq=875561 freq=86938
+OrHighMedDayTaxoFacets: time central +facets:taxonomy:DayOfYear # freq=1032071 freq=272531
+OrHighMedDayTaxoFacets: two my +facets:taxonomy:DayOfYear # freq=1104053 freq=274256
+OrHighMedDayTaxoFacets: with land +facets:taxonomy:DayOfYear # freq=3709421 freq=230284
+OrHighMedDayTaxoFacets: two financial +facets:taxonomy:DayOfYear # freq=1104053 freq=82536
+OrHighMedDayTaxoFacets: was convert +facets:taxonomy:DayOfYear # freq=3763623 freq=267974
+OrHighMedDayTaxoFacets: not course +facets:taxonomy:DayOfYear # freq=1713264 freq=106126
+OrHighMedDayTaxoFacets: 10 producer +facets:taxonomy:DayOfYear # freq=918339 freq=137098
+OrHighMedDayTaxoFacets: 3 52 +facets:taxonomy:DayOfYear # freq=1148799 freq=108395
+OrHighMedDayTaxoFacets: 2008 final +facets:taxonomy:DayOfYear # freq=831253 freq=230006
+OrHighMedDayTaxoFacets: from sir +facets:taxonomy:DayOfYear # freq=3224339 freq=107709
+OrHighMedDayTaxoFacets: to majority +facets:taxonomy:DayOfYear # freq=6155577 freq=105058
+OrHighMedDayTaxoFacets: work published +facets:taxonomy:DayOfYear # freq=853422 freq=243548
+OrHighMedDayTaxoFacets: but might +facets:taxonomy:DayOfYear # freq=1456553 freq=114290
+OrHighMedDayTaxoFacets: has radio +facets:taxonomy:DayOfYear # freq=1502961 freq=183866
+OrHighMedDayTaxoFacets: of 45 +facets:taxonomy:DayOfYear # freq=8184358 freq=180879
+OrHighMedDayTaxoFacets: some africa +facets:taxonomy:DayOfYear # freq=839919 freq=124511
+OrHighMedDayTaxoFacets: title club +facets:taxonomy:DayOfYear # freq=2397378 freq=232173
+OrHighMedDayTaxoFacets: his bgcolor +facets:taxonomy:DayOfYear # freq=1777780 freq=124305
+OrHighMedDayTaxoFacets: that opened +facets:taxonomy:DayOfYear # freq=2931020 freq=140033
+OrHighMedDayTaxoFacets: new station +facets:taxonomy:DayOfYear # freq=1657293 freq=239572
+OrHighMedDayTaxoFacets: were value +facets:taxonomy:DayOfYear # freq=1524630 freq=86806
+OrHighMedDayTaxoFacets: time end +facets:taxonomy:DayOfYear # freq=1032071 freq=526636
+OrHighMedDayTaxoFacets: date start +facets:taxonomy:DayOfYear # freq=2020626 freq=233925
+OrHighMedDayTaxoFacets: 3 across +facets:taxonomy:DayOfYear # freq=1148799 freq=134478
+OrHighMedDayTaxoFacets: 1 j +facets:taxonomy:DayOfYear # freq=1641090 freq=327713
+OrHighMedDayTaxoFacets: the ever +facets:taxonomy:DayOfYear # freq=8217362 freq=128732
+OrHighMedDayTaxoFacets: s archive +facets:taxonomy:DayOfYear # freq=1581243 freq=215381
+OrHighMedDayTaxoFacets: date style +facets:taxonomy:DayOfYear # freq=2020626 freq=606000
+OrHighMedDayTaxoFacets: 2010 caused +facets:taxonomy:DayOfYear # freq=950573 freq=86397
+OrHighMedDayTaxoFacets: or past +facets:taxonomy:DayOfYear # freq=1858841 freq=126130
+OrHighMedDayTaxoFacets: also edits +facets:taxonomy:DayOfYear # freq=1959419 freq=134321
+OrHighMedDayTaxoFacets: http stated +facets:taxonomy:DayOfYear # freq=3493581 freq=89795
+OrHighMedDayTaxoFacets: publisher association +facets:taxonomy:DayOfYear # freq=1289029 freq=247156
+OrHighMedDayTaxoFacets: other europe +facets:taxonomy:DayOfYear # freq=1269961 freq=188671
+OrHighMedDayTaxoFacets: work japan +facets:taxonomy:DayOfYear # freq=853422 freq=163103
+OrHighMedDayTaxoFacets: been committee +facets:taxonomy:DayOfYear # freq=1041183 freq=108636
+OrHighMedDayTaxoFacets: about five +facets:taxonomy:DayOfYear # freq=850283 freq=262923
+OrHighMedDayTaxoFacets: the throughout +facets:taxonomy:DayOfYear # freq=8217362 freq=143603
+OrHighMedDayTaxoFacets: first studies +facets:taxonomy:DayOfYear # freq=1933372 freq=128020
+OrHighMedDayTaxoFacets: his university +facets:taxonomy:DayOfYear # freq=1777780 freq=636959
+OrHighMedDayTaxoFacets: there legal +facets:taxonomy:DayOfYear # freq=956153 freq=90645
+OrHighMedDayTaxoFacets: all italian +facets:taxonomy:DayOfYear # freq=1203572 freq=107082
+OrHighMedDayTaxoFacets: may buildings +facets:taxonomy:DayOfYear # freq=1071932 freq=89046
+OrHighMedDayTaxoFacets: with day +facets:taxonomy:DayOfYear # freq=3709421 freq=402096
+OrHighMedDayTaxoFacets: is code +facets:taxonomy:DayOfYear # freq=4074455 freq=170156
+OrHighMedDayTaxoFacets: date asia +facets:taxonomy:DayOfYear # freq=2020626 freq=90307
+OrHighMedDayTaxoFacets: and thumb +facets:taxonomy:DayOfYear # freq=7318061 freq=672667
+OrHighMedDayTaxoFacets: 10 1970 +facets:taxonomy:DayOfYear # freq=918339 freq=139043
+OrHighMedDayTaxoFacets: from generated +facets:taxonomy:DayOfYear # freq=3224339 freq=97908
+OrHighMedDayTaxoFacets: for light +facets:taxonomy:DayOfYear # freq=4380011 freq=161671
+OrHighMedDayTaxoFacets: about 1970 +facets:taxonomy:DayOfYear # freq=850283 freq=139043
+OrHighMedDayTaxoFacets: states start +facets:taxonomy:DayOfYear # freq=1034872 freq=233925
+OrHighMedDayTaxoFacets: 2 sir +facets:taxonomy:DayOfYear # freq=1549245 freq=107709
+OrHighMedDayTaxoFacets: from information +facets:taxonomy:DayOfYear # freq=3224339 freq=353153
+OrHighMedDayTaxoFacets: 3 reflist +facets:taxonomy:DayOfYear # freq=1148799 freq=561253
+OrHighMedDayTaxoFacets: year modern +facets:taxonomy:DayOfYear # freq=1235231 freq=218831
+OrHighMedDayTaxoFacets: states successful +facets:taxonomy:DayOfYear # freq=1034872 freq=106021
+OrHighMedDayTaxoFacets: on local +facets:taxonomy:DayOfYear # freq=4074624 freq=299012
+OrHighMedDayTaxoFacets: also production +facets:taxonomy:DayOfYear # freq=1959419 freq=191554
+OrHighMedDayTaxoFacets: ref white +facets:taxonomy:DayOfYear # freq=3793973 freq=299411
+OrHighMedDayTaxoFacets: that too +facets:taxonomy:DayOfYear # freq=2931020 freq=161626
+OrHighMedDayTaxoFacets: 2 20 +facets:taxonomy:DayOfYear # freq=1549245 freq=624967
+OrHighMedDayTaxoFacets: 2008 strong +facets:taxonomy:DayOfYear # freq=831253 freq=125611
+OrHighMedDayTaxoFacets: no list +facets:taxonomy:DayOfYear # freq=1045000 freq=585922
+OrHighMedDayTaxoFacets: first label +facets:taxonomy:DayOfYear # freq=1933372 freq=159161
+OrHighMedDayTaxoFacets: see metadata +facets:taxonomy:DayOfYear # freq=1044180 freq=298533
+OrHighMedDayTaxoFacets: they before +facets:taxonomy:DayOfYear # freq=1021945 freq=580481
+OrHighMedDayTaxoFacets: been volume +facets:taxonomy:DayOfYear # freq=1041183 freq=312846
+OrHighMedDayTaxoFacets: last division +facets:taxonomy:DayOfYear # freq=958437 freq=182624
+OrHighMedDayTaxoFacets: new 1988 +facets:taxonomy:DayOfYear # freq=1657293 freq=181327
+OrHighMedDayTaxoFacets: its single +facets:taxonomy:DayOfYear # freq=1173450 freq=283824
+OrHighMedDayTaxoFacets: accessdate awards +facets:taxonomy:DayOfYear # freq=1228887 freq=159679
+OrHighMedDayTaxoFacets: of 1974 +facets:taxonomy:DayOfYear # freq=8184358 freq=132835
+OrHighMedDayTaxoFacets: and st +facets:taxonomy:DayOfYear # freq=7318061 freq=309092
+OrHighMedDayTaxoFacets: which 2002 +facets:taxonomy:DayOfYear # freq=1963428 freq=406953
+OrHighMedDayTaxoFacets: 10 role +facets:taxonomy:DayOfYear # freq=918339 freq=208579
+OrHighMedDayTaxoFacets: 2008 infobox +facets:taxonomy:DayOfYear # freq=831253 freq=524810
+OrHighMedDayTaxoFacets: by units +facets:taxonomy:DayOfYear # freq=3826691 freq=118189
+OrHighMedDayTaxoFacets: see reported +facets:taxonomy:DayOfYear # freq=1044180 freq=91533
+OrHighMedDayTaxoFacets: were love +facets:taxonomy:DayOfYear # freq=1524630 freq=177242
+OrHighMedDayTaxoFacets: their london +facets:taxonomy:DayOfYear # freq=1158682 freq=348918
+OrHighMedDayTaxoFacets: who persondata +facets:taxonomy:DayOfYear # freq=1196171 freq=246119
+OrHighMedDayTaxoFacets: be uk +facets:taxonomy:DayOfYear # freq=2051702 freq=319211
+OrHighMedDayTaxoFacets: for f +facets:taxonomy:DayOfYear # freq=4380011 freq=278015
+OrHighMedDayTaxoFacets: only hold +facets:taxonomy:DayOfYear # freq=875561 freq=82579
+OrHighMedDayTaxoFacets: new way +facets:taxonomy:DayOfYear # freq=1657293 freq=318344
+OrHighMedDayTaxoFacets: which lines +facets:taxonomy:DayOfYear # freq=1963428 freq=96969
+OrHighMedDayTaxoFacets: has div +facets:taxonomy:DayOfYear # freq=1502961 freq=206057
+OrHighMedDayTaxoFacets: all francisco +facets:taxonomy:DayOfYear # freq=1203572 freq=83200
+OrHighMedDayTaxoFacets: from per +facets:taxonomy:DayOfYear # freq=3224339 freq=283568
+OrHighMedDayTaxoFacets: it marriage +facets:taxonomy:DayOfYear # freq=2675552 freq=97658
+OrHighMedDayTaxoFacets: states small +facets:taxonomy:DayOfYear # freq=1034872 freq=581643
+OrHighMedDayTaxoFacets: 2011 july +facets:taxonomy:DayOfYear # freq=871410 freq=529655
+OrHighMedDayTaxoFacets: and mid +facets:taxonomy:DayOfYear # freq=7318061 freq=126355
+OrHighMedDayTaxoFacets: year copy +facets:taxonomy:DayOfYear # freq=1235231 freq=95252
+OrHighMedDayTaxoFacets: not ft +facets:taxonomy:DayOfYear # freq=1713264 freq=88505
+OrHighMedDayTaxoFacets: this 1988 +facets:taxonomy:DayOfYear # freq=2224932 freq=181327
+OrHighMedDayTaxoFacets: accessdate father +facets:taxonomy:DayOfYear # freq=1228887 freq=175393
+OrHighMedDayTaxoFacets: this continued +facets:taxonomy:DayOfYear # freq=2224932 freq=151209
+OrHighMedDayTaxoFacets: with union +facets:taxonomy:DayOfYear # freq=3709421 freq=214164
+OrHighMedDayTaxoFacets: 2011 festival +facets:taxonomy:DayOfYear # freq=871410 freq=85717
+OrHighMedDayTaxoFacets: states hall +facets:taxonomy:DayOfYear # freq=1034872 freq=177247
+OrHighMedDayTaxoFacets: after thomas +facets:taxonomy:DayOfYear # freq=1247398 freq=191625
+OrHighMedDayTaxoFacets: 2 god +facets:taxonomy:DayOfYear # freq=1549245 freq=97443
+OrHighMedDayTaxoFacets: states owned +facets:taxonomy:DayOfYear # freq=1034872 freq=93981
+OrHighMedDayTaxoFacets: were european +facets:taxonomy:DayOfYear # freq=1524630 freq=193975
+OrHighMedDayTaxoFacets: have jack +facets:taxonomy:DayOfYear # freq=1297121 freq=91552
+OrHighMedDayTaxoFacets: time majority +facets:taxonomy:DayOfYear # freq=1032071 freq=105058
+OrHighMedDayTaxoFacets: were went +facets:taxonomy:DayOfYear # freq=1524630 freq=172677
+OrHighMedDayTaxoFacets: only game +facets:taxonomy:DayOfYear # freq=875561 freq=315157
+OrHighMedDayTaxoFacets: a review +facets:taxonomy:DayOfYear # freq=6560531 freq=240157
+OrHighMedDayTaxoFacets: united thomas +facets:taxonomy:DayOfYear # freq=1196944 freq=191625
+OrHighMedDayTaxoFacets: may off +facets:taxonomy:DayOfYear # freq=1071932 freq=315473
+OrHighMedDayTaxoFacets: url persondata +facets:taxonomy:DayOfYear # freq=1513595 freq=246119
+OrHighMedDayTaxoFacets: new hill +facets:taxonomy:DayOfYear # freq=1657293 freq=133714
+OrHighMedDayTaxoFacets: at ice +facets:taxonomy:DayOfYear # freq=2857534 freq=87086
+OrHighMedDayTaxoFacets: 2008 fourth +facets:taxonomy:DayOfYear # freq=831253 freq=102351
+OrHighMedDayTaxoFacets: for 3rd +facets:taxonomy:DayOfYear # freq=4380011 freq=90723
+OrHighMedDayTaxoFacets: more cross +facets:taxonomy:DayOfYear # freq=963533 freq=127216
+OrHighMedDayTaxoFacets: not index.php +facets:taxonomy:DayOfYear # freq=1713264 freq=126813
+OrHighMedDayTaxoFacets: but census +facets:taxonomy:DayOfYear # freq=1456553 freq=205166
+OrHighMedDayTaxoFacets: work replaced +facets:taxonomy:DayOfYear # freq=853422 freq=112506
+OrHighMedDayTaxoFacets: some groups +facets:taxonomy:DayOfYear # freq=839919 freq=146670
+OrHighMedDayTaxoFacets: 10 collection +facets:taxonomy:DayOfYear # freq=918339 freq=110483
+OrHighMedDayTaxoFacets: not opening +facets:taxonomy:DayOfYear # freq=1713264 freq=84576
+OrHighMedDayTaxoFacets: see september +facets:taxonomy:DayOfYear # freq=1044180 freq=553409
+OrHighMedDayTaxoFacets: 4 steve +facets:taxonomy:DayOfYear # freq=986452 freq=84364
+OrHighMedDayTaxoFacets: ref appears +facets:taxonomy:DayOfYear # freq=3793973 freq=104511
+OrHighMedDayTaxoFacets: a named +facets:taxonomy:DayOfYear # freq=6560531 freq=310150
+OrHighMedDayTaxoFacets: which pre +facets:taxonomy:DayOfYear # freq=1963428 freq=90549
+OrHighMedDayTaxoFacets: has stone +facets:taxonomy:DayOfYear # freq=1502961 freq=92132
+OrHighMedDayTaxoFacets: to energy +facets:taxonomy:DayOfYear # freq=6155577 freq=91150
+OrHighMedDayTaxoFacets: not should +facets:taxonomy:DayOfYear # freq=1713264 freq=401379
+OrHighMedDayTaxoFacets: 2010 media +facets:taxonomy:DayOfYear # freq=950573 freq=206574
+OrHighMedDayTaxoFacets: was behind +facets:taxonomy:DayOfYear # freq=3763623 freq=112070
+OrHighMedDayTaxoFacets: that black +facets:taxonomy:DayOfYear # freq=2931020 freq=256526
+OrHighMedDayTaxoFacets: are itself +facets:taxonomy:DayOfYear # freq=1877802 freq=138231
+OrHighMedDayTaxoFacets: only 90 +facets:taxonomy:DayOfYear # freq=875561 freq=116206
+OrHighMedDayTaxoFacets: 4 main +facets:taxonomy:DayOfYear # freq=986452 freq=470429
+OrHighMedDayTaxoFacets: with august +facets:taxonomy:DayOfYear # freq=3709421 freq=527806
+OrHighMedDayTaxoFacets: have age +facets:taxonomy:DayOfYear # freq=1297121 freq=395368
+OrHighMedDayTaxoFacets: time citation +facets:taxonomy:DayOfYear # freq=1032071 freq=291478
+OrHighMedDayTaxoFacets: his notes +facets:taxonomy:DayOfYear # freq=1777780 freq=210029
+OrHighMedDayTaxoFacets: year 17 +facets:taxonomy:DayOfYear # freq=1235231 freq=507396
+OrHighMedDayTaxoFacets: i bbc +facets:taxonomy:DayOfYear # freq=956148 freq=138548
+OrHighMedDayTaxoFacets: name 1984 +facets:taxonomy:DayOfYear # freq=2827713 freq=161404
+OrHighMedDayTaxoFacets: his greek +facets:taxonomy:DayOfYear # freq=1777780 freq=94348
+OrHighMedDayTaxoFacets: cite votes +facets:taxonomy:DayOfYear # freq=1741194 freq=93844
+OrHighMedDayTaxoFacets: be fire +facets:taxonomy:DayOfYear # freq=2051702 freq=133712
+OrHighMedDayTaxoFacets: in sometimes +facets:taxonomy:DayOfYear # freq=7320987 freq=144078
+OrHighMedDayTaxoFacets: last better +facets:taxonomy:DayOfYear # freq=958437 freq=125889
+OrHighMedDayTaxoFacets: by considered +facets:taxonomy:DayOfYear # freq=3826691 freq=186840
+OrHighMedDayTaxoFacets: no leading +facets:taxonomy:DayOfYear # freq=1045000 freq=120945
+OrHighMedDayTaxoFacets: name influence +facets:taxonomy:DayOfYear # freq=2827713 freq=83101
+OrHighMedDayTaxoFacets: 2009 power +facets:taxonomy:DayOfYear # freq=887702 freq=262586
+OrHighMedDayTaxoFacets: is institute +facets:taxonomy:DayOfYear # freq=4074455 freq=136311
+OrHighMedDayTaxoFacets: into doi +facets:taxonomy:DayOfYear # freq=888684 freq=170085
+OrHighMedDayTaxoFacets: into short +facets:taxonomy:DayOfYear # freq=888684 freq=465205
+OrHighMedDayTaxoFacets: were gr +facets:taxonomy:DayOfYear # freq=1524630 freq=83712
+OrHighMedDayTaxoFacets: has 16 +facets:taxonomy:DayOfYear # freq=1502961 freq=540539
+OrHighMedDayTaxoFacets: this towards +facets:taxonomy:DayOfYear # freq=2224932 freq=95574
+OrHighMedDayTaxoFacets: the div +facets:taxonomy:DayOfYear # freq=8217362 freq=206057
+OrHighMedDayTaxoFacets: its jean +facets:taxonomy:DayOfYear # freq=1173450 freq=84299
+OrHighMedDayTaxoFacets: their continued +facets:taxonomy:DayOfYear # freq=1158682 freq=151209
+OrHighMedDayTaxoFacets: publisher come +facets:taxonomy:DayOfYear # freq=1289029 freq=139047
+OrHighMedDayTaxoFacets: name yet +facets:taxonomy:DayOfYear # freq=2827713 freq=100857
+OrHighMedDayTaxoFacets: be before +facets:taxonomy:DayOfYear # freq=2051702 freq=580481
+OrHighMedDayTaxoFacets: ref britain +facets:taxonomy:DayOfYear # freq=3793973 freq=101080
+OrHighMedDayTaxoFacets: 10 returned +facets:taxonomy:DayOfYear # freq=918339 freq=141639
+OrHighMedDayTaxoFacets: 2006 02 +facets:taxonomy:DayOfYear # freq=889954 freq=319783
+OrHighMedDayTaxoFacets: 2011 daughter +facets:taxonomy:DayOfYear # freq=871410 freq=103883
+OrHighMedDayTaxoFacets: be independent +facets:taxonomy:DayOfYear # freq=2051702 freq=164766
+OrHighMedDayTaxoFacets: more self +facets:taxonomy:DayOfYear # freq=963533 freq=135012
+OrHighMedDayTaxoFacets: in particular +facets:taxonomy:DayOfYear # freq=7320987 freq=103643
+OrHighMedDayTaxoFacets: which non +facets:taxonomy:DayOfYear # freq=1963428 freq=348142
+OrHighMedDayTaxoFacets: his birth +facets:taxonomy:DayOfYear # freq=1777780 freq=425138
+OrHighMedDayTaxoFacets: ref stations +facets:taxonomy:DayOfYear # freq=3793973 freq=92011
+OrHighMedDayTaxoFacets: united include +facets:taxonomy:DayOfYear # freq=1196944 freq=276466
+OrHighMedDayTaxoFacets: http flight +facets:taxonomy:DayOfYear # freq=3493581 freq=84316
+OrHighMedDayTaxoFacets: http singles +facets:taxonomy:DayOfYear # freq=3493581 freq=89221
+OrHighMedDayTaxoFacets: year northern +facets:taxonomy:DayOfYear # freq=1235231 freq=194363
+OrHighMedDayTaxoFacets: been htm +facets:taxonomy:DayOfYear # freq=1041183 freq=191479
+OrHighMedDayTaxoFacets: one alone +facets:taxonomy:DayOfYear # freq=1527689 freq=93166
+OrHighMedDayTaxoFacets: their systems +facets:taxonomy:DayOfYear # freq=1158682 freq=134476
+OrHighMedDayTaxoFacets: to yet +facets:taxonomy:DayOfYear # freq=6155577 freq=100857
+OrHighMedDayTaxoFacets: see leader +facets:taxonomy:DayOfYear # freq=1044180 freq=127591
+OrHighMedDayTaxoFacets: on seen +facets:taxonomy:DayOfYear # freq=4074624 freq=173530
+OrHighMedDayTaxoFacets: has 200px +facets:taxonomy:DayOfYear # freq=1502961 freq=102661
+OrHighMedDayTaxoFacets: that 56 +facets:taxonomy:DayOfYear # freq=2931020 freq=96215
+OrHighMedDayTaxoFacets: about women +facets:taxonomy:DayOfYear # freq=850283 freq=128847
+OrHighMedDayTaxoFacets: only michael +facets:taxonomy:DayOfYear # freq=875561 freq=217311
+OrHighMedDayTaxoFacets: 2009 provided +facets:taxonomy:DayOfYear # freq=887702 freq=110088
+OrHighMedDayTaxoFacets: with show +facets:taxonomy:DayOfYear # freq=3709421 freq=293934
+OrHighMedDayTaxoFacets: 2011 utc +facets:taxonomy:DayOfYear # freq=871410 freq=450225
+OrHighMedDayTaxoFacets: which give +facets:taxonomy:DayOfYear # freq=1963428 freq=116375
+OrHighMedDayTaxoFacets: 2010 support +facets:taxonomy:DayOfYear # freq=950573 freq=236989
+OrHighMedDayTaxoFacets: 4 very +facets:taxonomy:DayOfYear # freq=986452 freq=354898
+OrHighMedDayTaxoFacets: 2 foreign +facets:taxonomy:DayOfYear # freq=1549245 freq=109174
+OrHighMedDayTaxoFacets: were 59 +facets:taxonomy:DayOfYear # freq=1524630 freq=93856
+OrHighMedDayTaxoFacets: 2010 take +facets:taxonomy:DayOfYear # freq=950573 freq=224260
+OrHighMedDayTaxoFacets: by york +facets:taxonomy:DayOfYear # freq=3826691 freq=521383
+OrHighMedDayTaxoFacets: http kingdom +facets:taxonomy:DayOfYear # freq=3493581 freq=299825
+OrHighMedDayTaxoFacets: only brother +facets:taxonomy:DayOfYear # freq=875561 freq=110146
+OrHighMedDayTaxoFacets: no died +facets:taxonomy:DayOfYear # freq=1045000 freq=202125
+OrHighMedDayTaxoFacets: other november +facets:taxonomy:DayOfYear # freq=1269961 freq=527131
+OrHighMedDayTaxoFacets: 2008 system +facets:taxonomy:DayOfYear # freq=831253 freq=412862
+OrHighMedDayTaxoFacets: 5 still +facets:taxonomy:DayOfYear # freq=891361 freq=332543
+OrHighMedDayTaxoFacets: by required +facets:taxonomy:DayOfYear # freq=3826691 freq=100578
+OrHighMedDayTaxoFacets: title era +facets:taxonomy:DayOfYear # freq=2397378 freq=95989
+OrHighMedDayTaxoFacets: 3 larger +facets:taxonomy:DayOfYear # freq=1148799 freq=87424
+OrHighMedDayTaxoFacets: into within +facets:taxonomy:DayOfYear # freq=888684 freq=291049
+OrHighMedDayTaxoFacets: http where +facets:taxonomy:DayOfYear # freq=3493581 freq=630647
+OrHighMedDayTaxoFacets: united say +facets:taxonomy:DayOfYear # freq=1196944 freq=110895
+OrHighMedDayTaxoFacets: no second +facets:taxonomy:DayOfYear # freq=1045000 freq=505575
+OrHighMedDayTaxoFacets: work 1998 +facets:taxonomy:DayOfYear # freq=853422 freq=300506
+OrHighMedDayTaxoFacets: 1 think +facets:taxonomy:DayOfYear # freq=1641090 freq=129332
+OrHighMedDayTaxoFacets: by b +facets:taxonomy:DayOfYear # freq=3826691 freq=369454
+OrHighMedDayTaxoFacets: 4 thumb +facets:taxonomy:DayOfYear # freq=986452 freq=672667
+OrHighMedDayTaxoFacets: be usa +facets:taxonomy:DayOfYear # freq=2051702 freq=191220
+OrHighMedDayTaxoFacets: not african +facets:taxonomy:DayOfYear # freq=1713264 freq=128682
+OrHighMedDayTaxoFacets: 1 president +facets:taxonomy:DayOfYear # freq=1641090 freq=263341
+OrHighMedDayTaxoFacets: 4 worked +facets:taxonomy:DayOfYear # freq=986452 freq=119896
+OrHighMedDayTaxoFacets: http added +facets:taxonomy:DayOfYear # freq=3493581 freq=138409
+OrHighMedDayTaxoFacets: s deletion +facets:taxonomy:DayOfYear # freq=1581243 freq=166633
+OrHighMedDayTaxoFacets: time nbsp +facets:taxonomy:DayOfYear # freq=1032071 freq=506054
+OrHighMedDayTaxoFacets: when 02 +facets:taxonomy:DayOfYear # freq=1027487 freq=319783
+OrHighMedDayTaxoFacets: may la +facets:taxonomy:DayOfYear # freq=1071932 freq=232610
+OrHighMedDayTaxoFacets: 2 royal +facets:taxonomy:DayOfYear # freq=1549245 freq=211710
+OrHighMedDayTaxoFacets: from office +facets:taxonomy:DayOfYear # freq=3224339 freq=225338
+OrHighMedDayTaxoFacets: and 22 +facets:taxonomy:DayOfYear # freq=7318061 freq=502778
+OrHighMedDayTaxoFacets: cite order +facets:taxonomy:DayOfYear # freq=1741194 freq=360915
+OrHighMedDayTaxoFacets: of upper +facets:taxonomy:DayOfYear # freq=8184358 freq=86379
+OrHighMedDayTaxoFacets: all htm +facets:taxonomy:DayOfYear # freq=1203572 freq=191479
+OrHighMedDayTaxoFacets: he towards +facets:taxonomy:DayOfYear # freq=1659434 freq=95574
+OrHighMedDayTaxoFacets: are traditional +facets:taxonomy:DayOfYear # freq=1877802 freq=110425
+OrHighMedDayTaxoFacets: a team +facets:taxonomy:DayOfYear # freq=6560531 freq=379028
+OrHighMedDayTaxoFacets: or imagesize +facets:taxonomy:DayOfYear # freq=1858841 freq=82746
+OrHighMedDayTaxoFacets: date regular +facets:taxonomy:DayOfYear # freq=2020626 freq=93809
+OrHighMedDayTaxoFacets: or birth_date +facets:taxonomy:DayOfYear # freq=1858841 freq=122665
+OrHighMedDayTaxoFacets: name each +facets:taxonomy:DayOfYear # freq=2827713 freq=354583
+OrHighMedDayTaxoFacets: but begin +facets:taxonomy:DayOfYear # freq=1456553 freq=104303
+OrHighMedDayTaxoFacets: 2 developed +facets:taxonomy:DayOfYear # freq=1549245 freq=151220
+OrHighMedDayTaxoFacets: ref note +facets:taxonomy:DayOfYear # freq=3793973 freq=194472
+OrHighMedDayTaxoFacets: united programs +facets:taxonomy:DayOfYear # freq=1196944 freq=83974
 HighTermTitleSort: titledvsort//ref # freq=3793973
 HighTermTitleSort: titledvsort//http # freq=3493581
 HighTermTitleSort: titledvsort//from # freq=3224339

--- a/tasks/wikimedium.10M.tasks
+++ b/tasks/wikimedium.10M.tasks
@@ -11225,14 +11225,14 @@ Respell: 20000
 Fuzzy1: 2010a~1
 Fuzzy2: 2010a~2
 Respell: 2010a
-BrowseDateTaxoFacets: *:* +facets:Date.taxonomy
-BrowseMonthTaxoFacets: *:* +facets:Month.taxonomy
-BrowseDayOfYearTaxoFacets: *:* +facets:DayOfYear.taxonomy
-BrowseDateSSDVFacets: *:* +facets:Date.sortedset
-BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
-BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
-BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
-BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
+BrowseDateTaxoFacets: *:* +facets:taxonomy:Date
+BrowseMonthTaxoFacets: *:* +facets:taxonomy:Month
+BrowseDayOfYearTaxoFacets: *:* +facets:taxonomy:DayOfYear
+BrowseDateSSDVFacets: *:* +facets:sortedset:Date
+BrowseMonthSSDVFacets: *:* +facets:sortedset:Month
+BrowseDayOfYearSSDVFacets: *:* +facets:sortedset:DayOfYear
+BrowseRandomLabelSSDVFacets: *:* +facets:sortedset:RandomLabel
+BrowseRandomLabelTaxoFacets: *:* +facets:taxonomy:RandomLabel
 
 HighTermDayOfYearSort: dayofyeardvsort//ref # freq=3793973
 HighTermDayOfYearSort: dayofyeardvsort//http # freq=3493581
@@ -11954,2003 +11954,2003 @@ HighTermTitleBDVSort: titlebdvsort//government # freq=384004
 HighTermTitleBDVSort: titlebdvsort//27 # freq=383042
 HighTermTitleBDVSort: titlebdvsort//old # freq=381809
 
-MedTermDayTaxoFacets: most +facets:DayOfYear.taxonomy # freq=819634
-MedTermDayTaxoFacets: up +facets:DayOfYear.taxonomy # freq=818546
-MedTermDayTaxoFacets: world +facets:DayOfYear.taxonomy # freq=808563
-MedTermDayTaxoFacets: 2007 +facets:DayOfYear.taxonomy # freq=801586
-MedTermDayTaxoFacets: during +facets:DayOfYear.taxonomy # freq=798114
-MedTermDayTaxoFacets: people +facets:DayOfYear.taxonomy # freq=790960
-MedTermDayTaxoFacets: years +facets:DayOfYear.taxonomy # freq=789628
-MedTermDayTaxoFacets: such +facets:DayOfYear.taxonomy # freq=787877
-MedTermDayTaxoFacets: 12 +facets:DayOfYear.taxonomy # freq=774572
-MedTermDayTaxoFacets: over +facets:DayOfYear.taxonomy # freq=774312
-MedTermDayTaxoFacets: can +facets:DayOfYear.taxonomy # freq=765163
-MedTermDayTaxoFacets: references +facets:DayOfYear.taxonomy # freq=760306
-MedTermDayTaxoFacets: city +facets:DayOfYear.taxonomy # freq=760272
-MedTermDayTaxoFacets: 6 +facets:DayOfYear.taxonomy # freq=759234
-MedTermDayTaxoFacets: american +facets:DayOfYear.taxonomy # freq=758337
-MedTermDayTaxoFacets: news +facets:DayOfYear.taxonomy # freq=756063
-MedTermDayTaxoFacets: history +facets:DayOfYear.taxonomy # freq=755471
-MedTermDayTaxoFacets: 0 +facets:DayOfYear.taxonomy # freq=754451
-MedTermDayTaxoFacets: made +facets:DayOfYear.taxonomy # freq=742313
-MedTermDayTaxoFacets: out +facets:DayOfYear.taxonomy # freq=733775
-MedTermDayTaxoFacets: 11 +facets:DayOfYear.taxonomy # freq=730505
-MedTermDayTaxoFacets: used +facets:DayOfYear.taxonomy # freq=708455
-MedTermDayTaxoFacets: links +facets:DayOfYear.taxonomy # freq=703350
-MedTermDayTaxoFacets: state +facets:DayOfYear.taxonomy # freq=702598
-MedTermDayTaxoFacets: many +facets:DayOfYear.taxonomy # freq=694439
-MedTermDayTaxoFacets: would +facets:DayOfYear.taxonomy # freq=690480
-MedTermDayTaxoFacets: page +facets:DayOfYear.taxonomy # freq=681036
-MedTermDayTaxoFacets: national +facets:DayOfYear.taxonomy # freq=677281
-MedTermDayTaxoFacets: than +facets:DayOfYear.taxonomy # freq=676864
-MedTermDayTaxoFacets: thumb +facets:DayOfYear.taxonomy # freq=672667
-MedTermDayTaxoFacets: 7 +facets:DayOfYear.taxonomy # freq=660220
-MedTermDayTaxoFacets: place +facets:DayOfYear.taxonomy # freq=654158
-MedTermDayTaxoFacets: de +facets:DayOfYear.taxonomy # freq=652242
-MedTermDayTaxoFacets: if +facets:DayOfYear.taxonomy # freq=640551
-MedTermDayTaxoFacets: university +facets:DayOfYear.taxonomy # freq=636959
-MedTermDayTaxoFacets: 8 +facets:DayOfYear.taxonomy # freq=635822
-MedTermDayTaxoFacets: external +facets:DayOfYear.taxonomy # freq=635450
-MedTermDayTaxoFacets: between +facets:DayOfYear.taxonomy # freq=630650
-MedTermDayTaxoFacets: where +facets:DayOfYear.taxonomy # freq=630647
-MedTermDayTaxoFacets: right +facets:DayOfYear.taxonomy # freq=630423
-MedTermDayTaxoFacets: 20 +facets:DayOfYear.taxonomy # freq=624967
-MedTermDayTaxoFacets: under +facets:DayOfYear.taxonomy # freq=623872
-MedTermDayTaxoFacets: these +facets:DayOfYear.taxonomy # freq=623267
-MedTermDayTaxoFacets: march +facets:DayOfYear.taxonomy # freq=620393
-MedTermDayTaxoFacets: br +facets:DayOfYear.taxonomy # freq=617824
-MedTermDayTaxoFacets: book +facets:DayOfYear.taxonomy # freq=617297
-MedTermDayTaxoFacets: p +facets:DayOfYear.taxonomy # freq=616159
-MedTermDayTaxoFacets: article +facets:DayOfYear.taxonomy # freq=610650
-MedTermDayTaxoFacets: known +facets:DayOfYear.taxonomy # freq=607158
-MedTermDayTaxoFacets: then +facets:DayOfYear.taxonomy # freq=606159
-MedTermDayTaxoFacets: style +facets:DayOfYear.taxonomy # freq=606000
-MedTermDayTaxoFacets: later +facets:DayOfYear.taxonomy # freq=604921
-MedTermDayTaxoFacets: three +facets:DayOfYear.taxonomy # freq=598349
-MedTermDayTaxoFacets: use +facets:DayOfYear.taxonomy # freq=597053
-MedTermDayTaxoFacets: category +facets:DayOfYear.taxonomy # freq=595446
-MedTermDayTaxoFacets: john +facets:DayOfYear.taxonomy # freq=594461
-MedTermDayTaxoFacets: part +facets:DayOfYear.taxonomy # freq=594224
-MedTermDayTaxoFacets: left +facets:DayOfYear.taxonomy # freq=593967
-MedTermDayTaxoFacets: 2004 +facets:DayOfYear.taxonomy # freq=593934
-MedTermDayTaxoFacets: 15 +facets:DayOfYear.taxonomy # freq=592407
-MedTermDayTaxoFacets: december +facets:DayOfYear.taxonomy # freq=590171
-MedTermDayTaxoFacets: april +facets:DayOfYear.taxonomy # freq=587542
-MedTermDayTaxoFacets: list +facets:DayOfYear.taxonomy # freq=585922
-MedTermDayTaxoFacets: 18 +facets:DayOfYear.taxonomy # freq=585631
-MedTermDayTaxoFacets: small +facets:DayOfYear.taxonomy # freq=581643
-MedTermDayTaxoFacets: january +facets:DayOfYear.taxonomy # freq=581309
-MedTermDayTaxoFacets: before +facets:DayOfYear.taxonomy # freq=580481
-MedTermDayTaxoFacets: being +facets:DayOfYear.taxonomy # freq=580185
-MedTermDayTaxoFacets: well +facets:DayOfYear.taxonomy # freq=580011
-MedTermDayTaxoFacets: id +facets:DayOfYear.taxonomy # freq=579566
-MedTermDayTaxoFacets: while +facets:DayOfYear.taxonomy # freq=579117
-MedTermDayTaxoFacets: 9 +facets:DayOfYear.taxonomy # freq=574434
-MedTermDayTaxoFacets: death +facets:DayOfYear.taxonomy # freq=568895
-MedTermDayTaxoFacets: author +facets:DayOfYear.taxonomy # freq=567768
-MedTermDayTaxoFacets: however +facets:DayOfYear.taxonomy # freq=566494
-MedTermDayTaxoFacets: october +facets:DayOfYear.taxonomy # freq=566229
-MedTermDayTaxoFacets: north +facets:DayOfYear.taxonomy # freq=564195
-MedTermDayTaxoFacets: so +facets:DayOfYear.taxonomy # freq=562598
-MedTermDayTaxoFacets: reflist +facets:DayOfYear.taxonomy # freq=561253
-MedTermDayTaxoFacets: south +facets:DayOfYear.taxonomy # freq=560468
-MedTermDayTaxoFacets: area +facets:DayOfYear.taxonomy # freq=559023
-MedTermDayTaxoFacets: class +facets:DayOfYear.taxonomy # freq=556838
-MedTermDayTaxoFacets: september +facets:DayOfYear.taxonomy # freq=553409
-MedTermDayTaxoFacets: war +facets:DayOfYear.taxonomy # freq=547417
-MedTermDayTaxoFacets: image +facets:DayOfYear.taxonomy # freq=541747
-MedTermDayTaxoFacets: 16 +facets:DayOfYear.taxonomy # freq=540539
-MedTermDayTaxoFacets: both +facets:DayOfYear.taxonomy # freq=534900
-MedTermDayTaxoFacets: 14 +facets:DayOfYear.taxonomy # freq=534005
-MedTermDayTaxoFacets: 13 +facets:DayOfYear.taxonomy # freq=530419
-MedTermDayTaxoFacets: july +facets:DayOfYear.taxonomy # freq=529655
-MedTermDayTaxoFacets: august +facets:DayOfYear.taxonomy # freq=527806
-MedTermDayTaxoFacets: november +facets:DayOfYear.taxonomy # freq=527131
-MedTermDayTaxoFacets: end +facets:DayOfYear.taxonomy # freq=526636
-MedTermDayTaxoFacets: february +facets:DayOfYear.taxonomy # freq=524886
-MedTermDayTaxoFacets: infobox +facets:DayOfYear.taxonomy # freq=524810
-MedTermDayTaxoFacets: june +facets:DayOfYear.taxonomy # freq=522519
-MedTermDayTaxoFacets: series +facets:DayOfYear.taxonomy # freq=521861
-MedTermDayTaxoFacets: york +facets:DayOfYear.taxonomy # freq=521383
-MedTermDayTaxoFacets: including +facets:DayOfYear.taxonomy # freq=521324
-MedTermDayTaxoFacets: county +facets:DayOfYear.taxonomy # freq=521126
-MedTermDayTaxoFacets: them +facets:DayOfYear.taxonomy # freq=520298
-MedTermDayTaxoFacets: her +facets:DayOfYear.taxonomy # freq=518717
-MedTermDayTaxoFacets: through +facets:DayOfYear.taxonomy # freq=514966
-MedTermDayTaxoFacets: do +facets:DayOfYear.taxonomy # freq=511178
-MedTermDayTaxoFacets: 17 +facets:DayOfYear.taxonomy # freq=507396
-MedTermDayTaxoFacets: him +facets:DayOfYear.taxonomy # freq=507350
-MedTermDayTaxoFacets: nbsp +facets:DayOfYear.taxonomy # freq=506054
-MedTermDayTaxoFacets: second +facets:DayOfYear.taxonomy # freq=505575
-MedTermDayTaxoFacets: 22 +facets:DayOfYear.taxonomy # freq=502778
-MedTermDayTaxoFacets: html +facets:DayOfYear.taxonomy # freq=500198
-MedTermDayTaxoFacets: 2000 +facets:DayOfYear.taxonomy # freq=499639
-MedTermDayTaxoFacets: 25 +facets:DayOfYear.taxonomy # freq=491957
-MedTermDayTaxoFacets: location +facets:DayOfYear.taxonomy # freq=489791
-MedTermDayTaxoFacets: will +facets:DayOfYear.taxonomy # freq=489711
-MedTermDayTaxoFacets: center +facets:DayOfYear.taxonomy # freq=489673
-MedTermDayTaxoFacets: 30 +facets:DayOfYear.taxonomy # freq=488930
-MedTermDayTaxoFacets: since +facets:DayOfYear.taxonomy # freq=485325
-MedTermDayTaxoFacets: 19 +facets:DayOfYear.taxonomy # freq=484187
-MedTermDayTaxoFacets: now +facets:DayOfYear.taxonomy # freq=484114
-MedTermDayTaxoFacets: any +facets:DayOfYear.taxonomy # freq=483514
-MedTermDayTaxoFacets: early +facets:DayOfYear.taxonomy # freq=482793
-MedTermDayTaxoFacets: 21 +facets:DayOfYear.taxonomy # freq=482314
-MedTermDayTaxoFacets: high +facets:DayOfYear.taxonomy # freq=482152
-MedTermDayTaxoFacets: like +facets:DayOfYear.taxonomy # freq=479390
-MedTermDayTaxoFacets: life +facets:DayOfYear.taxonomy # freq=477007
-MedTermDayTaxoFacets: general +facets:DayOfYear.taxonomy # freq=476690
-MedTermDayTaxoFacets: music +facets:DayOfYear.taxonomy # freq=473240
-MedTermDayTaxoFacets: number +facets:DayOfYear.taxonomy # freq=473154
-MedTermDayTaxoFacets: 24 +facets:DayOfYear.taxonomy # freq=470708
-MedTermDayTaxoFacets: main +facets:DayOfYear.taxonomy # freq=470429
-MedTermDayTaxoFacets: isbn +facets:DayOfYear.taxonomy # freq=467574
-MedTermDayTaxoFacets: pages +facets:DayOfYear.taxonomy # freq=466290
-MedTermDayTaxoFacets: became +facets:DayOfYear.taxonomy # freq=465594
-MedTermDayTaxoFacets: short +facets:DayOfYear.taxonomy # freq=465205
-MedTermDayTaxoFacets: school +facets:DayOfYear.taxonomy # freq=462166
-MedTermDayTaxoFacets: you +facets:DayOfYear.taxonomy # freq=461587
-MedTermDayTaxoFacets: 23 +facets:DayOfYear.taxonomy # freq=457097
-MedTermDayTaxoFacets: 2003 +facets:DayOfYear.taxonomy # freq=456990
-MedTermDayTaxoFacets: called +facets:DayOfYear.taxonomy # freq=454580
-MedTermDayTaxoFacets: utc +facets:DayOfYear.taxonomy # freq=450225
-MedTermDayTaxoFacets: n +facets:DayOfYear.taxonomy # freq=449994
-MedTermDayTaxoFacets: c +facets:DayOfYear.taxonomy # freq=444247
-MedTermDayTaxoFacets: group +facets:DayOfYear.taxonomy # freq=442503
-MedTermDayTaxoFacets: m +facets:DayOfYear.taxonomy # freq=441232
-MedTermDayTaxoFacets: several +facets:DayOfYear.taxonomy # freq=436129
-MedTermDayTaxoFacets: website +facets:DayOfYear.taxonomy # freq=435941
-MedTermDayTaxoFacets: film +facets:DayOfYear.taxonomy # freq=432758
-MedTermDayTaxoFacets: west +facets:DayOfYear.taxonomy # freq=431006
-MedTermDayTaxoFacets: u.s +facets:DayOfYear.taxonomy # freq=428534
-MedTermDayTaxoFacets: she +facets:DayOfYear.taxonomy # freq=426267
-MedTermDayTaxoFacets: until +facets:DayOfYear.taxonomy # freq=425389
-MedTermDayTaxoFacets: birth +facets:DayOfYear.taxonomy # freq=425138
-MedTermDayTaxoFacets: us +facets:DayOfYear.taxonomy # freq=421210
-MedTermDayTaxoFacets: same +facets:DayOfYear.taxonomy # freq=420741
-MedTermDayTaxoFacets: country +facets:DayOfYear.taxonomy # freq=420052
-MedTermDayTaxoFacets: international +facets:DayOfYear.taxonomy # freq=418261
-MedTermDayTaxoFacets: british +facets:DayOfYear.taxonomy # freq=417307
-MedTermDayTaxoFacets: language +facets:DayOfYear.taxonomy # freq=416771
-MedTermDayTaxoFacets: following +facets:DayOfYear.taxonomy # freq=416515
-MedTermDayTaxoFacets: because +facets:DayOfYear.taxonomy # freq=413003
-MedTermDayTaxoFacets: system +facets:DayOfYear.taxonomy # freq=412862
-MedTermDayTaxoFacets: english +facets:DayOfYear.taxonomy # freq=412061
-MedTermDayTaxoFacets: 2001 +facets:DayOfYear.taxonomy # freq=410364
-MedTermDayTaxoFacets: e +facets:DayOfYear.taxonomy # freq=408741
-MedTermDayTaxoFacets: times +facets:DayOfYear.taxonomy # freq=407155
-MedTermDayTaxoFacets: 2002 +facets:DayOfYear.taxonomy # freq=406953
-MedTermDayTaxoFacets: names +facets:DayOfYear.taxonomy # freq=404796
-MedTermDayTaxoFacets: w +facets:DayOfYear.taxonomy # freq=404764
-MedTermDayTaxoFacets: day +facets:DayOfYear.taxonomy # freq=402096
-MedTermDayTaxoFacets: should +facets:DayOfYear.taxonomy # freq=401379
-MedTermDayTaxoFacets: against +facets:DayOfYear.taxonomy # freq=399228
-MedTermDayTaxoFacets: press +facets:DayOfYear.taxonomy # freq=398988
-MedTermDayTaxoFacets: based +facets:DayOfYear.taxonomy # freq=398415
-MedTermDayTaxoFacets: age +facets:DayOfYear.taxonomy # freq=395368
-MedTermDayTaxoFacets: what +facets:DayOfYear.taxonomy # freq=394675
-MedTermDayTaxoFacets: party +facets:DayOfYear.taxonomy # freq=394410
-MedTermDayTaxoFacets: company +facets:DayOfYear.taxonomy # freq=391520
-MedTermDayTaxoFacets: four +facets:DayOfYear.taxonomy # freq=389818
-MedTermDayTaxoFacets: 28 +facets:DayOfYear.taxonomy # freq=389552
-MedTermDayTaxoFacets: 26 +facets:DayOfYear.taxonomy # freq=389026
-MedTermDayTaxoFacets: family +facets:DayOfYear.taxonomy # freq=387175
-MedTermDayTaxoFacets: long +facets:DayOfYear.taxonomy # freq=385787
-MedTermDayTaxoFacets: century +facets:DayOfYear.taxonomy # freq=385541
-MedTermDayTaxoFacets: government +facets:DayOfYear.taxonomy # freq=384004
-MedTermDayTaxoFacets: 27 +facets:DayOfYear.taxonomy # freq=383042
-MedTermDayTaxoFacets: old +facets:DayOfYear.taxonomy # freq=381809
-MedTermDayTaxoFacets: team +facets:DayOfYear.taxonomy # freq=379028
-MedTermDayTaxoFacets: house +facets:DayOfYear.taxonomy # freq=377336
-MedTermDayTaxoFacets: population +facets:DayOfYear.taxonomy # freq=374481
-MedTermDayTaxoFacets: 29 +facets:DayOfYear.taxonomy # freq=372091
-MedTermDayTaxoFacets: b +facets:DayOfYear.taxonomy # freq=369454
-MedTermDayTaxoFacets: public +facets:DayOfYear.taxonomy # freq=368868
-MedTermDayTaxoFacets: home +facets:DayOfYear.taxonomy # freq=367819
-MedTermDayTaxoFacets: top +facets:DayOfYear.taxonomy # freq=364628
-MedTermDayTaxoFacets: east +facets:DayOfYear.taxonomy # freq=364582
-MedTermDayTaxoFacets: talk +facets:DayOfYear.taxonomy # freq=364194
-MedTermDayTaxoFacets: order +facets:DayOfYear.taxonomy # freq=360915
-MedTermDayTaxoFacets: line +facets:DayOfYear.taxonomy # freq=360442
-MedTermDayTaxoFacets: could +facets:DayOfYear.taxonomy # freq=356679
-MedTermDayTaxoFacets: 2012 +facets:DayOfYear.taxonomy # freq=355641
-MedTermDayTaxoFacets: description +facets:DayOfYear.taxonomy # freq=355070
-MedTermDayTaxoFacets: very +facets:DayOfYear.taxonomy # freq=354898
-MedTermDayTaxoFacets: each +facets:DayOfYear.taxonomy # freq=354583
-MedTermDayTaxoFacets: information +facets:DayOfYear.taxonomy # freq=353153
-MedTermDayTaxoFacets: another +facets:DayOfYear.taxonomy # freq=352496
-MedTermDayTaxoFacets: born +facets:DayOfYear.taxonomy # freq=352196
-MedTermDayTaxoFacets: back +facets:DayOfYear.taxonomy # freq=349276
-MedTermDayTaxoFacets: london +facets:DayOfYear.taxonomy # freq=348918
-MedTermDayTaxoFacets: just +facets:DayOfYear.taxonomy # freq=348911
-MedTermDayTaxoFacets: town +facets:DayOfYear.taxonomy # freq=348598
-MedTermDayTaxoFacets: journal +facets:DayOfYear.taxonomy # freq=348162
-MedTermDayTaxoFacets: non +facets:DayOfYear.taxonomy # freq=348142
-MedTermDayTaxoFacets: color +facets:DayOfYear.taxonomy # freq=347941
-MedTermDayTaxoFacets: 01 +facets:DayOfYear.taxonomy # freq=347922
-MedTermDayTaxoFacets: great +facets:DayOfYear.taxonomy # freq=347499
-MedTermDayTaxoFacets: although +facets:DayOfYear.taxonomy # freq=341432
-MedTermDayTaxoFacets: books +facets:DayOfYear.taxonomy # freq=341376
-MedTermDayTaxoFacets: ii +facets:DayOfYear.taxonomy # freq=340800
-MedTermDayTaxoFacets: major +facets:DayOfYear.taxonomy # freq=340345
-MedTermDayTaxoFacets: further +facets:DayOfYear.taxonomy # freq=339350
-MedTermDayTaxoFacets: 1999 +facets:DayOfYear.taxonomy # freq=334887
-MedTermDayTaxoFacets: around +facets:DayOfYear.taxonomy # freq=334840
-MedTermDayTaxoFacets: best +facets:DayOfYear.taxonomy # freq=334550
-MedTermDayTaxoFacets: former +facets:DayOfYear.taxonomy # freq=332750
-MedTermDayTaxoFacets: still +facets:DayOfYear.taxonomy # freq=332543
-MedTermDayTaxoFacets: album +facets:DayOfYear.taxonomy # freq=331360
-MedTermDayTaxoFacets: stub +facets:DayOfYear.taxonomy # freq=329768
-MedTermDayTaxoFacets: did +facets:DayOfYear.taxonomy # freq=328303
-MedTermDayTaxoFacets: j +facets:DayOfYear.taxonomy # freq=327713
-MedTermDayTaxoFacets: even +facets:DayOfYear.taxonomy # freq=326231
-MedTermDayTaxoFacets: official +facets:DayOfYear.taxonomy # freq=326177
-MedTermDayTaxoFacets: original +facets:DayOfYear.taxonomy # freq=323521
-MedTermDayTaxoFacets: user +facets:DayOfYear.taxonomy # freq=323242
-MedTermDayTaxoFacets: alternative +facets:DayOfYear.taxonomy # freq=322536
-MedTermDayTaxoFacets: released +facets:DayOfYear.taxonomy # freq=322473
-MedTermDayTaxoFacets: jpg +facets:DayOfYear.taxonomy # freq=322278
-MedTermDayTaxoFacets: issue +facets:DayOfYear.taxonomy # freq=322106
-MedTermDayTaxoFacets: own +facets:DayOfYear.taxonomy # freq=321703
-MedTermDayTaxoFacets: season +facets:DayOfYear.taxonomy # freq=320228
-MedTermDayTaxoFacets: those +facets:DayOfYear.taxonomy # freq=320013
-MedTermDayTaxoFacets: 02 +facets:DayOfYear.taxonomy # freq=319783
-MedTermDayTaxoFacets: uk +facets:DayOfYear.taxonomy # freq=319211
-MedTermDayTaxoFacets: way +facets:DayOfYear.taxonomy # freq=318344
-MedTermDayTaxoFacets: type +facets:DayOfYear.taxonomy # freq=318210
-MedTermDayTaxoFacets: 03 +facets:DayOfYear.taxonomy # freq=318112
-MedTermDayTaxoFacets: england +facets:DayOfYear.taxonomy # freq=317884
-MedTermDayTaxoFacets: much +facets:DayOfYear.taxonomy # freq=317670
-MedTermDayTaxoFacets: off +facets:DayOfYear.taxonomy # freq=315473
-MedTermDayTaxoFacets: game +facets:DayOfYear.taxonomy # freq=315157
-MedTermDayTaxoFacets: background +facets:DayOfYear.taxonomy # freq=314229
-MedTermDayTaxoFacets: 04 +facets:DayOfYear.taxonomy # freq=313827
-MedTermDayTaxoFacets: found +facets:DayOfYear.taxonomy # freq=313247
-MedTermDayTaxoFacets: volume +facets:DayOfYear.taxonomy # freq=312846
-MedTermDayTaxoFacets: named +facets:DayOfYear.taxonomy # freq=310150
-MedTermDayTaxoFacets: service +facets:DayOfYear.taxonomy # freq=309976
-MedTermDayTaxoFacets: d +facets:DayOfYear.taxonomy # freq=309729
-MedTermDayTaxoFacets: st +facets:DayOfYear.taxonomy # freq=309092
-MedTermDayTaxoFacets: large +facets:DayOfYear.taxonomy # freq=308888
-MedTermDayTaxoFacets: often +facets:DayOfYear.taxonomy # freq=307684
-MedTermDayTaxoFacets: 06 +facets:DayOfYear.taxonomy # freq=305698
-MedTermDayTaxoFacets: 05 +facets:DayOfYear.taxonomy # freq=302860
-MedTermDayTaxoFacets: 1998 +facets:DayOfYear.taxonomy # freq=300506
-MedTermDayTaxoFacets: align +facets:DayOfYear.taxonomy # freq=300455
-MedTermDayTaxoFacets: kingdom +facets:DayOfYear.taxonomy # freq=299825
-MedTermDayTaxoFacets: using +facets:DayOfYear.taxonomy # freq=299474
-MedTermDayTaxoFacets: white +facets:DayOfYear.taxonomy # freq=299411
-MedTermDayTaxoFacets: 07 +facets:DayOfYear.taxonomy # freq=299351
-MedTermDayTaxoFacets: district +facets:DayOfYear.taxonomy # freq=299108
-MedTermDayTaxoFacets: local +facets:DayOfYear.taxonomy # freq=299012
-MedTermDayTaxoFacets: metadata +facets:DayOfYear.taxonomy # freq=298533
-MedTermDayTaxoFacets: 31 +facets:DayOfYear.taxonomy # freq=298349
-MedTermDayTaxoFacets: 08 +facets:DayOfYear.taxonomy # freq=297258
-MedTermDayTaxoFacets: 09 +facets:DayOfYear.taxonomy # freq=296300
-MedTermDayTaxoFacets: r +facets:DayOfYear.taxonomy # freq=296283
-MedTermDayTaxoFacets: set +facets:DayOfYear.taxonomy # freq=294255
-MedTermDayTaxoFacets: show +facets:DayOfYear.taxonomy # freq=293934
-MedTermDayTaxoFacets: david +facets:DayOfYear.taxonomy # freq=292847
-MedTermDayTaxoFacets: make +facets:DayOfYear.taxonomy # freq=292607
-MedTermDayTaxoFacets: story +facets:DayOfYear.taxonomy # freq=292404
-MedTermDayTaxoFacets: citation +facets:DayOfYear.taxonomy # freq=291478
-MedTermDayTaxoFacets: within +facets:DayOfYear.taxonomy # freq=291049
-MedTermDayTaxoFacets: due +facets:DayOfYear.taxonomy # freq=290531
-MedTermDayTaxoFacets: link +facets:DayOfYear.taxonomy # freq=287552
-MedTermDayTaxoFacets: 1997 +facets:DayOfYear.taxonomy # freq=286789
-MedTermDayTaxoFacets: members +facets:DayOfYear.taxonomy # freq=286028
-MedTermDayTaxoFacets: william +facets:DayOfYear.taxonomy # freq=284592
-MedTermDayTaxoFacets: along +facets:DayOfYear.taxonomy # freq=284442
-MedTermDayTaxoFacets: v +facets:DayOfYear.taxonomy # freq=284318
-MedTermDayTaxoFacets: located +facets:DayOfYear.taxonomy # freq=283899
-MedTermDayTaxoFacets: single +facets:DayOfYear.taxonomy # freq=283824
-MedTermDayTaxoFacets: per +facets:DayOfYear.taxonomy # freq=283568
-MedTermDayTaxoFacets: established +facets:DayOfYear.taxonomy # freq=282471
-MedTermDayTaxoFacets: james +facets:DayOfYear.taxonomy # freq=281597
-MedTermDayTaxoFacets: needed +facets:DayOfYear.taxonomy # freq=281051
-MedTermDayTaxoFacets: down +facets:DayOfYear.taxonomy # freq=280662
-MedTermDayTaxoFacets: present +facets:DayOfYear.taxonomy # freq=278449
-MedTermDayTaxoFacets: man +facets:DayOfYear.taxonomy # freq=278112
-MedTermDayTaxoFacets: college +facets:DayOfYear.taxonomy # freq=278094
-MedTermDayTaxoFacets: f +facets:DayOfYear.taxonomy # freq=278015
-MedTermDayTaxoFacets: site +facets:DayOfYear.taxonomy # freq=277788
-MedTermDayTaxoFacets: football +facets:DayOfYear.taxonomy # freq=277738
-MedTermDayTaxoFacets: en +facets:DayOfYear.taxonomy # freq=277463
-MedTermDayTaxoFacets: result +facets:DayOfYear.taxonomy # freq=276803
-MedTermDayTaxoFacets: include +facets:DayOfYear.taxonomy # freq=276466
-MedTermDayTaxoFacets: began +facets:DayOfYear.taxonomy # freq=276036
-MedTermDayTaxoFacets: my +facets:DayOfYear.taxonomy # freq=274256
-MedTermDayTaxoFacets: x +facets:DayOfYear.taxonomy # freq=272695
-MedTermDayTaxoFacets: central +facets:DayOfYear.taxonomy # freq=272531
-MedTermDayTaxoFacets: band +facets:DayOfYear.taxonomy # freq=272207
-MedTermDayTaxoFacets: 1996 +facets:DayOfYear.taxonomy # freq=271980
-MedTermDayTaxoFacets: form +facets:DayOfYear.taxonomy # freq=271966
-MedTermDayTaxoFacets: member +facets:DayOfYear.taxonomy # freq=271607
-MedTermDayTaxoFacets: television +facets:DayOfYear.taxonomy # freq=271426
-MedTermDayTaxoFacets: league +facets:DayOfYear.taxonomy # freq=270223
-MedTermDayTaxoFacets: free +facets:DayOfYear.taxonomy # freq=270199
-MedTermDayTaxoFacets: political +facets:DayOfYear.taxonomy # freq=269665
-MedTermDayTaxoFacets: font +facets:DayOfYear.taxonomy # freq=269439
-MedTermDayTaxoFacets: 100 +facets:DayOfYear.taxonomy # freq=268978
-MedTermDayTaxoFacets: convert +facets:DayOfYear.taxonomy # freq=267974
-MedTermDayTaxoFacets: red +facets:DayOfYear.taxonomy # freq=266177
-MedTermDayTaxoFacets: president +facets:DayOfYear.taxonomy # freq=263341
-MedTermDayTaxoFacets: five +facets:DayOfYear.taxonomy # freq=262923
-MedTermDayTaxoFacets: t +facets:DayOfYear.taxonomy # freq=262832
-MedTermDayTaxoFacets: power +facets:DayOfYear.taxonomy # freq=262586
-MedTermDayTaxoFacets: river +facets:DayOfYear.taxonomy # freq=262231
-MedTermDayTaxoFacets: we +facets:DayOfYear.taxonomy # freq=261001
-MedTermDayTaxoFacets: song +facets:DayOfYear.taxonomy # freq=260741
-MedTermDayTaxoFacets: next +facets:DayOfYear.taxonomy # freq=259039
-MedTermDayTaxoFacets: articles +facets:DayOfYear.taxonomy # freq=258949
-MedTermDayTaxoFacets: point +facets:DayOfYear.taxonomy # freq=258471
-MedTermDayTaxoFacets: text +facets:DayOfYear.taxonomy # freq=257803
-MedTermDayTaxoFacets: according +facets:DayOfYear.taxonomy # freq=256949
-MedTermDayTaxoFacets: black +facets:DayOfYear.taxonomy # freq=256526
-MedTermDayTaxoFacets: george +facets:DayOfYear.taxonomy # freq=256196
-MedTermDayTaxoFacets: different +facets:DayOfYear.taxonomy # freq=255951
-MedTermDayTaxoFacets: ndash +facets:DayOfYear.taxonomy # freq=255747
-MedTermDayTaxoFacets: third +facets:DayOfYear.taxonomy # freq=255690
-MedTermDayTaxoFacets: tv +facets:DayOfYear.taxonomy # freq=255429
-MedTermDayTaxoFacets: law +facets:DayOfYear.taxonomy # freq=255248
-MedTermDayTaxoFacets: canada +facets:DayOfYear.taxonomy # freq=254867
-MedTermDayTaxoFacets: near +facets:DayOfYear.taxonomy # freq=254492
-MedTermDayTaxoFacets: built +facets:DayOfYear.taxonomy # freq=254491
-MedTermDayTaxoFacets: 1995 +facets:DayOfYear.taxonomy # freq=252837
-MedTermDayTaxoFacets: how +facets:DayOfYear.taxonomy # freq=252284
-MedTermDayTaxoFacets: record +facets:DayOfYear.taxonomy # freq=250484
-MedTermDayTaxoFacets: french +facets:DayOfYear.taxonomy # freq=250453
-MedTermDayTaxoFacets: air +facets:DayOfYear.taxonomy # freq=250411
-MedTermDayTaxoFacets: king +facets:DayOfYear.taxonomy # freq=250321
-MedTermDayTaxoFacets: without +facets:DayOfYear.taxonomy # freq=249926
-MedTermDayTaxoFacets: though +facets:DayOfYear.taxonomy # freq=248968
-MedTermDayTaxoFacets: played +facets:DayOfYear.taxonomy # freq=248191
-MedTermDayTaxoFacets: park +facets:DayOfYear.taxonomy # freq=247801
-MedTermDayTaxoFacets: took +facets:DayOfYear.taxonomy # freq=247388
-MedTermDayTaxoFacets: association +facets:DayOfYear.taxonomy # freq=247156
-MedTermDayTaxoFacets: military +facets:DayOfYear.taxonomy # freq=246727
-MedTermDayTaxoFacets: robert +facets:DayOfYear.taxonomy # freq=246405
-MedTermDayTaxoFacets: above +facets:DayOfYear.taxonomy # freq=246135
-MedTermDayTaxoFacets: persondata +facets:DayOfYear.taxonomy # freq=246119
-MedTermDayTaxoFacets: career +facets:DayOfYear.taxonomy # freq=245439
-MedTermDayTaxoFacets: version +facets:DayOfYear.taxonomy # freq=244541
-MedTermDayTaxoFacets: again +facets:DayOfYear.taxonomy # freq=244255
-MedTermDayTaxoFacets: late +facets:DayOfYear.taxonomy # freq=243636
-MedTermDayTaxoFacets: published +facets:DayOfYear.taxonomy # freq=243548
-MedTermDayTaxoFacets: live +facets:DayOfYear.taxonomy # freq=242147
-MedTermDayTaxoFacets: h +facets:DayOfYear.taxonomy # freq=241946
-MedTermDayTaxoFacets: good +facets:DayOfYear.taxonomy # freq=241649
-MedTermDayTaxoFacets: player +facets:DayOfYear.taxonomy # freq=241451
-MedTermDayTaxoFacets: others +facets:DayOfYear.taxonomy # freq=240487
-MedTermDayTaxoFacets: america +facets:DayOfYear.taxonomy # freq=240374
-MedTermDayTaxoFacets: review +facets:DayOfYear.taxonomy # freq=240157
-MedTermDayTaxoFacets: station +facets:DayOfYear.taxonomy # freq=239572
-MedTermDayTaxoFacets: among +facets:DayOfYear.taxonomy # freq=238986
-MedTermDayTaxoFacets: section +facets:DayOfYear.taxonomy # freq=238874
-MedTermDayTaxoFacets: border +facets:DayOfYear.taxonomy # freq=238540
-MedTermDayTaxoFacets: your +facets:DayOfYear.taxonomy # freq=237723
-MedTermDayTaxoFacets: size +facets:DayOfYear.taxonomy # freq=237662
-MedTermDayTaxoFacets: births +facets:DayOfYear.taxonomy # freq=237033
-MedTermDayTaxoFacets: support +facets:DayOfYear.taxonomy # freq=236989
-MedTermDayTaxoFacets: german +facets:DayOfYear.taxonomy # freq=236721
-MedTermDayTaxoFacets: california +facets:DayOfYear.taxonomy # freq=236086
-MedTermDayTaxoFacets: given +facets:DayOfYear.taxonomy # freq=235719
-MedTermDayTaxoFacets: commons +facets:DayOfYear.taxonomy # freq=235235
-MedTermDayTaxoFacets: 1994 +facets:DayOfYear.taxonomy # freq=235100
-MedTermDayTaxoFacets: start +facets:DayOfYear.taxonomy # freq=233925
-MedTermDayTaxoFacets: km +facets:DayOfYear.taxonomy # freq=233831
-MedTermDayTaxoFacets: said +facets:DayOfYear.taxonomy # freq=233066
-MedTermDayTaxoFacets: western +facets:DayOfYear.taxonomy # freq=232781
-MedTermDayTaxoFacets: won +facets:DayOfYear.taxonomy # freq=232751
-MedTermDayTaxoFacets: la +facets:DayOfYear.taxonomy # freq=232610
-MedTermDayTaxoFacets: held +facets:DayOfYear.taxonomy # freq=232354
-MedTermDayTaxoFacets: children +facets:DayOfYear.taxonomy # freq=232342
-MedTermDayTaxoFacets: does +facets:DayOfYear.taxonomy # freq=232202
-MedTermDayTaxoFacets: club +facets:DayOfYear.taxonomy # freq=232173
-MedTermDayTaxoFacets: source +facets:DayOfYear.taxonomy # freq=231838
-MedTermDayTaxoFacets: church +facets:DayOfYear.taxonomy # freq=231667
-MedTermDayTaxoFacets: format +facets:DayOfYear.taxonomy # freq=231300
-MedTermDayTaxoFacets: example +facets:DayOfYear.taxonomy # freq=230457
-MedTermDayTaxoFacets: development +facets:DayOfYear.taxonomy # freq=230286
-MedTermDayTaxoFacets: land +facets:DayOfYear.taxonomy # freq=230284
-MedTermDayTaxoFacets: total +facets:DayOfYear.taxonomy # freq=230013
-MedTermDayTaxoFacets: final +facets:DayOfYear.taxonomy # freq=230006
-MedTermDayTaxoFacets: 50 +facets:DayOfYear.taxonomy # freq=229614
-MedTermDayTaxoFacets: please +facets:DayOfYear.taxonomy # freq=229602
-MedTermDayTaxoFacets: region +facets:DayOfYear.taxonomy # freq=229561
-MedTermDayTaxoFacets: here +facets:DayOfYear.taxonomy # freq=229505
-MedTermDayTaxoFacets: me +facets:DayOfYear.taxonomy # freq=229204
-MedTermDayTaxoFacets: caption +facets:DayOfYear.taxonomy # freq=229172
-MedTermDayTaxoFacets: must +facets:DayOfYear.taxonomy # freq=228491
-MedTermDayTaxoFacets: army +facets:DayOfYear.taxonomy # freq=228105
-MedTermDayTaxoFacets: l +facets:DayOfYear.taxonomy # freq=227974
-MedTermDayTaxoFacets: side +facets:DayOfYear.taxonomy # freq=227747
-MedTermDayTaxoFacets: society +facets:DayOfYear.taxonomy # freq=226742
-MedTermDayTaxoFacets: full +facets:DayOfYear.taxonomy # freq=226457
-MedTermDayTaxoFacets: few +facets:DayOfYear.taxonomy # freq=226422
-MedTermDayTaxoFacets: records +facets:DayOfYear.taxonomy # freq=225886
-MedTermDayTaxoFacets: below +facets:DayOfYear.taxonomy # freq=225843
-MedTermDayTaxoFacets: community +facets:DayOfYear.taxonomy # freq=225571
-MedTermDayTaxoFacets: office +facets:DayOfYear.taxonomy # freq=225338
-MedTermDayTaxoFacets: 1992 +facets:DayOfYear.taxonomy # freq=225200
-MedTermDayTaxoFacets: road +facets:DayOfYear.taxonomy # freq=225050
-MedTermDayTaxoFacets: research +facets:DayOfYear.taxonomy # freq=224925
-MedTermDayTaxoFacets: various +facets:DayOfYear.taxonomy # freq=224593
-MedTermDayTaxoFacets: take +facets:DayOfYear.taxonomy # freq=224260
-MedTermDayTaxoFacets: wikipedia:persondata +facets:DayOfYear.taxonomy # freq=222385
-MedTermDayTaxoFacets: 1990 +facets:DayOfYear.taxonomy # freq=222154
-MedTermDayTaxoFacets: 40 +facets:DayOfYear.taxonomy # freq=221687
-MedTermDayTaxoFacets: created +facets:DayOfYear.taxonomy # freq=220831
-MedTermDayTaxoFacets: 1993 +facets:DayOfYear.taxonomy # freq=220776
-MedTermDayTaxoFacets: france +facets:DayOfYear.taxonomy # freq=220058
-MedTermDayTaxoFacets: science +facets:DayOfYear.taxonomy # freq=219988
-MedTermDayTaxoFacets: every +facets:DayOfYear.taxonomy # freq=219884
-MedTermDayTaxoFacets: become +facets:DayOfYear.taxonomy # freq=219753
-MedTermDayTaxoFacets: modern +facets:DayOfYear.taxonomy # freq=218831
-MedTermDayTaxoFacets: post +facets:DayOfYear.taxonomy # freq=218570
-MedTermDayTaxoFacets: games +facets:DayOfYear.taxonomy # freq=218434
-MedTermDayTaxoFacets: michael +facets:DayOfYear.taxonomy # freq=217311
-MedTermDayTaxoFacets: current +facets:DayOfYear.taxonomy # freq=217174
-MedTermDayTaxoFacets: included +facets:DayOfYear.taxonomy # freq=216978
-MedTermDayTaxoFacets: ja +facets:DayOfYear.taxonomy # freq=216549
-MedTermDayTaxoFacets: magazine +facets:DayOfYear.taxonomy # freq=215725
-MedTermDayTaxoFacets: position +facets:DayOfYear.taxonomy # freq=215493
-MedTermDayTaxoFacets: australia +facets:DayOfYear.taxonomy # freq=215391
-MedTermDayTaxoFacets: archive +facets:DayOfYear.taxonomy # freq=215381
-MedTermDayTaxoFacets: union +facets:DayOfYear.taxonomy # freq=214164
-MedTermDayTaxoFacets: having +facets:DayOfYear.taxonomy # freq=213416
-MedTermDayTaxoFacets: g +facets:DayOfYear.taxonomy # freq=212936
-MedTermDayTaxoFacets: popular +facets:DayOfYear.taxonomy # freq=212493
-MedTermDayTaxoFacets: royal +facets:DayOfYear.taxonomy # freq=211710
-MedTermDayTaxoFacets: period +facets:DayOfYear.taxonomy # freq=211690
-MedTermDayTaxoFacets: little +facets:DayOfYear.taxonomy # freq=211124
-MedTermDayTaxoFacets: wikitable +facets:DayOfYear.taxonomy # freq=210990
-MedTermDayTaxoFacets: rock +facets:DayOfYear.taxonomy # freq=210815
-MedTermDayTaxoFacets: artist +facets:DayOfYear.taxonomy # freq=210591
-MedTermDayTaxoFacets: play +facets:DayOfYear.taxonomy # freq=210199
-MedTermDayTaxoFacets: led +facets:DayOfYear.taxonomy # freq=210033
-MedTermDayTaxoFacets: notes +facets:DayOfYear.taxonomy # freq=210029
-MedTermDayTaxoFacets: water +facets:DayOfYear.taxonomy # freq=209444
-MedTermDayTaxoFacets: business +facets:DayOfYear.taxonomy # freq=209353
-MedTermDayTaxoFacets: art +facets:DayOfYear.taxonomy # freq=209322
-MedTermDayTaxoFacets: common +facets:DayOfYear.taxonomy # freq=209310
-MedTermDayTaxoFacets: co +facets:DayOfYear.taxonomy # freq=209086
-MedTermDayTaxoFacets: education +facets:DayOfYear.taxonomy # freq=208909
-MedTermDayTaxoFacets: role +facets:DayOfYear.taxonomy # freq=208579
-MedTermDayTaxoFacets: 1991 +facets:DayOfYear.taxonomy # freq=207589
-MedTermDayTaxoFacets: case +facets:DayOfYear.taxonomy # freq=207307
-MedTermDayTaxoFacets: paul +facets:DayOfYear.taxonomy # freq=207229
-MedTermDayTaxoFacets: media +facets:DayOfYear.taxonomy # freq=206574
-MedTermDayTaxoFacets: div +facets:DayOfYear.taxonomy # freq=206057
-MedTermDayTaxoFacets: census +facets:DayOfYear.taxonomy # freq=205166
-MedTermDayTaxoFacets: charles +facets:DayOfYear.taxonomy # freq=204987
-MedTermDayTaxoFacets: written +facets:DayOfYear.taxonomy # freq=204891
-MedTermDayTaxoFacets: pp +facets:DayOfYear.taxonomy # freq=204742
-MedTermDayTaxoFacets: green +facets:DayOfYear.taxonomy # freq=203371
-MedTermDayTaxoFacets: island +facets:DayOfYear.taxonomy # freq=203023
-MedTermDayTaxoFacets: never +facets:DayOfYear.taxonomy # freq=203017
-MedTermDayTaxoFacets: making +facets:DayOfYear.taxonomy # freq=203003
-MedTermDayTaxoFacets: term +facets:DayOfYear.taxonomy # freq=202691
-MedTermDayTaxoFacets: video +facets:DayOfYear.taxonomy # freq=202380
-MedTermDayTaxoFacets: son +facets:DayOfYear.taxonomy # freq=202340
-MedTermDayTaxoFacets: discussion +facets:DayOfYear.taxonomy # freq=202145
-MedTermDayTaxoFacets: died +facets:DayOfYear.taxonomy # freq=202125
-MedTermDayTaxoFacets: view +facets:DayOfYear.taxonomy # freq=201593
-MedTermDayTaxoFacets: street +facets:DayOfYear.taxonomy # freq=200985
-MedTermDayTaxoFacets: council +facets:DayOfYear.taxonomy # freq=200706
-MedTermDayTaxoFacets: re +facets:DayOfYear.taxonomy # freq=199632
-MedTermDayTaxoFacets: award +facets:DayOfYear.taxonomy # freq=199318
-MedTermDayTaxoFacets: works +facets:DayOfYear.taxonomy # freq=199177
-MedTermDayTaxoFacets: special +facets:DayOfYear.taxonomy # freq=198917
-MedTermDayTaxoFacets: force +facets:DayOfYear.taxonomy # freq=198556
-MedTermDayTaxoFacets: six +facets:DayOfYear.taxonomy # freq=197970
-MedTermDayTaxoFacets: came +facets:DayOfYear.taxonomy # freq=197126
-MedTermDayTaxoFacets: building +facets:DayOfYear.taxonomy # freq=196508
-MedTermDayTaxoFacets: young +facets:DayOfYear.taxonomy # freq=196428
-MedTermDayTaxoFacets: together +facets:DayOfYear.taxonomy # freq=195949
-MedTermDayTaxoFacets: important +facets:DayOfYear.taxonomy # freq=195851
-MedTermDayTaxoFacets: star +facets:DayOfYear.taxonomy # freq=195768
-MedTermDayTaxoFacets: similar +facets:DayOfYear.taxonomy # freq=195171
-MedTermDayTaxoFacets: received +facets:DayOfYear.taxonomy # freq=194983
-MedTermDayTaxoFacets: sup +facets:DayOfYear.taxonomy # freq=194723
-MedTermDayTaxoFacets: head +facets:DayOfYear.taxonomy # freq=194682
-AndHighHighDayTaxoFacets: +of +s +facets:DayOfYear.taxonomy # freq=8184358 freq=1581243
-AndHighHighDayTaxoFacets: +date +he +facets:DayOfYear.taxonomy # freq=2020626 freq=1659434
-AndHighHighDayTaxoFacets: +cite +2005 +facets:DayOfYear.taxonomy # freq=1741194 freq=835460
-AndHighHighDayTaxoFacets: +i +10 +facets:DayOfYear.taxonomy # freq=956148 freq=918339
-AndHighHighDayTaxoFacets: +date +2009 +facets:DayOfYear.taxonomy # freq=2020626 freq=887702
-AndHighHighDayTaxoFacets: +for +cite +facets:DayOfYear.taxonomy # freq=4380011 freq=1741194
-AndHighHighDayTaxoFacets: +as +its +facets:DayOfYear.taxonomy # freq=3925535 freq=1173450
-AndHighHighDayTaxoFacets: +which +2011 +facets:DayOfYear.taxonomy # freq=1963428 freq=871410
-AndHighHighDayTaxoFacets: +have +see +facets:DayOfYear.taxonomy # freq=1297121 freq=1044180
-AndHighHighDayTaxoFacets: +first +accessdate +facets:DayOfYear.taxonomy # freq=1933372 freq=1228887
-AndHighHighDayTaxoFacets: +also +no +facets:DayOfYear.taxonomy # freq=1959419 freq=1045000
-AndHighHighDayTaxoFacets: +first +new +facets:DayOfYear.taxonomy # freq=1933372 freq=1657293
-AndHighHighDayTaxoFacets: +publisher +web +facets:DayOfYear.taxonomy # freq=1289029 freq=1118334
-AndHighHighDayTaxoFacets: +states +work +facets:DayOfYear.taxonomy # freq=1034872 freq=853422
-AndHighHighDayTaxoFacets: +more +work +facets:DayOfYear.taxonomy # freq=963533 freq=853422
-AndHighHighDayTaxoFacets: +1 +their +facets:DayOfYear.taxonomy # freq=1641090 freq=1158682
-AndHighHighDayTaxoFacets: +http +an +facets:DayOfYear.taxonomy # freq=3493581 freq=2628056
-AndHighHighDayTaxoFacets: +year +5 +facets:DayOfYear.taxonomy # freq=1235231 freq=891361
-AndHighHighDayTaxoFacets: +4 +there +facets:DayOfYear.taxonomy # freq=986452 freq=956153
-AndHighHighDayTaxoFacets: +s +who +facets:DayOfYear.taxonomy # freq=1581243 freq=1196171
-AndHighHighDayTaxoFacets: +who +may +facets:DayOfYear.taxonomy # freq=1196171 freq=1071932
-AndHighHighDayTaxoFacets: +united +time +facets:DayOfYear.taxonomy # freq=1196944 freq=1032071
-AndHighHighDayTaxoFacets: +other +no +facets:DayOfYear.taxonomy # freq=1269961 freq=1045000
-AndHighHighDayTaxoFacets: +time +when +facets:DayOfYear.taxonomy # freq=1032071 freq=1027487
-AndHighHighDayTaxoFacets: +that +cite +facets:DayOfYear.taxonomy # freq=2931020 freq=1741194
-AndHighHighDayTaxoFacets: +to +its +facets:DayOfYear.taxonomy # freq=6155577 freq=1173450
-AndHighHighDayTaxoFacets: +2011 +2008 +facets:DayOfYear.taxonomy # freq=871410 freq=831253
-AndHighHighDayTaxoFacets: +been +2005 +facets:DayOfYear.taxonomy # freq=1041183 freq=835460
-AndHighHighDayTaxoFacets: +1 +year +facets:DayOfYear.taxonomy # freq=1641090 freq=1235231
-AndHighHighDayTaxoFacets: +was +more +facets:DayOfYear.taxonomy # freq=3763623 freq=963533
-AndHighHighDayTaxoFacets: +3 +2005 +facets:DayOfYear.taxonomy # freq=1148799 freq=835460
-AndHighHighDayTaxoFacets: +a +they +facets:DayOfYear.taxonomy # freq=6560531 freq=1021945
-AndHighHighDayTaxoFacets: +s +time +facets:DayOfYear.taxonomy # freq=1581243 freq=1032071
-AndHighHighDayTaxoFacets: +in +2011 +facets:DayOfYear.taxonomy # freq=7320987 freq=871410
-AndHighHighDayTaxoFacets: +a +work +facets:DayOfYear.taxonomy # freq=6560531 freq=853422
-AndHighHighDayTaxoFacets: +they +4 +facets:DayOfYear.taxonomy # freq=1021945 freq=986452
-AndHighHighDayTaxoFacets: +and +2 +facets:DayOfYear.taxonomy # freq=7318061 freq=1549245
-AndHighHighDayTaxoFacets: +to +an +facets:DayOfYear.taxonomy # freq=6155577 freq=2628056
-AndHighHighDayTaxoFacets: +an +which +facets:DayOfYear.taxonomy # freq=2628056 freq=1963428
-AndHighHighDayTaxoFacets: +was +also +facets:DayOfYear.taxonomy # freq=3763623 freq=1959419
-AndHighHighDayTaxoFacets: +this +see +facets:DayOfYear.taxonomy # freq=2224932 freq=1044180
-AndHighHighDayTaxoFacets: +all +2010 +facets:DayOfYear.taxonomy # freq=1203572 freq=950573
-AndHighHighDayTaxoFacets: +2 +2010 +facets:DayOfYear.taxonomy # freq=1549245 freq=950573
-AndHighHighDayTaxoFacets: +first +work +facets:DayOfYear.taxonomy # freq=1933372 freq=853422
-AndHighHighDayTaxoFacets: +he +10 +facets:DayOfYear.taxonomy # freq=1659434 freq=918339
-AndHighHighDayTaxoFacets: +http +that +facets:DayOfYear.taxonomy # freq=3493581 freq=2931020
-AndHighHighDayTaxoFacets: +new +2011 +facets:DayOfYear.taxonomy # freq=1657293 freq=871410
-AndHighHighDayTaxoFacets: +as +by +facets:DayOfYear.taxonomy # freq=3925535 freq=3826691
-AndHighHighDayTaxoFacets: +there +2008 +facets:DayOfYear.taxonomy # freq=956153 freq=831253
-AndHighHighDayTaxoFacets: +is +they +facets:DayOfYear.taxonomy # freq=4074455 freq=1021945
-AndHighHighDayTaxoFacets: +2010 +2011 +facets:DayOfYear.taxonomy # freq=950573 freq=871410
-AndHighHighDayTaxoFacets: +accessdate +2005 +facets:DayOfYear.taxonomy # freq=1228887 freq=835460
-AndHighHighDayTaxoFacets: +at +this +facets:DayOfYear.taxonomy # freq=2857534 freq=2224932
-AndHighHighDayTaxoFacets: +as +some +facets:DayOfYear.taxonomy # freq=3925535 freq=839919
-AndHighHighDayTaxoFacets: +after +all +facets:DayOfYear.taxonomy # freq=1247398 freq=1203572
-AndHighHighDayTaxoFacets: +year +they +facets:DayOfYear.taxonomy # freq=1235231 freq=1021945
-AndHighHighDayTaxoFacets: +1 +accessdate +facets:DayOfYear.taxonomy # freq=1641090 freq=1228887
-AndHighHighDayTaxoFacets: +on +web +facets:DayOfYear.taxonomy # freq=4074624 freq=1118334
-AndHighHighDayTaxoFacets: +first +5 +facets:DayOfYear.taxonomy # freq=1933372 freq=891361
-AndHighHighDayTaxoFacets: +he +but +facets:DayOfYear.taxonomy # freq=1659434 freq=1456553
-AndHighHighDayTaxoFacets: +title +when +facets:DayOfYear.taxonomy # freq=2397378 freq=1027487
-AndHighHighDayTaxoFacets: +who +two +facets:DayOfYear.taxonomy # freq=1196171 freq=1104053
-AndHighHighDayTaxoFacets: +last +2006 +facets:DayOfYear.taxonomy # freq=958437 freq=889954
-AndHighHighDayTaxoFacets: +from +name +facets:DayOfYear.taxonomy # freq=3224339 freq=2827713
-AndHighHighDayTaxoFacets: +new +i +facets:DayOfYear.taxonomy # freq=1657293 freq=956148
-AndHighHighDayTaxoFacets: +was +publisher +facets:DayOfYear.taxonomy # freq=3763623 freq=1289029
-AndHighHighDayTaxoFacets: +and +not +facets:DayOfYear.taxonomy # freq=7318061 freq=1713264
-AndHighHighDayTaxoFacets: +is +their +facets:DayOfYear.taxonomy # freq=4074455 freq=1158682
-AndHighHighDayTaxoFacets: +ref +that +facets:DayOfYear.taxonomy # freq=3793973 freq=2931020
-AndHighHighDayTaxoFacets: +of +for +facets:DayOfYear.taxonomy # freq=8184358 freq=4380011
-AndHighHighDayTaxoFacets: +name +which +facets:DayOfYear.taxonomy # freq=2827713 freq=1963428
-AndHighHighDayTaxoFacets: +after +2008 +facets:DayOfYear.taxonomy # freq=1247398 freq=831253
-AndHighHighDayTaxoFacets: +that +an +facets:DayOfYear.taxonomy # freq=2931020 freq=2628056
-AndHighHighDayTaxoFacets: +by +2006 +facets:DayOfYear.taxonomy # freq=3826691 freq=889954
-AndHighHighDayTaxoFacets: +that +or +facets:DayOfYear.taxonomy # freq=2931020 freq=1858841
-AndHighHighDayTaxoFacets: +be +which +facets:DayOfYear.taxonomy # freq=2051702 freq=1963428
-AndHighHighDayTaxoFacets: +with +2010 +facets:DayOfYear.taxonomy # freq=3709421 freq=950573
-AndHighHighDayTaxoFacets: +by +with +facets:DayOfYear.taxonomy # freq=3826691 freq=3709421
-AndHighHighDayTaxoFacets: +by +4 +facets:DayOfYear.taxonomy # freq=3826691 freq=986452
-AndHighHighDayTaxoFacets: +was +cite +facets:DayOfYear.taxonomy # freq=3763623 freq=1741194
-AndHighHighDayTaxoFacets: +was +they +facets:DayOfYear.taxonomy # freq=3763623 freq=1021945
-AndHighHighDayTaxoFacets: +on +was +facets:DayOfYear.taxonomy # freq=4074624 freq=3763623
-AndHighHighDayTaxoFacets: +is +time +facets:DayOfYear.taxonomy # freq=4074455 freq=1032071
-AndHighHighDayTaxoFacets: +the +be +facets:DayOfYear.taxonomy # freq=8217362 freq=2051702
-AndHighHighDayTaxoFacets: +were +2010 +facets:DayOfYear.taxonomy # freq=1524630 freq=950573
-AndHighHighDayTaxoFacets: +they +2006 +facets:DayOfYear.taxonomy # freq=1021945 freq=889954
-AndHighHighDayTaxoFacets: +he +may +facets:DayOfYear.taxonomy # freq=1659434 freq=1071932
-AndHighHighDayTaxoFacets: +an +title +facets:DayOfYear.taxonomy # freq=2628056 freq=2397378
-AndHighHighDayTaxoFacets: +into +some +facets:DayOfYear.taxonomy # freq=888684 freq=839919
-AndHighHighDayTaxoFacets: +first +some +facets:DayOfYear.taxonomy # freq=1933372 freq=839919
-AndHighHighDayTaxoFacets: +name +new +facets:DayOfYear.taxonomy # freq=2827713 freq=1657293
-AndHighHighDayTaxoFacets: +cite +3 +facets:DayOfYear.taxonomy # freq=1741194 freq=1148799
-AndHighHighDayTaxoFacets: +to +web +facets:DayOfYear.taxonomy # freq=6155577 freq=1118334
-AndHighHighDayTaxoFacets: +for +it +facets:DayOfYear.taxonomy # freq=4380011 freq=2675552
-AndHighHighDayTaxoFacets: +year +there +facets:DayOfYear.taxonomy # freq=1235231 freq=956153
-AndHighHighDayTaxoFacets: +but +been +facets:DayOfYear.taxonomy # freq=1456553 freq=1041183
-AndHighHighDayTaxoFacets: +this +who +facets:DayOfYear.taxonomy # freq=2224932 freq=1196171
-AndHighHighDayTaxoFacets: +ref +web +facets:DayOfYear.taxonomy # freq=3793973 freq=1118334
-AndHighHighDayTaxoFacets: +cite +2011 +facets:DayOfYear.taxonomy # freq=1741194 freq=871410
-AndHighHighDayTaxoFacets: +by +he +facets:DayOfYear.taxonomy # freq=3826691 freq=1659434
-AndHighHighDayTaxoFacets: +name +first +facets:DayOfYear.taxonomy # freq=2827713 freq=1933372
-AndHighHighDayTaxoFacets: +has +about +facets:DayOfYear.taxonomy # freq=1502961 freq=850283
-AndHighHighDayTaxoFacets: +were +two +facets:DayOfYear.taxonomy # freq=1524630 freq=1104053
-AndHighHighDayTaxoFacets: +two +work +facets:DayOfYear.taxonomy # freq=1104053 freq=853422
-AndHighHighDayTaxoFacets: +he +been +facets:DayOfYear.taxonomy # freq=1659434 freq=1041183
-AndHighHighDayTaxoFacets: +from +2 +facets:DayOfYear.taxonomy # freq=3224339 freq=1549245
-AndHighHighDayTaxoFacets: +all +some +facets:DayOfYear.taxonomy # freq=1203572 freq=839919
-AndHighHighDayTaxoFacets: +on +only +facets:DayOfYear.taxonomy # freq=4074624 freq=875561
-AndHighHighDayTaxoFacets: +was +no +facets:DayOfYear.taxonomy # freq=3763623 freq=1045000
-AndHighHighDayTaxoFacets: +name +see +facets:DayOfYear.taxonomy # freq=2827713 freq=1044180
-AndHighHighDayTaxoFacets: +of +as +facets:DayOfYear.taxonomy # freq=8184358 freq=3925535
-AndHighHighDayTaxoFacets: +be +has +facets:DayOfYear.taxonomy # freq=2051702 freq=1502961
-AndHighHighDayTaxoFacets: +url +into +facets:DayOfYear.taxonomy # freq=1513595 freq=888684
-AndHighHighDayTaxoFacets: +of +2006 +facets:DayOfYear.taxonomy # freq=8184358 freq=889954
-AndHighHighDayTaxoFacets: +ref +or +facets:DayOfYear.taxonomy # freq=3793973 freq=1858841
-AndHighHighDayTaxoFacets: +by +url +facets:DayOfYear.taxonomy # freq=3826691 freq=1513595
-AndHighHighDayTaxoFacets: +3 +into +facets:DayOfYear.taxonomy # freq=1148799 freq=888684
-AndHighHighDayTaxoFacets: +which +year +facets:DayOfYear.taxonomy # freq=1963428 freq=1235231
-AndHighHighDayTaxoFacets: +at +only +facets:DayOfYear.taxonomy # freq=2857534 freq=875561
-AndHighHighDayTaxoFacets: +http +publisher +facets:DayOfYear.taxonomy # freq=3493581 freq=1289029
-AndHighHighDayTaxoFacets: +with +accessdate +facets:DayOfYear.taxonomy # freq=3709421 freq=1228887
-AndHighHighDayTaxoFacets: +had +work +facets:DayOfYear.taxonomy # freq=1246743 freq=853422
-AndHighHighDayTaxoFacets: +as +they +facets:DayOfYear.taxonomy # freq=3925535 freq=1021945
-AndHighHighDayTaxoFacets: +the +2009 +facets:DayOfYear.taxonomy # freq=8217362 freq=887702
-AndHighHighDayTaxoFacets: +are +but +facets:DayOfYear.taxonomy # freq=1877802 freq=1456553
-AndHighHighDayTaxoFacets: +other +10 +facets:DayOfYear.taxonomy # freq=1269961 freq=918339
-AndHighHighDayTaxoFacets: +two +they +facets:DayOfYear.taxonomy # freq=1104053 freq=1021945
-AndHighHighDayTaxoFacets: +all +they +facets:DayOfYear.taxonomy # freq=1203572 freq=1021945
-AndHighHighDayTaxoFacets: +2011 +about +facets:DayOfYear.taxonomy # freq=871410 freq=850283
-AndHighHighDayTaxoFacets: +name +states +facets:DayOfYear.taxonomy # freq=2827713 freq=1034872
-AndHighHighDayTaxoFacets: +were +may +facets:DayOfYear.taxonomy # freq=1524630 freq=1071932
-AndHighHighDayTaxoFacets: +the +into +facets:DayOfYear.taxonomy # freq=8217362 freq=888684
-AndHighHighDayTaxoFacets: +new +united +facets:DayOfYear.taxonomy # freq=1657293 freq=1196944
-AndHighHighDayTaxoFacets: +their +only +facets:DayOfYear.taxonomy # freq=1158682 freq=875561
-AndHighHighDayTaxoFacets: +be +10 +facets:DayOfYear.taxonomy # freq=2051702 freq=918339
-AndHighHighDayTaxoFacets: +that +not +facets:DayOfYear.taxonomy # freq=2931020 freq=1713264
-AndHighHighDayTaxoFacets: +title +all +facets:DayOfYear.taxonomy # freq=2397378 freq=1203572
-AndHighHighDayTaxoFacets: +with +have +facets:DayOfYear.taxonomy # freq=3709421 freq=1297121
-AndHighHighDayTaxoFacets: +as +been +facets:DayOfYear.taxonomy # freq=3925535 freq=1041183
-AndHighHighDayTaxoFacets: +it +more +facets:DayOfYear.taxonomy # freq=2675552 freq=963533
-AndHighHighDayTaxoFacets: +all +united +facets:DayOfYear.taxonomy # freq=1203572 freq=1196944
-AndHighHighDayTaxoFacets: +other +two +facets:DayOfYear.taxonomy # freq=1269961 freq=1104053
-AndHighHighDayTaxoFacets: +he +url +facets:DayOfYear.taxonomy # freq=1659434 freq=1513595
-AndHighHighDayTaxoFacets: +to +3 +facets:DayOfYear.taxonomy # freq=6155577 freq=1148799
-AndHighHighDayTaxoFacets: +in +from +facets:DayOfYear.taxonomy # freq=7320987 freq=3224339
-AndHighHighDayTaxoFacets: +not +there +facets:DayOfYear.taxonomy # freq=1713264 freq=956153
-AndHighHighDayTaxoFacets: +other +see +facets:DayOfYear.taxonomy # freq=1269961 freq=1044180
-AndHighHighDayTaxoFacets: +its +i +facets:DayOfYear.taxonomy # freq=1173450 freq=956148
-AndHighHighDayTaxoFacets: +as +2008 +facets:DayOfYear.taxonomy # freq=3925535 freq=831253
-AndHighHighDayTaxoFacets: +http +s +facets:DayOfYear.taxonomy # freq=3493581 freq=1581243
-AndHighHighDayTaxoFacets: +or +web +facets:DayOfYear.taxonomy # freq=1858841 freq=1118334
-AndHighHighDayTaxoFacets: +new +publisher +facets:DayOfYear.taxonomy # freq=1657293 freq=1289029
-AndHighHighDayTaxoFacets: +of +who +facets:DayOfYear.taxonomy # freq=8184358 freq=1196171
-AndHighHighDayTaxoFacets: +10 +2009 +facets:DayOfYear.taxonomy # freq=918339 freq=887702
-AndHighHighDayTaxoFacets: +that +he +facets:DayOfYear.taxonomy # freq=2931020 freq=1659434
-AndHighHighDayTaxoFacets: +url +2005 +facets:DayOfYear.taxonomy # freq=1513595 freq=835460
-AndHighHighDayTaxoFacets: +the +a +facets:DayOfYear.taxonomy # freq=8217362 freq=6560531
-AndHighHighDayTaxoFacets: +more +there +facets:DayOfYear.taxonomy # freq=963533 freq=956153
-AndHighHighDayTaxoFacets: +and +an +facets:DayOfYear.taxonomy # freq=7318061 freq=2628056
-AndHighHighDayTaxoFacets: +with +they +facets:DayOfYear.taxonomy # freq=3709421 freq=1021945
-AndHighHighDayTaxoFacets: +title +time +facets:DayOfYear.taxonomy # freq=2397378 freq=1032071
-AndHighHighDayTaxoFacets: +states +4 +facets:DayOfYear.taxonomy # freq=1034872 freq=986452
-AndHighHighDayTaxoFacets: +united +when +facets:DayOfYear.taxonomy # freq=1196944 freq=1027487
-AndHighHighDayTaxoFacets: +is +title +facets:DayOfYear.taxonomy # freq=4074455 freq=2397378
-AndHighHighDayTaxoFacets: +from +who +facets:DayOfYear.taxonomy # freq=3224339 freq=1196171
-AndHighHighDayTaxoFacets: +more +some +facets:DayOfYear.taxonomy # freq=963533 freq=839919
-AndHighHighDayTaxoFacets: +title +year +facets:DayOfYear.taxonomy # freq=2397378 freq=1235231
-AndHighHighDayTaxoFacets: +one +after +facets:DayOfYear.taxonomy # freq=1527689 freq=1247398
-AndHighHighDayTaxoFacets: +with +title +facets:DayOfYear.taxonomy # freq=3709421 freq=2397378
-AndHighHighDayTaxoFacets: +in +first +facets:DayOfYear.taxonomy # freq=7320987 freq=1933372
-AndHighHighDayTaxoFacets: +are +i +facets:DayOfYear.taxonomy # freq=1877802 freq=956148
-AndHighHighDayTaxoFacets: +the +two +facets:DayOfYear.taxonomy # freq=8217362 freq=1104053
-AndHighHighDayTaxoFacets: +but +there +facets:DayOfYear.taxonomy # freq=1456553 freq=956153
-AndHighHighDayTaxoFacets: +from +all +facets:DayOfYear.taxonomy # freq=3224339 freq=1203572
-AndHighHighDayTaxoFacets: +2 +more +facets:DayOfYear.taxonomy # freq=1549245 freq=963533
-AndHighHighDayTaxoFacets: +had +its +facets:DayOfYear.taxonomy # freq=1246743 freq=1173450
-AndHighHighDayTaxoFacets: +in +no +facets:DayOfYear.taxonomy # freq=7320987 freq=1045000
-AndHighHighDayTaxoFacets: +other +more +facets:DayOfYear.taxonomy # freq=1269961 freq=963533
-AndHighHighDayTaxoFacets: +his +united +facets:DayOfYear.taxonomy # freq=1777780 freq=1196944
-AndHighHighDayTaxoFacets: +more +last +facets:DayOfYear.taxonomy # freq=963533 freq=958437
-AndHighHighDayTaxoFacets: +ref +more +facets:DayOfYear.taxonomy # freq=3793973 freq=963533
-AndHighHighDayTaxoFacets: +ref +been +facets:DayOfYear.taxonomy # freq=3793973 freq=1041183
-AndHighHighDayTaxoFacets: +cite +time +facets:DayOfYear.taxonomy # freq=1741194 freq=1032071
-AndHighHighDayTaxoFacets: +http +3 +facets:DayOfYear.taxonomy # freq=3493581 freq=1148799
-AndHighHighDayTaxoFacets: +has +they +facets:DayOfYear.taxonomy # freq=1502961 freq=1021945
-AndHighHighDayTaxoFacets: +and +2011 +facets:DayOfYear.taxonomy # freq=7318061 freq=871410
-AndHighHighDayTaxoFacets: +be +accessdate +facets:DayOfYear.taxonomy # freq=2051702 freq=1228887
-AndHighHighDayTaxoFacets: +are +2010 +facets:DayOfYear.taxonomy # freq=1877802 freq=950573
-AndHighHighDayTaxoFacets: +at +2009 +facets:DayOfYear.taxonomy # freq=2857534 freq=887702
-AndHighHighDayTaxoFacets: +also +united +facets:DayOfYear.taxonomy # freq=1959419 freq=1196944
-AndHighHighDayTaxoFacets: +united +been +facets:DayOfYear.taxonomy # freq=1196944 freq=1041183
-AndHighHighDayTaxoFacets: +also +1 +facets:DayOfYear.taxonomy # freq=1959419 freq=1641090
-AndHighHighDayTaxoFacets: +he +last +facets:DayOfYear.taxonomy # freq=1659434 freq=958437
-AndHighHighDayTaxoFacets: +was +from +facets:DayOfYear.taxonomy # freq=3763623 freq=3224339
-AndHighHighDayTaxoFacets: +ref +when +facets:DayOfYear.taxonomy # freq=3793973 freq=1027487
-AndHighHighDayTaxoFacets: +not +they +facets:DayOfYear.taxonomy # freq=1713264 freq=1021945
-AndHighHighDayTaxoFacets: +the +other +facets:DayOfYear.taxonomy # freq=8217362 freq=1269961
-AndHighHighDayTaxoFacets: +cite +work +facets:DayOfYear.taxonomy # freq=1741194 freq=853422
-AndHighHighDayTaxoFacets: +was +were +facets:DayOfYear.taxonomy # freq=3763623 freq=1524630
-AndHighHighDayTaxoFacets: +in +after +facets:DayOfYear.taxonomy # freq=7320987 freq=1247398
-AndHighHighDayTaxoFacets: +and +first +facets:DayOfYear.taxonomy # freq=7318061 freq=1933372
-AndHighHighDayTaxoFacets: +have +their +facets:DayOfYear.taxonomy # freq=1297121 freq=1158682
-AndHighHighDayTaxoFacets: +also +4 +facets:DayOfYear.taxonomy # freq=1959419 freq=986452
-AndHighHighDayTaxoFacets: +he +2006 +facets:DayOfYear.taxonomy # freq=1659434 freq=889954
-AndHighHighDayTaxoFacets: +may +time +facets:DayOfYear.taxonomy # freq=1071932 freq=1032071
-AndHighHighDayTaxoFacets: +is +url +facets:DayOfYear.taxonomy # freq=4074455 freq=1513595
-AndHighHighDayTaxoFacets: +for +has +facets:DayOfYear.taxonomy # freq=4380011 freq=1502961
-AndHighHighDayTaxoFacets: +and +be +facets:DayOfYear.taxonomy # freq=7318061 freq=2051702
-AndHighHighDayTaxoFacets: +url +had +facets:DayOfYear.taxonomy # freq=1513595 freq=1246743
-AndHighHighDayTaxoFacets: +his +5 +facets:DayOfYear.taxonomy # freq=1777780 freq=891361
-AndHighHighDayTaxoFacets: +on +he +facets:DayOfYear.taxonomy # freq=4074624 freq=1659434
-AndHighHighDayTaxoFacets: +this +first +facets:DayOfYear.taxonomy # freq=2224932 freq=1933372
-AndHighHighDayTaxoFacets: +new +its +facets:DayOfYear.taxonomy # freq=1657293 freq=1173450
-AndHighHighDayTaxoFacets: +s +2009 +facets:DayOfYear.taxonomy # freq=1581243 freq=887702
-AndHighHighDayTaxoFacets: +see +2010 +facets:DayOfYear.taxonomy # freq=1044180 freq=950573
-AndHighHighDayTaxoFacets: +or +but +facets:DayOfYear.taxonomy # freq=1858841 freq=1456553
-AndHighHighDayTaxoFacets: +its +into +facets:DayOfYear.taxonomy # freq=1173450 freq=888684
-AndHighHighDayTaxoFacets: +on +accessdate +facets:DayOfYear.taxonomy # freq=4074624 freq=1228887
-AndHighHighDayTaxoFacets: +are +accessdate +facets:DayOfYear.taxonomy # freq=1877802 freq=1228887
-AndHighHighDayTaxoFacets: +2 +there +facets:DayOfYear.taxonomy # freq=1549245 freq=956153
-AndHighHighDayTaxoFacets: +united +3 +facets:DayOfYear.taxonomy # freq=1196944 freq=1148799
-AndHighHighDayTaxoFacets: +which +no +facets:DayOfYear.taxonomy # freq=1963428 freq=1045000
-AndHighHighDayTaxoFacets: +s +2006 +facets:DayOfYear.taxonomy # freq=1581243 freq=889954
-AndHighHighDayTaxoFacets: +ref +there +facets:DayOfYear.taxonomy # freq=3793973 freq=956153
-AndHighHighDayTaxoFacets: +he +more +facets:DayOfYear.taxonomy # freq=1659434 freq=963533
-AndHighHighDayTaxoFacets: +had +two +facets:DayOfYear.taxonomy # freq=1246743 freq=1104053
-AndHighHighDayTaxoFacets: +the +only +facets:DayOfYear.taxonomy # freq=8217362 freq=875561
-AndHighHighDayTaxoFacets: +be +about +facets:DayOfYear.taxonomy # freq=2051702 freq=850283
-AndHighHighDayTaxoFacets: +in +has +facets:DayOfYear.taxonomy # freq=7320987 freq=1502961
-AndHighHighDayTaxoFacets: +2009 +work +facets:DayOfYear.taxonomy # freq=887702 freq=853422
-AndHighHighDayTaxoFacets: +on +10 +facets:DayOfYear.taxonomy # freq=4074624 freq=918339
-AndHighHighDayTaxoFacets: +ref +2010 +facets:DayOfYear.taxonomy # freq=3793973 freq=950573
-AndHighHighDayTaxoFacets: +other +2006 +facets:DayOfYear.taxonomy # freq=1269961 freq=889954
-AndHighHighDayTaxoFacets: +with +all +facets:DayOfYear.taxonomy # freq=3709421 freq=1203572
-AndHighHighDayTaxoFacets: +in +work +facets:DayOfYear.taxonomy # freq=7320987 freq=853422
-AndHighHighDayTaxoFacets: +url +about +facets:DayOfYear.taxonomy # freq=1513595 freq=850283
-AndHighHighDayTaxoFacets: +after +some +facets:DayOfYear.taxonomy # freq=1247398 freq=839919
-AndHighHighDayTaxoFacets: +this +when +facets:DayOfYear.taxonomy # freq=2224932 freq=1027487
-AndHighHighDayTaxoFacets: +not +1 +facets:DayOfYear.taxonomy # freq=1713264 freq=1641090
-AndHighHighDayTaxoFacets: +1 +more +facets:DayOfYear.taxonomy # freq=1641090 freq=963533
-AndHighHighDayTaxoFacets: +not +2 +facets:DayOfYear.taxonomy # freq=1713264 freq=1549245
-AndHighHighDayTaxoFacets: +publisher +2005 +facets:DayOfYear.taxonomy # freq=1289029 freq=835460
-AndHighHighDayTaxoFacets: +in +at +facets:DayOfYear.taxonomy # freq=7320987 freq=2857534
-AndHighHighDayTaxoFacets: +1 +some +facets:DayOfYear.taxonomy # freq=1641090 freq=839919
-AndHighHighDayTaxoFacets: +s +its +facets:DayOfYear.taxonomy # freq=1581243 freq=1173450
-AndHighHighDayTaxoFacets: +date +more +facets:DayOfYear.taxonomy # freq=2020626 freq=963533
-AndHighHighDayTaxoFacets: +from +his +facets:DayOfYear.taxonomy # freq=3224339 freq=1777780
-AndHighHighDayTaxoFacets: +was +when +facets:DayOfYear.taxonomy # freq=3763623 freq=1027487
-AndHighHighDayTaxoFacets: +time +2010 +facets:DayOfYear.taxonomy # freq=1032071 freq=950573
-AndHighHighDayTaxoFacets: +it +2 +facets:DayOfYear.taxonomy # freq=2675552 freq=1549245
-AndHighHighDayTaxoFacets: +of +http +facets:DayOfYear.taxonomy # freq=8184358 freq=3493581
-AndHighHighDayTaxoFacets: +2 +2011 +facets:DayOfYear.taxonomy # freq=1549245 freq=871410
-AndHighHighDayTaxoFacets: +who +2009 +facets:DayOfYear.taxonomy # freq=1196171 freq=887702
-AndHighHighDayTaxoFacets: +in +2009 +facets:DayOfYear.taxonomy # freq=7320987 freq=887702
-AndHighHighDayTaxoFacets: +by +3 +facets:DayOfYear.taxonomy # freq=3826691 freq=1148799
-AndHighHighDayTaxoFacets: +when +2011 +facets:DayOfYear.taxonomy # freq=1027487 freq=871410
-AndHighHighDayTaxoFacets: +not +have +facets:DayOfYear.taxonomy # freq=1713264 freq=1297121
-AndHighHighDayTaxoFacets: +all +their +facets:DayOfYear.taxonomy # freq=1203572 freq=1158682
-AndHighHighDayTaxoFacets: +an +2005 +facets:DayOfYear.taxonomy # freq=2628056 freq=835460
-AndHighHighDayTaxoFacets: +of +is +facets:DayOfYear.taxonomy # freq=8184358 freq=4074455
-AndHighHighDayTaxoFacets: +of +url +facets:DayOfYear.taxonomy # freq=8184358 freq=1513595
-AndHighHighDayTaxoFacets: +also +year +facets:DayOfYear.taxonomy # freq=1959419 freq=1235231
-AndHighHighDayTaxoFacets: +is +new +facets:DayOfYear.taxonomy # freq=4074455 freq=1657293
-AndHighHighDayTaxoFacets: +http +name +facets:DayOfYear.taxonomy # freq=3493581 freq=2827713
-AndHighHighDayTaxoFacets: +i +into +facets:DayOfYear.taxonomy # freq=956148 freq=888684
-AndHighHighDayTaxoFacets: +are +united +facets:DayOfYear.taxonomy # freq=1877802 freq=1196944
-AndHighHighDayTaxoFacets: +or +only +facets:DayOfYear.taxonomy # freq=1858841 freq=875561
-AndHighHighDayTaxoFacets: +who +their +facets:DayOfYear.taxonomy # freq=1196171 freq=1158682
-AndHighHighDayTaxoFacets: +name +been +facets:DayOfYear.taxonomy # freq=2827713 freq=1041183
-AndHighHighDayTaxoFacets: +last +2009 +facets:DayOfYear.taxonomy # freq=958437 freq=887702
-AndHighHighDayTaxoFacets: +they +2005 +facets:DayOfYear.taxonomy # freq=1021945 freq=835460
-AndHighHighDayTaxoFacets: +new +1 +facets:DayOfYear.taxonomy # freq=1657293 freq=1641090
-AndHighHighDayTaxoFacets: +title +some +facets:DayOfYear.taxonomy # freq=2397378 freq=839919
-AndHighHighDayTaxoFacets: +name +5 +facets:DayOfYear.taxonomy # freq=2827713 freq=891361
-AndHighHighDayTaxoFacets: +and +or +facets:DayOfYear.taxonomy # freq=7318061 freq=1858841
-AndHighHighDayTaxoFacets: +3 +2006 +facets:DayOfYear.taxonomy # freq=1148799 freq=889954
-AndHighHighDayTaxoFacets: +of +has +facets:DayOfYear.taxonomy # freq=8184358 freq=1502961
-AndHighHighDayTaxoFacets: +which +i +facets:DayOfYear.taxonomy # freq=1963428 freq=956148
-AndHighHighDayTaxoFacets: +see +5 +facets:DayOfYear.taxonomy # freq=1044180 freq=891361
-AndHighHighDayTaxoFacets: +has +2011 +facets:DayOfYear.taxonomy # freq=1502961 freq=871410
-AndHighHighDayTaxoFacets: +new +accessdate +facets:DayOfYear.taxonomy # freq=1657293 freq=1228887
-AndHighHighDayTaxoFacets: +united +i +facets:DayOfYear.taxonomy # freq=1196944 freq=956148
-AndHighHighDayTaxoFacets: +are +10 +facets:DayOfYear.taxonomy # freq=1877802 freq=918339
-AndHighHighDayTaxoFacets: +the +is +facets:DayOfYear.taxonomy # freq=8217362 freq=4074455
-AndHighHighDayTaxoFacets: +other +web +facets:DayOfYear.taxonomy # freq=1269961 freq=1118334
-AndHighHighDayTaxoFacets: +i +2006 +facets:DayOfYear.taxonomy # freq=956148 freq=889954
-AndHighHighDayTaxoFacets: +were +publisher +facets:DayOfYear.taxonomy # freq=1524630 freq=1289029
-AndHighHighDayTaxoFacets: +be +when +facets:DayOfYear.taxonomy # freq=2051702 freq=1027487
-AndHighHighDayTaxoFacets: +to +date +facets:DayOfYear.taxonomy # freq=6155577 freq=2020626
-AndHighHighDayTaxoFacets: +for +2006 +facets:DayOfYear.taxonomy # freq=4380011 freq=889954
-AndHighHighDayTaxoFacets: +for +at +facets:DayOfYear.taxonomy # freq=4380011 freq=2857534
-AndHighHighDayTaxoFacets: +his +s +facets:DayOfYear.taxonomy # freq=1777780 freq=1581243
-AndHighHighDayTaxoFacets: +from +or +facets:DayOfYear.taxonomy # freq=3224339 freq=1858841
-AndHighHighDayTaxoFacets: +ref +an +facets:DayOfYear.taxonomy # freq=3793973 freq=2628056
-AndHighHighDayTaxoFacets: +which +had +facets:DayOfYear.taxonomy # freq=1963428 freq=1246743
-AndHighHighDayTaxoFacets: +an +were +facets:DayOfYear.taxonomy # freq=2628056 freq=1524630
-AndHighHighDayTaxoFacets: +web +only +facets:DayOfYear.taxonomy # freq=1118334 freq=875561
-AndHighHighDayTaxoFacets: +ref +one +facets:DayOfYear.taxonomy # freq=3793973 freq=1527689
-AndHighHighDayTaxoFacets: +a +one +facets:DayOfYear.taxonomy # freq=6560531 freq=1527689
-AndHighHighDayTaxoFacets: +they +into +facets:DayOfYear.taxonomy # freq=1021945 freq=888684
-AndHighHighDayTaxoFacets: +of +2008 +facets:DayOfYear.taxonomy # freq=8184358 freq=831253
-AndHighHighDayTaxoFacets: +in +which +facets:DayOfYear.taxonomy # freq=7320987 freq=1963428
-AndHighHighDayTaxoFacets: +united +2010 +facets:DayOfYear.taxonomy # freq=1196944 freq=950573
-AndHighHighDayTaxoFacets: +after +i +facets:DayOfYear.taxonomy # freq=1247398 freq=956148
-AndHighHighDayTaxoFacets: +he +web +facets:DayOfYear.taxonomy # freq=1659434 freq=1118334
-AndHighHighDayTaxoFacets: +are +states +facets:DayOfYear.taxonomy # freq=1877802 freq=1034872
-AndHighHighDayTaxoFacets: +after +time +facets:DayOfYear.taxonomy # freq=1247398 freq=1032071
-AndHighHighDayTaxoFacets: +its +web +facets:DayOfYear.taxonomy # freq=1173450 freq=1118334
-AndHighHighDayTaxoFacets: +for +when +facets:DayOfYear.taxonomy # freq=4380011 freq=1027487
-AndHighHighDayTaxoFacets: +has +states +facets:DayOfYear.taxonomy # freq=1502961 freq=1034872
-AndHighHighDayTaxoFacets: +the +no +facets:DayOfYear.taxonomy # freq=8217362 freq=1045000
-AndHighHighDayTaxoFacets: +title +one +facets:DayOfYear.taxonomy # freq=2397378 freq=1527689
-AndHighHighDayTaxoFacets: +i +2009 +facets:DayOfYear.taxonomy # freq=956148 freq=887702
-AndHighHighDayTaxoFacets: +1 +states +facets:DayOfYear.taxonomy # freq=1641090 freq=1034872
-AndHighHighDayTaxoFacets: +other +only +facets:DayOfYear.taxonomy # freq=1269961 freq=875561
-AndHighHighDayTaxoFacets: +by +they +facets:DayOfYear.taxonomy # freq=3826691 freq=1021945
-AndHighHighDayTaxoFacets: +http +its +facets:DayOfYear.taxonomy # freq=3493581 freq=1173450
-AndHighHighDayTaxoFacets: +for +two +facets:DayOfYear.taxonomy # freq=4380011 freq=1104053
-AndHighHighDayTaxoFacets: +all +may +facets:DayOfYear.taxonomy # freq=1203572 freq=1071932
-AndHighHighDayTaxoFacets: +after +last +facets:DayOfYear.taxonomy # freq=1247398 freq=958437
-AndHighHighDayTaxoFacets: +there +only +facets:DayOfYear.taxonomy # freq=956153 freq=875561
-AndHighHighDayTaxoFacets: +2 +no +facets:DayOfYear.taxonomy # freq=1549245 freq=1045000
-AndHighHighDayTaxoFacets: +an +he +facets:DayOfYear.taxonomy # freq=2628056 freq=1659434
-AndHighHighDayTaxoFacets: +his +i +facets:DayOfYear.taxonomy # freq=1777780 freq=956148
-AndHighHighDayTaxoFacets: +first +not +facets:DayOfYear.taxonomy # freq=1933372 freq=1713264
-AndHighHighDayTaxoFacets: +a +5 +facets:DayOfYear.taxonomy # freq=6560531 freq=891361
-AndHighHighDayTaxoFacets: +from +2005 +facets:DayOfYear.taxonomy # freq=3224339 freq=835460
-AndHighHighDayTaxoFacets: +after +web +facets:DayOfYear.taxonomy # freq=1247398 freq=1118334
-AndHighHighDayTaxoFacets: +to +which +facets:DayOfYear.taxonomy # freq=6155577 freq=1963428
-AndHighHighDayTaxoFacets: +this +into +facets:DayOfYear.taxonomy # freq=2224932 freq=888684
-AndHighHighDayTaxoFacets: +its +last +facets:DayOfYear.taxonomy # freq=1173450 freq=958437
-AndHighHighDayTaxoFacets: +it +there +facets:DayOfYear.taxonomy # freq=2675552 freq=956153
-AndHighHighDayTaxoFacets: +name +are +facets:DayOfYear.taxonomy # freq=2827713 freq=1877802
-AndHighHighDayTaxoFacets: +are +4 +facets:DayOfYear.taxonomy # freq=1877802 freq=986452
-AndHighHighDayTaxoFacets: +name +cite +facets:DayOfYear.taxonomy # freq=2827713 freq=1741194
-AndHighHighDayTaxoFacets: +more +2008 +facets:DayOfYear.taxonomy # freq=963533 freq=831253
-AndHighHighDayTaxoFacets: +of +that +facets:DayOfYear.taxonomy # freq=8184358 freq=2931020
-AndHighHighDayTaxoFacets: +ref +at +facets:DayOfYear.taxonomy # freq=3793973 freq=2857534
-AndHighHighDayTaxoFacets: +new +web +facets:DayOfYear.taxonomy # freq=1657293 freq=1118334
-AndHighHighDayTaxoFacets: +the +2 +facets:DayOfYear.taxonomy # freq=8217362 freq=1549245
-AndHighHighDayTaxoFacets: +for +1 +facets:DayOfYear.taxonomy # freq=4380011 freq=1641090
-AndHighHighDayTaxoFacets: +by +no +facets:DayOfYear.taxonomy # freq=3826691 freq=1045000
-AndHighHighDayTaxoFacets: +all +i +facets:DayOfYear.taxonomy # freq=1203572 freq=956148
-AndHighHighDayTaxoFacets: +5 +2006 +facets:DayOfYear.taxonomy # freq=891361 freq=889954
-AndHighHighDayTaxoFacets: +4 +work +facets:DayOfYear.taxonomy # freq=986452 freq=853422
-AndHighHighDayTaxoFacets: +was +new +facets:DayOfYear.taxonomy # freq=3763623 freq=1657293
-AndHighHighDayTaxoFacets: +year +see +facets:DayOfYear.taxonomy # freq=1235231 freq=1044180
-AndHighHighDayTaxoFacets: +s +had +facets:DayOfYear.taxonomy # freq=1581243 freq=1246743
-AndHighHighDayTaxoFacets: +an +last +facets:DayOfYear.taxonomy # freq=2628056 freq=958437
-AndHighHighDayTaxoFacets: +had +4 +facets:DayOfYear.taxonomy # freq=1246743 freq=986452
-AndHighHighDayTaxoFacets: +from +publisher +facets:DayOfYear.taxonomy # freq=3224339 freq=1289029
-AndHighHighDayTaxoFacets: +new +url +facets:DayOfYear.taxonomy # freq=1657293 freq=1513595
-AndHighHighDayTaxoFacets: +4 +5 +facets:DayOfYear.taxonomy # freq=986452 freq=891361
-AndHighHighDayTaxoFacets: +by +cite +facets:DayOfYear.taxonomy # freq=3826691 freq=1741194
-AndHighHighDayTaxoFacets: +2010 +2009 +facets:DayOfYear.taxonomy # freq=950573 freq=887702
-AndHighHighDayTaxoFacets: +their +4 +facets:DayOfYear.taxonomy # freq=1158682 freq=986452
-AndHighHighDayTaxoFacets: +publisher +who +facets:DayOfYear.taxonomy # freq=1289029 freq=1196171
-AndHighHighDayTaxoFacets: +that +more +facets:DayOfYear.taxonomy # freq=2931020 freq=963533
-AndHighHighDayTaxoFacets: +ref +see +facets:DayOfYear.taxonomy # freq=3793973 freq=1044180
-AndHighHighDayTaxoFacets: +publisher +last +facets:DayOfYear.taxonomy # freq=1289029 freq=958437
-AndHighHighDayTaxoFacets: +but +their +facets:DayOfYear.taxonomy # freq=1456553 freq=1158682
-AndHighHighDayTaxoFacets: +is +1 +facets:DayOfYear.taxonomy # freq=4074455 freq=1641090
-AndHighHighDayTaxoFacets: +new +have +facets:DayOfYear.taxonomy # freq=1657293 freq=1297121
-AndHighHighDayTaxoFacets: +title +also +facets:DayOfYear.taxonomy # freq=2397378 freq=1959419
-AndHighHighDayTaxoFacets: +also +i +facets:DayOfYear.taxonomy # freq=1959419 freq=956148
-AndHighHighDayTaxoFacets: +had +into +facets:DayOfYear.taxonomy # freq=1246743 freq=888684
-AndHighHighDayTaxoFacets: +first +when +facets:DayOfYear.taxonomy # freq=1933372 freq=1027487
-AndHighHighDayTaxoFacets: +in +be +facets:DayOfYear.taxonomy # freq=7320987 freq=2051702
-AndHighHighDayTaxoFacets: +are +2008 +facets:DayOfYear.taxonomy # freq=1877802 freq=831253
-AndHighHighDayTaxoFacets: +two +2006 +facets:DayOfYear.taxonomy # freq=1104053 freq=889954
-AndHighHighDayTaxoFacets: +date +about +facets:DayOfYear.taxonomy # freq=2020626 freq=850283
-AndHighHighDayTaxoFacets: +its +only +facets:DayOfYear.taxonomy # freq=1173450 freq=875561
-AndHighHighDayTaxoFacets: +title +new +facets:DayOfYear.taxonomy # freq=2397378 freq=1657293
-AndHighHighDayTaxoFacets: +2 +10 +facets:DayOfYear.taxonomy # freq=1549245 freq=918339
-AndHighHighDayTaxoFacets: +2 +one +facets:DayOfYear.taxonomy # freq=1549245 freq=1527689
-AndHighHighDayTaxoFacets: +is +an +facets:DayOfYear.taxonomy # freq=4074455 freq=2628056
-AndHighHighDayTaxoFacets: +at +no +facets:DayOfYear.taxonomy # freq=2857534 freq=1045000
-AndHighHighDayTaxoFacets: +has +its +facets:DayOfYear.taxonomy # freq=1502961 freq=1173450
-AndHighHighDayTaxoFacets: +were +there +facets:DayOfYear.taxonomy # freq=1524630 freq=956153
-AndHighHighDayTaxoFacets: +with +were +facets:DayOfYear.taxonomy # freq=3709421 freq=1524630
-AndHighHighDayTaxoFacets: +on +i +facets:DayOfYear.taxonomy # freq=4074624 freq=956148
-AndHighHighDayTaxoFacets: +as +was +facets:DayOfYear.taxonomy # freq=3925535 freq=3763623
-AndHighHighDayTaxoFacets: +date +cite +facets:DayOfYear.taxonomy # freq=2020626 freq=1741194
-AndHighHighDayTaxoFacets: +or +united +facets:DayOfYear.taxonomy # freq=1858841 freq=1196944
-AndHighHighDayTaxoFacets: +to +http +facets:DayOfYear.taxonomy # freq=6155577 freq=3493581
-AndHighHighDayTaxoFacets: +he +have +facets:DayOfYear.taxonomy # freq=1659434 freq=1297121
-AndHighHighDayTaxoFacets: +s +about +facets:DayOfYear.taxonomy # freq=1581243 freq=850283
-AndHighHighDayTaxoFacets: +this +s +facets:DayOfYear.taxonomy # freq=2224932 freq=1581243
-AndHighHighDayTaxoFacets: +is +but +facets:DayOfYear.taxonomy # freq=4074455 freq=1456553
-AndHighHighDayTaxoFacets: +web +2010 +facets:DayOfYear.taxonomy # freq=1118334 freq=950573
-AndHighHighDayTaxoFacets: +first +are +facets:DayOfYear.taxonomy # freq=1933372 freq=1877802
-AndHighHighDayTaxoFacets: +have +2008 +facets:DayOfYear.taxonomy # freq=1297121 freq=831253
-AndHighHighDayTaxoFacets: +to +no +facets:DayOfYear.taxonomy # freq=6155577 freq=1045000
-AndHighHighDayTaxoFacets: +or +2 +facets:DayOfYear.taxonomy # freq=1858841 freq=1549245
-AndHighHighDayTaxoFacets: +was +about +facets:DayOfYear.taxonomy # freq=3763623 freq=850283
-AndHighHighDayTaxoFacets: +cite +more +facets:DayOfYear.taxonomy # freq=1741194 freq=963533
-AndHighHighDayTaxoFacets: +date +their +facets:DayOfYear.taxonomy # freq=2020626 freq=1158682
-AndHighHighDayTaxoFacets: +from +work +facets:DayOfYear.taxonomy # freq=3224339 freq=853422
-AndHighHighDayTaxoFacets: +at +2010 +facets:DayOfYear.taxonomy # freq=2857534 freq=950573
-AndHighHighDayTaxoFacets: +other +last +facets:DayOfYear.taxonomy # freq=1269961 freq=958437
-AndHighHighDayTaxoFacets: +date +into +facets:DayOfYear.taxonomy # freq=2020626 freq=888684
-AndHighHighDayTaxoFacets: +they +more +facets:DayOfYear.taxonomy # freq=1021945 freq=963533
-AndHighHighDayTaxoFacets: +to +ref +facets:DayOfYear.taxonomy # freq=6155577 freq=3793973
-AndHighHighDayTaxoFacets: +be +but +facets:DayOfYear.taxonomy # freq=2051702 freq=1456553
-AndHighHighDayTaxoFacets: +or +into +facets:DayOfYear.taxonomy # freq=1858841 freq=888684
-AndHighHighDayTaxoFacets: +has +last +facets:DayOfYear.taxonomy # freq=1502961 freq=958437
-AndHighHighDayTaxoFacets: +to +time +facets:DayOfYear.taxonomy # freq=6155577 freq=1032071
-AndHighHighDayTaxoFacets: +the +some +facets:DayOfYear.taxonomy # freq=8217362 freq=839919
-AndHighHighDayTaxoFacets: +ref +united +facets:DayOfYear.taxonomy # freq=3793973 freq=1196944
-AndHighHighDayTaxoFacets: +all +last +facets:DayOfYear.taxonomy # freq=1203572 freq=958437
-AndHighHighDayTaxoFacets: +url +all +facets:DayOfYear.taxonomy # freq=1513595 freq=1203572
-AndHighHighDayTaxoFacets: +other +some +facets:DayOfYear.taxonomy # freq=1269961 freq=839919
-AndHighHighDayTaxoFacets: +cite +new +facets:DayOfYear.taxonomy # freq=1741194 freq=1657293
-AndHighHighDayTaxoFacets: +and +by +facets:DayOfYear.taxonomy # freq=7318061 freq=3826691
-AndHighHighDayTaxoFacets: +publisher +i +facets:DayOfYear.taxonomy # freq=1289029 freq=956148
-AndHighHighDayTaxoFacets: +to +publisher +facets:DayOfYear.taxonomy # freq=6155577 freq=1289029
-AndHighHighDayTaxoFacets: +the +about +facets:DayOfYear.taxonomy # freq=8217362 freq=850283
-AndHighHighDayTaxoFacets: +as +are +facets:DayOfYear.taxonomy # freq=3925535 freq=1877802
-AndHighHighDayTaxoFacets: +it +title +facets:DayOfYear.taxonomy # freq=2675552 freq=2397378
-AndHighHighDayTaxoFacets: +by +are +facets:DayOfYear.taxonomy # freq=3826691 freq=1877802
-AndHighHighDayTaxoFacets: +has +have +facets:DayOfYear.taxonomy # freq=1502961 freq=1297121
-AndHighHighDayTaxoFacets: +one +2011 +facets:DayOfYear.taxonomy # freq=1527689 freq=871410
-AndHighHighDayTaxoFacets: +are +2005 +facets:DayOfYear.taxonomy # freq=1877802 freq=835460
-AndHighHighDayTaxoFacets: +had +some +facets:DayOfYear.taxonomy # freq=1246743 freq=839919
-AndHighHighDayTaxoFacets: +by +when +facets:DayOfYear.taxonomy # freq=3826691 freq=1027487
-AndHighHighDayTaxoFacets: +it +2011 +facets:DayOfYear.taxonomy # freq=2675552 freq=871410
-AndHighHighDayTaxoFacets: +1 +they +facets:DayOfYear.taxonomy # freq=1641090 freq=1021945
-AndHighHighDayTaxoFacets: +on +their +facets:DayOfYear.taxonomy # freq=4074624 freq=1158682
-AndHighHighDayTaxoFacets: +been +10 +facets:DayOfYear.taxonomy # freq=1041183 freq=918339
-AndHighHighDayTaxoFacets: +was +only +facets:DayOfYear.taxonomy # freq=3763623 freq=875561
-AndHighHighDayTaxoFacets: +also +other +facets:DayOfYear.taxonomy # freq=1959419 freq=1269961
-AndHighHighDayTaxoFacets: +who +its +facets:DayOfYear.taxonomy # freq=1196171 freq=1173450
-AndHighHighDayTaxoFacets: +3 +may +facets:DayOfYear.taxonomy # freq=1148799 freq=1071932
-AndHighHighDayTaxoFacets: +with +2006 +facets:DayOfYear.taxonomy # freq=3709421 freq=889954
-AndHighHighDayTaxoFacets: +from +but +facets:DayOfYear.taxonomy # freq=3224339 freq=1456553
-AndHighHighDayTaxoFacets: +was +work +facets:DayOfYear.taxonomy # freq=3763623 freq=853422
-AndHighHighDayTaxoFacets: +as +also +facets:DayOfYear.taxonomy # freq=3925535 freq=1959419
-AndHighHighDayTaxoFacets: +which +into +facets:DayOfYear.taxonomy # freq=1963428 freq=888684
-AndHighHighDayTaxoFacets: +see +i +facets:DayOfYear.taxonomy # freq=1044180 freq=956148
-AndHighHighDayTaxoFacets: +have +more +facets:DayOfYear.taxonomy # freq=1297121 freq=963533
-AndHighHighDayTaxoFacets: +were +after +facets:DayOfYear.taxonomy # freq=1524630 freq=1247398
-AndHighHighDayTaxoFacets: +on +2010 +facets:DayOfYear.taxonomy # freq=4074624 freq=950573
-AndHighHighDayTaxoFacets: +is +had +facets:DayOfYear.taxonomy # freq=4074455 freq=1246743
-AndHighHighDayTaxoFacets: +he +5 +facets:DayOfYear.taxonomy # freq=1659434 freq=891361
-AndHighHighDayTaxoFacets: +first +year +facets:DayOfYear.taxonomy # freq=1933372 freq=1235231
-AndHighHighDayTaxoFacets: +not +url +facets:DayOfYear.taxonomy # freq=1713264 freq=1513595
-AndHighHighDayTaxoFacets: +first +his +facets:DayOfYear.taxonomy # freq=1933372 freq=1777780
-AndHighHighDayTaxoFacets: +date +10 +facets:DayOfYear.taxonomy # freq=2020626 freq=918339
-AndHighHighDayTaxoFacets: +was +not +facets:DayOfYear.taxonomy # freq=3763623 freq=1713264
-AndHighHighDayTaxoFacets: +and +may +facets:DayOfYear.taxonomy # freq=7318061 freq=1071932
-AndHighHighDayTaxoFacets: +no +more +facets:DayOfYear.taxonomy # freq=1045000 freq=963533
-AndHighHighDayTaxoFacets: +it +url +facets:DayOfYear.taxonomy # freq=2675552 freq=1513595
-AndHighHighDayTaxoFacets: +as +no +facets:DayOfYear.taxonomy # freq=3925535 freq=1045000
-AndHighHighDayTaxoFacets: +other +all +facets:DayOfYear.taxonomy # freq=1269961 freq=1203572
-AndHighHighDayTaxoFacets: +as +2 +facets:DayOfYear.taxonomy # freq=3925535 freq=1549245
-AndHighHighDayTaxoFacets: +for +as +facets:DayOfYear.taxonomy # freq=4380011 freq=3925535
-AndHighHighDayTaxoFacets: +for +there +facets:DayOfYear.taxonomy # freq=4380011 freq=956153
-AndHighHighDayTaxoFacets: +the +new +facets:DayOfYear.taxonomy # freq=8217362 freq=1657293
-AndHighHighDayTaxoFacets: +is +no +facets:DayOfYear.taxonomy # freq=4074455 freq=1045000
-AndHighHighDayTaxoFacets: +also +their +facets:DayOfYear.taxonomy # freq=1959419 freq=1158682
-AndHighHighDayTaxoFacets: +that +2010 +facets:DayOfYear.taxonomy # freq=2931020 freq=950573
-AndHighHighDayTaxoFacets: +s +2008 +facets:DayOfYear.taxonomy # freq=1581243 freq=831253
-AndHighHighDayTaxoFacets: +were +2009 +facets:DayOfYear.taxonomy # freq=1524630 freq=887702
-AndHighHighDayTaxoFacets: +of +after +facets:DayOfYear.taxonomy # freq=8184358 freq=1247398
-AndHighHighDayTaxoFacets: +of +an +facets:DayOfYear.taxonomy # freq=8184358 freq=2628056
-AndHighHighDayTaxoFacets: +the +10 +facets:DayOfYear.taxonomy # freq=8217362 freq=918339
-AndHighHighDayTaxoFacets: +title +web +facets:DayOfYear.taxonomy # freq=2397378 freq=1118334
-AndHighHighDayTaxoFacets: +on +they +facets:DayOfYear.taxonomy # freq=4074624 freq=1021945
-AndHighHighDayTaxoFacets: +to +have +facets:DayOfYear.taxonomy # freq=6155577 freq=1297121
-AndHighHighDayTaxoFacets: +was +its +facets:DayOfYear.taxonomy # freq=3763623 freq=1173450
-AndHighHighDayTaxoFacets: +at +time +facets:DayOfYear.taxonomy # freq=2857534 freq=1032071
-AndHighHighDayTaxoFacets: +2 +accessdate +facets:DayOfYear.taxonomy # freq=1549245 freq=1228887
-AndHighHighDayTaxoFacets: +with +united +facets:DayOfYear.taxonomy # freq=3709421 freq=1196944
-AndHighHighDayTaxoFacets: +in +about +facets:DayOfYear.taxonomy # freq=7320987 freq=850283
-AndHighHighDayTaxoFacets: +in +2005 +facets:DayOfYear.taxonomy # freq=7320987 freq=835460
-AndHighHighDayTaxoFacets: +for +last +facets:DayOfYear.taxonomy # freq=4380011 freq=958437
-AndHighHighDayTaxoFacets: +and +when +facets:DayOfYear.taxonomy # freq=7318061 freq=1027487
-AndHighHighDayTaxoFacets: +an +their +facets:DayOfYear.taxonomy # freq=2628056 freq=1158682
-AndHighHighDayTaxoFacets: +2010 +into +facets:DayOfYear.taxonomy # freq=950573 freq=888684
-AndHighHighDayTaxoFacets: +web +two +facets:DayOfYear.taxonomy # freq=1118334 freq=1104053
-AndHighHighDayTaxoFacets: +two +4 +facets:DayOfYear.taxonomy # freq=1104053 freq=986452
-AndHighHighDayTaxoFacets: +1 +there +facets:DayOfYear.taxonomy # freq=1641090 freq=956153
-AndHighHighDayTaxoFacets: +name +url +facets:DayOfYear.taxonomy # freq=2827713 freq=1513595
-AndHighHighDayTaxoFacets: +united +who +facets:DayOfYear.taxonomy # freq=1196944 freq=1196171
-AndHighHighDayTaxoFacets: +they +there +facets:DayOfYear.taxonomy # freq=1021945 freq=956153
-AndHighHighDayTaxoFacets: +http +5 +facets:DayOfYear.taxonomy # freq=3493581 freq=891361
-AndHighHighDayTaxoFacets: +not +2008 +facets:DayOfYear.taxonomy # freq=1713264 freq=831253
-AndHighHighDayTaxoFacets: +are +2009 +facets:DayOfYear.taxonomy # freq=1877802 freq=887702
-AndHighHighDayTaxoFacets: +on +may +facets:DayOfYear.taxonomy # freq=4074624 freq=1071932
-AndHighHighDayTaxoFacets: +is +are +facets:DayOfYear.taxonomy # freq=4074455 freq=1877802
-AndHighHighDayTaxoFacets: +been +there +facets:DayOfYear.taxonomy # freq=1041183 freq=956153
-AndHighHighDayTaxoFacets: +other +into +facets:DayOfYear.taxonomy # freq=1269961 freq=888684
-AndHighHighDayTaxoFacets: +be +their +facets:DayOfYear.taxonomy # freq=2051702 freq=1158682
-AndHighHighDayTaxoFacets: +new +other +facets:DayOfYear.taxonomy # freq=1657293 freq=1269961
-AndHighHighDayTaxoFacets: +its +2011 +facets:DayOfYear.taxonomy # freq=1173450 freq=871410
-AndHighHighDayTaxoFacets: +ref +3 +facets:DayOfYear.taxonomy # freq=3793973 freq=1148799
-AndHighHighDayTaxoFacets: +name +be +facets:DayOfYear.taxonomy # freq=2827713 freq=2051702
-AndHighHighDayTaxoFacets: +had +see +facets:DayOfYear.taxonomy # freq=1246743 freq=1044180
-AndHighHighDayTaxoFacets: +also +or +facets:DayOfYear.taxonomy # freq=1959419 freq=1858841
-AndHighHighDayTaxoFacets: +but +4 +facets:DayOfYear.taxonomy # freq=1456553 freq=986452
-AndHighMedDayTaxoFacets: +has +please +facets:DayOfYear.taxonomy # freq=1502961 freq=229602
-AndHighMedDayTaxoFacets: +he +battle +facets:DayOfYear.taxonomy # freq=1659434 freq=192357
-AndHighMedDayTaxoFacets: +be +century +facets:DayOfYear.taxonomy # freq=2051702 freq=385541
-AndHighMedDayTaxoFacets: +may +studio +facets:DayOfYear.taxonomy # freq=1071932 freq=101979
-AndHighMedDayTaxoFacets: +have +level +facets:DayOfYear.taxonomy # freq=1297121 freq=175382
-AndHighMedDayTaxoFacets: +web +place +facets:DayOfYear.taxonomy # freq=1118334 freq=654158
-AndHighMedDayTaxoFacets: +all +close +facets:DayOfYear.taxonomy # freq=1203572 freq=136706
-AndHighMedDayTaxoFacets: +as +chart +facets:DayOfYear.taxonomy # freq=3925535 freq=84194
-AndHighMedDayTaxoFacets: +ref +appropriate +facets:DayOfYear.taxonomy # freq=3793973 freq=135343
-AndHighMedDayTaxoFacets: +be +put +facets:DayOfYear.taxonomy # freq=2051702 freq=139882
-AndHighMedDayTaxoFacets: +and +called +facets:DayOfYear.taxonomy # freq=7318061 freq=454580
-AndHighMedDayTaxoFacets: +been +four +facets:DayOfYear.taxonomy # freq=1041183 freq=389818
-AndHighMedDayTaxoFacets: +url +whether +facets:DayOfYear.taxonomy # freq=1513595 freq=93965
-AndHighMedDayTaxoFacets: +with +day +facets:DayOfYear.taxonomy # freq=3709421 freq=402096
-AndHighMedDayTaxoFacets: +a +famous +facets:DayOfYear.taxonomy # freq=6560531 freq=139092
-AndHighMedDayTaxoFacets: +it +nature +facets:DayOfYear.taxonomy # freq=2675552 freq=107428
-AndHighMedDayTaxoFacets: +his +although +facets:DayOfYear.taxonomy # freq=1777780 freq=341432
-AndHighMedDayTaxoFacets: +1 +artists +facets:DayOfYear.taxonomy # freq=1641090 freq=107145
-AndHighMedDayTaxoFacets: +title +digital +facets:DayOfYear.taxonomy # freq=2397378 freq=82650
-AndHighMedDayTaxoFacets: +that +37 +facets:DayOfYear.taxonomy # freq=2931020 freq=126429
-AndHighMedDayTaxoFacets: +was +free +facets:DayOfYear.taxonomy # freq=3763623 freq=270199
-AndHighMedDayTaxoFacets: +5 +west +facets:DayOfYear.taxonomy # freq=891361 freq=431006
-AndHighMedDayTaxoFacets: +had +reference +facets:DayOfYear.taxonomy # freq=1246743 freq=111493
-AndHighMedDayTaxoFacets: +in +sports +facets:DayOfYear.taxonomy # freq=7320987 freq=178542
-AndHighMedDayTaxoFacets: +its +interview +facets:DayOfYear.taxonomy # freq=1173450 freq=98846
-AndHighMedDayTaxoFacets: +url +took +facets:DayOfYear.taxonomy # freq=1513595 freq=247388
-AndHighMedDayTaxoFacets: +and +los +facets:DayOfYear.taxonomy # freq=7318061 freq=145404
-AndHighMedDayTaxoFacets: +last +english +facets:DayOfYear.taxonomy # freq=958437 freq=412061
-AndHighMedDayTaxoFacets: +not +lee +facets:DayOfYear.taxonomy # freq=1713264 freq=90461
-AndHighMedDayTaxoFacets: +their +few +facets:DayOfYear.taxonomy # freq=1158682 freq=226422
-AndHighMedDayTaxoFacets: +they +round +facets:DayOfYear.taxonomy # freq=1021945 freq=122499
-AndHighMedDayTaxoFacets: +cite +area +facets:DayOfYear.taxonomy # freq=1741194 freq=559023
-AndHighMedDayTaxoFacets: +two +lake +facets:DayOfYear.taxonomy # freq=1104053 freq=131603
-AndHighMedDayTaxoFacets: +time +8 +facets:DayOfYear.taxonomy # freq=1032071 freq=635822
-AndHighMedDayTaxoFacets: +this +winning +facets:DayOfYear.taxonomy # freq=2224932 freq=95704
-AndHighMedDayTaxoFacets: +only +performed +facets:DayOfYear.taxonomy # freq=875561 freq=104044
-AndHighMedDayTaxoFacets: +when +books.google.com +facets:DayOfYear.taxonomy # freq=1027487 freq=119391
-AndHighMedDayTaxoFacets: +who +legal +facets:DayOfYear.taxonomy # freq=1196171 freq=90645
-AndHighMedDayTaxoFacets: +2009 +keep +facets:DayOfYear.taxonomy # freq=887702 freq=177996
-AndHighMedDayTaxoFacets: +http +running +facets:DayOfYear.taxonomy # freq=3493581 freq=101764
-AndHighMedDayTaxoFacets: +5 +grand +facets:DayOfYear.taxonomy # freq=891361 freq=139202
-AndHighMedDayTaxoFacets: +it +man +facets:DayOfYear.taxonomy # freq=2675552 freq=278112
-AndHighMedDayTaxoFacets: +had +entertainment +facets:DayOfYear.taxonomy # freq=1246743 freq=117931
-AndHighMedDayTaxoFacets: +with +200px +facets:DayOfYear.taxonomy # freq=3709421 freq=102661
-AndHighMedDayTaxoFacets: +had +van +facets:DayOfYear.taxonomy # freq=1246743 freq=116920
-AndHighMedDayTaxoFacets: +was +track +facets:DayOfYear.taxonomy # freq=3763623 freq=148840
-AndHighMedDayTaxoFacets: +10 +corporation +facets:DayOfYear.taxonomy # freq=918339 freq=107425
-AndHighMedDayTaxoFacets: +other +make +facets:DayOfYear.taxonomy # freq=1269961 freq=292607
-AndHighMedDayTaxoFacets: +first +results +facets:DayOfYear.taxonomy # freq=1933372 freq=137248
-AndHighMedDayTaxoFacets: +2010 +unreferenced +facets:DayOfYear.taxonomy # freq=950573 freq=107803
-AndHighMedDayTaxoFacets: +first +top +facets:DayOfYear.taxonomy # freq=1933372 freq=364628
-AndHighMedDayTaxoFacets: +his +en +facets:DayOfYear.taxonomy # freq=1777780 freq=277463
-AndHighMedDayTaxoFacets: +other +airport +facets:DayOfYear.taxonomy # freq=1269961 freq=88205
-AndHighMedDayTaxoFacets: +10 +march +facets:DayOfYear.taxonomy # freq=918339 freq=620393
-AndHighMedDayTaxoFacets: +all +recently +facets:DayOfYear.taxonomy # freq=1203572 freq=90249
-AndHighMedDayTaxoFacets: +were +genre +facets:DayOfYear.taxonomy # freq=1524630 freq=121233
-AndHighMedDayTaxoFacets: +and +program +facets:DayOfYear.taxonomy # freq=7318061 freq=173553
-AndHighMedDayTaxoFacets: +i +09 +facets:DayOfYear.taxonomy # freq=956148 freq=296300
-AndHighMedDayTaxoFacets: +to +ended +facets:DayOfYear.taxonomy # freq=6155577 freq=84664
-AndHighMedDayTaxoFacets: +not +playing +facets:DayOfYear.taxonomy # freq=1713264 freq=133330
-AndHighMedDayTaxoFacets: +time +companies +facets:DayOfYear.taxonomy # freq=1032071 freq=98905
-AndHighMedDayTaxoFacets: +to +living +facets:DayOfYear.taxonomy # freq=6155577 freq=181427
-AndHighMedDayTaxoFacets: +of +silver +facets:DayOfYear.taxonomy # freq=8184358 freq=85967
-AndHighMedDayTaxoFacets: +in +images +facets:DayOfYear.taxonomy # freq=7320987 freq=125154
-AndHighMedDayTaxoFacets: +2008 +debate +facets:DayOfYear.taxonomy # freq=831253 freq=177827
-AndHighMedDayTaxoFacets: +some +los +facets:DayOfYear.taxonomy # freq=839919 freq=145404
-AndHighMedDayTaxoFacets: +2008 +simply +facets:DayOfYear.taxonomy # freq=831253 freq=84090
-AndHighMedDayTaxoFacets: +first +producer +facets:DayOfYear.taxonomy # freq=1933372 freq=137098
-AndHighMedDayTaxoFacets: +last +seven +facets:DayOfYear.taxonomy # freq=958437 freq=134402
-AndHighMedDayTaxoFacets: +more +soon +facets:DayOfYear.taxonomy # freq=963533 freq=123657
-AndHighMedDayTaxoFacets: +date +talk +facets:DayOfYear.taxonomy # freq=2020626 freq=364194
-AndHighMedDayTaxoFacets: +its +49 +facets:DayOfYear.taxonomy # freq=1173450 freq=103612
-AndHighMedDayTaxoFacets: +publisher +car +facets:DayOfYear.taxonomy # freq=1289029 freq=121250
-AndHighMedDayTaxoFacets: +were +v +facets:DayOfYear.taxonomy # freq=1524630 freq=284318
-AndHighMedDayTaxoFacets: +more +says +facets:DayOfYear.taxonomy # freq=963533 freq=84589
-AndHighMedDayTaxoFacets: +3 +man +facets:DayOfYear.taxonomy # freq=1148799 freq=278112
-AndHighMedDayTaxoFacets: +but +1974 +facets:DayOfYear.taxonomy # freq=1456553 freq=132835
-AndHighMedDayTaxoFacets: +but +02 +facets:DayOfYear.taxonomy # freq=1456553 freq=319783
-AndHighMedDayTaxoFacets: +see +historic +facets:DayOfYear.taxonomy # freq=1044180 freq=112292
-AndHighMedDayTaxoFacets: +which +wife +facets:DayOfYear.taxonomy # freq=1963428 freq=130807
-AndHighMedDayTaxoFacets: +1 +grand +facets:DayOfYear.taxonomy # freq=1641090 freq=139202
-AndHighMedDayTaxoFacets: +it +real +facets:DayOfYear.taxonomy # freq=2675552 freq=151505
-AndHighMedDayTaxoFacets: +its +development +facets:DayOfYear.taxonomy # freq=1173450 freq=230286
-AndHighMedDayTaxoFacets: +3 +office +facets:DayOfYear.taxonomy # freq=1148799 freq=225338
-AndHighMedDayTaxoFacets: +10 +class +facets:DayOfYear.taxonomy # freq=918339 freq=556838
-AndHighMedDayTaxoFacets: +not +abbr +facets:DayOfYear.taxonomy # freq=1713264 freq=96135
-AndHighMedDayTaxoFacets: +accessdate +hand +facets:DayOfYear.taxonomy # freq=1228887 freq=119947
-AndHighMedDayTaxoFacets: +2011 +trade +facets:DayOfYear.taxonomy # freq=871410 freq=106384
-AndHighMedDayTaxoFacets: +that +love +facets:DayOfYear.taxonomy # freq=2931020 freq=177242
-AndHighMedDayTaxoFacets: +from +took +facets:DayOfYear.taxonomy # freq=3224339 freq=247388
-AndHighMedDayTaxoFacets: +united +id +facets:DayOfYear.taxonomy # freq=1196944 freq=579566
-AndHighMedDayTaxoFacets: +s +mi +facets:DayOfYear.taxonomy # freq=1581243 freq=97131
-AndHighMedDayTaxoFacets: +as +young +facets:DayOfYear.taxonomy # freq=3925535 freq=196428
-AndHighMedDayTaxoFacets: +3 +opening +facets:DayOfYear.taxonomy # freq=1148799 freq=84576
-AndHighMedDayTaxoFacets: +other +european +facets:DayOfYear.taxonomy # freq=1269961 freq=193975
-AndHighMedDayTaxoFacets: +ref +chart +facets:DayOfYear.taxonomy # freq=3793973 freq=84194
-AndHighMedDayTaxoFacets: +about +thought +facets:DayOfYear.taxonomy # freq=850283 freq=108963
-AndHighMedDayTaxoFacets: +for +should +facets:DayOfYear.taxonomy # freq=4380011 freq=401379
-AndHighMedDayTaxoFacets: +united +lead +facets:DayOfYear.taxonomy # freq=1196944 freq=141336
-AndHighMedDayTaxoFacets: +this +movie +facets:DayOfYear.taxonomy # freq=2224932 freq=133291
-AndHighMedDayTaxoFacets: +2011 +winning +facets:DayOfYear.taxonomy # freq=871410 freq=95704
-AndHighMedDayTaxoFacets: +new +shows +facets:DayOfYear.taxonomy # freq=1657293 freq=131923
-AndHighMedDayTaxoFacets: +no +him +facets:DayOfYear.taxonomy # freq=1045000 freq=507350
-AndHighMedDayTaxoFacets: +has +always +facets:DayOfYear.taxonomy # freq=1502961 freq=112388
-AndHighMedDayTaxoFacets: +ref +above +facets:DayOfYear.taxonomy # freq=3793973 freq=246135
-AndHighMedDayTaxoFacets: +have +uses +facets:DayOfYear.taxonomy # freq=1297121 freq=134331
-AndHighMedDayTaxoFacets: +who +80 +facets:DayOfYear.taxonomy # freq=1196171 freq=104865
-AndHighMedDayTaxoFacets: +2008 +series +facets:DayOfYear.taxonomy # freq=831253 freq=521861
-AndHighMedDayTaxoFacets: +ref +40 +facets:DayOfYear.taxonomy # freq=3793973 freq=221687
-AndHighMedDayTaxoFacets: +when +second +facets:DayOfYear.taxonomy # freq=1027487 freq=505575
-AndHighMedDayTaxoFacets: +at +parliament +facets:DayOfYear.taxonomy # freq=2857534 freq=127008
-AndHighMedDayTaxoFacets: +were +pacific +facets:DayOfYear.taxonomy # freq=1524630 freq=107648
-AndHighMedDayTaxoFacets: +2 +recent +facets:DayOfYear.taxonomy # freq=1549245 freq=113385
-AndHighMedDayTaxoFacets: +http +close +facets:DayOfYear.taxonomy # freq=3493581 freq=136706
-AndHighMedDayTaxoFacets: +has +power +facets:DayOfYear.taxonomy # freq=1502961 freq=262586
-AndHighMedDayTaxoFacets: +or +words +facets:DayOfYear.taxonomy # freq=1858841 freq=104783
-AndHighMedDayTaxoFacets: +after +mary +facets:DayOfYear.taxonomy # freq=1247398 freq=96445
-AndHighMedDayTaxoFacets: +3 +state +facets:DayOfYear.taxonomy # freq=1148799 freq=702598
-AndHighMedDayTaxoFacets: +its +directed +facets:DayOfYear.taxonomy # freq=1173450 freq=86592
-AndHighMedDayTaxoFacets: +more +army +facets:DayOfYear.taxonomy # freq=963533 freq=228105
-AndHighMedDayTaxoFacets: +see +genre +facets:DayOfYear.taxonomy # freq=1044180 freq=121233
-AndHighMedDayTaxoFacets: +5 +natural +facets:DayOfYear.taxonomy # freq=891361 freq=125503
-AndHighMedDayTaxoFacets: +into +ship +facets:DayOfYear.taxonomy # freq=888684 freq=113012
-AndHighMedDayTaxoFacets: +2005 +construction +facets:DayOfYear.taxonomy # freq=835460 freq=124179
-AndHighMedDayTaxoFacets: +some +found +facets:DayOfYear.taxonomy # freq=839919 freq=313247
-AndHighMedDayTaxoFacets: +2 +actor +facets:DayOfYear.taxonomy # freq=1549245 freq=144573
-AndHighMedDayTaxoFacets: +and +owned +facets:DayOfYear.taxonomy # freq=7318061 freq=93981
-AndHighMedDayTaxoFacets: +which +authority +facets:DayOfYear.taxonomy # freq=1963428 freq=85540
-AndHighMedDayTaxoFacets: +have +r +facets:DayOfYear.taxonomy # freq=1297121 freq=296283
-AndHighMedDayTaxoFacets: +is +approximately +facets:DayOfYear.taxonomy # freq=4074455 freq=88426
-AndHighMedDayTaxoFacets: +he +deletion +facets:DayOfYear.taxonomy # freq=1659434 freq=166633
-AndHighMedDayTaxoFacets: +and +jean +facets:DayOfYear.taxonomy # freq=7318061 freq=84299
-AndHighMedDayTaxoFacets: +have +43 +facets:DayOfYear.taxonomy # freq=1297121 freq=115496
-AndHighMedDayTaxoFacets: +only +daily +facets:DayOfYear.taxonomy # freq=875561 freq=111717
-AndHighMedDayTaxoFacets: +united +zealand +facets:DayOfYear.taxonomy # freq=1196944 freq=92761
-AndHighMedDayTaxoFacets: +also +read +facets:DayOfYear.taxonomy # freq=1959419 freq=86513
-AndHighMedDayTaxoFacets: +are +division +facets:DayOfYear.taxonomy # freq=1877802 freq=182624
-AndHighMedDayTaxoFacets: +for +seat +facets:DayOfYear.taxonomy # freq=4380011 freq=91288
-AndHighMedDayTaxoFacets: +2005 +hand +facets:DayOfYear.taxonomy # freq=835460 freq=119947
-AndHighMedDayTaxoFacets: +publisher +usually +facets:DayOfYear.taxonomy # freq=1289029 freq=176058
-AndHighMedDayTaxoFacets: +from +teams +facets:DayOfYear.taxonomy # freq=3224339 freq=105245
-AndHighMedDayTaxoFacets: +in +wife +facets:DayOfYear.taxonomy # freq=7320987 freq=130807
-AndHighMedDayTaxoFacets: +2006 +james +facets:DayOfYear.taxonomy # freq=889954 freq=281597
-AndHighMedDayTaxoFacets: +2005 +found +facets:DayOfYear.taxonomy # freq=835460 freq=313247
-AndHighMedDayTaxoFacets: +after +replaced +facets:DayOfYear.taxonomy # freq=1247398 freq=112506
-AndHighMedDayTaxoFacets: +5 +played +facets:DayOfYear.taxonomy # freq=891361 freq=248191
-AndHighMedDayTaxoFacets: +last +1945 +facets:DayOfYear.taxonomy # freq=958437 freq=106881
-AndHighMedDayTaxoFacets: +not +william +facets:DayOfYear.taxonomy # freq=1713264 freq=284592
-AndHighMedDayTaxoFacets: +may +changed +facets:DayOfYear.taxonomy # freq=1071932 freq=112032
-AndHighMedDayTaxoFacets: +one +might +facets:DayOfYear.taxonomy # freq=1527689 freq=114290
-AndHighMedDayTaxoFacets: +one +1966 +facets:DayOfYear.taxonomy # freq=1527689 freq=106672
-AndHighMedDayTaxoFacets: +2006 +mother +facets:DayOfYear.taxonomy # freq=889954 freq=122930
-AndHighMedDayTaxoFacets: +no +hi +facets:DayOfYear.taxonomy # freq=1045000 freq=91593
-AndHighMedDayTaxoFacets: +they +my +facets:DayOfYear.taxonomy # freq=1021945 freq=274256
-AndHighMedDayTaxoFacets: +it +london +facets:DayOfYear.taxonomy # freq=2675552 freq=348918
-AndHighMedDayTaxoFacets: +but +according +facets:DayOfYear.taxonomy # freq=1456553 freq=256949
-AndHighMedDayTaxoFacets: +an +results +facets:DayOfYear.taxonomy # freq=2628056 freq=137248
-AndHighMedDayTaxoFacets: +from +you +facets:DayOfYear.taxonomy # freq=3224339 freq=461587
-AndHighMedDayTaxoFacets: +web +single +facets:DayOfYear.taxonomy # freq=1118334 freq=283824
-AndHighMedDayTaxoFacets: +two +old +facets:DayOfYear.taxonomy # freq=1104053 freq=381809
-AndHighMedDayTaxoFacets: +some +daughter +facets:DayOfYear.taxonomy # freq=839919 freq=103883
-AndHighMedDayTaxoFacets: +url +various +facets:DayOfYear.taxonomy # freq=1513595 freq=224593
-AndHighMedDayTaxoFacets: +have +would +facets:DayOfYear.taxonomy # freq=1297121 freq=690480
-AndHighMedDayTaxoFacets: +to +released +facets:DayOfYear.taxonomy # freq=6155577 freq=322473
-AndHighMedDayTaxoFacets: +had +refer +facets:DayOfYear.taxonomy # freq=1246743 freq=110259
-AndHighMedDayTaxoFacets: +url +article +facets:DayOfYear.taxonomy # freq=1513595 freq=610650
-AndHighMedDayTaxoFacets: +when +designed +facets:DayOfYear.taxonomy # freq=1027487 freq=118748
-AndHighMedDayTaxoFacets: +which +party +facets:DayOfYear.taxonomy # freq=1963428 freq=394410
-AndHighMedDayTaxoFacets: +a +florida +facets:DayOfYear.taxonomy # freq=6560531 freq=92166
-AndHighMedDayTaxoFacets: +the +image_caption +facets:DayOfYear.taxonomy # freq=8217362 freq=87977
-AndHighMedDayTaxoFacets: +last +width +facets:DayOfYear.taxonomy # freq=958437 freq=172609
-AndHighMedDayTaxoFacets: +may +r +facets:DayOfYear.taxonomy # freq=1071932 freq=296283
-AndHighMedDayTaxoFacets: +at +inside +facets:DayOfYear.taxonomy # freq=2857534 freq=84712
-AndHighMedDayTaxoFacets: +3 +p +facets:DayOfYear.taxonomy # freq=1148799 freq=616159
-AndHighMedDayTaxoFacets: +2009 +imperial +facets:DayOfYear.taxonomy # freq=887702 freq=86508
-AndHighMedDayTaxoFacets: +for +access +facets:DayOfYear.taxonomy # freq=4380011 freq=100041
-AndHighMedDayTaxoFacets: +some +former +facets:DayOfYear.taxonomy # freq=839919 freq=332750
-AndHighMedDayTaxoFacets: +url +important +facets:DayOfYear.taxonomy # freq=1513595 freq=195851
-AndHighMedDayTaxoFacets: +which +recorded +facets:DayOfYear.taxonomy # freq=1963428 freq=160249
-AndHighMedDayTaxoFacets: +of +family +facets:DayOfYear.taxonomy # freq=8184358 freq=387175
-AndHighMedDayTaxoFacets: +2 +family +facets:DayOfYear.taxonomy # freq=1549245 freq=387175
-AndHighMedDayTaxoFacets: +was +old +facets:DayOfYear.taxonomy # freq=3763623 freq=381809
-AndHighMedDayTaxoFacets: +more +jpg +facets:DayOfYear.taxonomy # freq=963533 freq=322278
-AndHighMedDayTaxoFacets: +2005 +1979 +facets:DayOfYear.taxonomy # freq=835460 freq=145407
-AndHighMedDayTaxoFacets: +are +became +facets:DayOfYear.taxonomy # freq=1877802 freq=465594
-AndHighMedDayTaxoFacets: +new +products +facets:DayOfYear.taxonomy # freq=1657293 freq=88448
-AndHighMedDayTaxoFacets: +first +mexico +facets:DayOfYear.taxonomy # freq=1933372 freq=88689
-AndHighMedDayTaxoFacets: +10 +nbsp +facets:DayOfYear.taxonomy # freq=918339 freq=506054
-AndHighMedDayTaxoFacets: +by +25 +facets:DayOfYear.taxonomy # freq=3826691 freq=491957
-AndHighMedDayTaxoFacets: +was +language +facets:DayOfYear.taxonomy # freq=3763623 freq=416771
-AndHighMedDayTaxoFacets: +and +future +facets:DayOfYear.taxonomy # freq=7318061 freq=136421
-AndHighMedDayTaxoFacets: +their +flight +facets:DayOfYear.taxonomy # freq=1158682 freq=84316
-AndHighMedDayTaxoFacets: +2011 +hold +facets:DayOfYear.taxonomy # freq=871410 freq=82579
-AndHighMedDayTaxoFacets: +there +programs +facets:DayOfYear.taxonomy # freq=956153 freq=83974
-AndHighMedDayTaxoFacets: +after +original +facets:DayOfYear.taxonomy # freq=1247398 freq=323521
-AndHighMedDayTaxoFacets: +only +ten +facets:DayOfYear.taxonomy # freq=875561 freq=114388
-AndHighMedDayTaxoFacets: +to +traditional +facets:DayOfYear.taxonomy # freq=6155577 freq=110425
-AndHighMedDayTaxoFacets: +also +centre +facets:DayOfYear.taxonomy # freq=1959419 freq=159597
-AndHighMedDayTaxoFacets: +all +isbn +facets:DayOfYear.taxonomy # freq=1203572 freq=467574
-AndHighMedDayTaxoFacets: +this +direct +facets:DayOfYear.taxonomy # freq=2224932 freq=82292
-AndHighMedDayTaxoFacets: +http +earlier +facets:DayOfYear.taxonomy # freq=3493581 freq=100372
-AndHighMedDayTaxoFacets: +cite +system +facets:DayOfYear.taxonomy # freq=1741194 freq=412862
-AndHighMedDayTaxoFacets: +were +library +facets:DayOfYear.taxonomy # freq=1524630 freq=138468
-AndHighMedDayTaxoFacets: +first +alone +facets:DayOfYear.taxonomy # freq=1933372 freq=93166
-AndHighMedDayTaxoFacets: +new +century +facets:DayOfYear.taxonomy # freq=1657293 freq=385541
-AndHighMedDayTaxoFacets: +s +reached +facets:DayOfYear.taxonomy # freq=1581243 freq=89854
-AndHighMedDayTaxoFacets: +united +le +facets:DayOfYear.taxonomy # freq=1196944 freq=84979
-AndHighMedDayTaxoFacets: +url +auto +facets:DayOfYear.taxonomy # freq=1513595 freq=103107
-AndHighMedDayTaxoFacets: +3 +practice +facets:DayOfYear.taxonomy # freq=1148799 freq=93287
-AndHighMedDayTaxoFacets: +http +working +facets:DayOfYear.taxonomy # freq=3493581 freq=144617
-AndHighMedDayTaxoFacets: +in +fire +facets:DayOfYear.taxonomy # freq=7320987 freq=133712
-AndHighMedDayTaxoFacets: +10 +52 +facets:DayOfYear.taxonomy # freq=918339 freq=108395
-AndHighMedDayTaxoFacets: +more +singer +facets:DayOfYear.taxonomy # freq=963533 freq=114006
-AndHighMedDayTaxoFacets: +new +low +facets:DayOfYear.taxonomy # freq=1657293 freq=157852
-AndHighMedDayTaxoFacets: +with +previously +facets:DayOfYear.taxonomy # freq=3709421 freq=96083
-AndHighMedDayTaxoFacets: +first +original +facets:DayOfYear.taxonomy # freq=1933372 freq=323521
-AndHighMedDayTaxoFacets: +2008 +wikitable +facets:DayOfYear.taxonomy # freq=831253 freq=210990
-AndHighMedDayTaxoFacets: +http +can +facets:DayOfYear.taxonomy # freq=3493581 freq=765163
-AndHighMedDayTaxoFacets: +year +1965 +facets:DayOfYear.taxonomy # freq=1235231 freq=104539
-AndHighMedDayTaxoFacets: +have +mother +facets:DayOfYear.taxonomy # freq=1297121 freq=122930
-AndHighMedDayTaxoFacets: +states +lived +facets:DayOfYear.taxonomy # freq=1034872 freq=91327
-AndHighMedDayTaxoFacets: +to +me +facets:DayOfYear.taxonomy # freq=6155577 freq=229204
-AndHighMedDayTaxoFacets: +4 +race +facets:DayOfYear.taxonomy # freq=986452 freq=148763
-AndHighMedDayTaxoFacets: +of +54 +facets:DayOfYear.taxonomy # freq=8184358 freq=101462
-AndHighMedDayTaxoFacets: +some +series +facets:DayOfYear.taxonomy # freq=839919 freq=521861
-AndHighMedDayTaxoFacets: +2 +big +facets:DayOfYear.taxonomy # freq=1549245 freq=163394
-AndHighMedDayTaxoFacets: +some +without +facets:DayOfYear.taxonomy # freq=839919 freq=249926
-AndHighMedDayTaxoFacets: +2011 +font +facets:DayOfYear.taxonomy # freq=871410 freq=269439
-AndHighMedDayTaxoFacets: +http +votes +facets:DayOfYear.taxonomy # freq=3493581 freq=93844
-AndHighMedDayTaxoFacets: +2009 +19th +facets:DayOfYear.taxonomy # freq=887702 freq=93290
-AndHighMedDayTaxoFacets: +an +central +facets:DayOfYear.taxonomy # freq=2628056 freq=272531
-AndHighMedDayTaxoFacets: +some +1959 +facets:DayOfYear.taxonomy # freq=839919 freq=87097
-AndHighMedDayTaxoFacets: +cite +out +facets:DayOfYear.taxonomy # freq=1741194 freq=733775
-AndHighMedDayTaxoFacets: +was +cross +facets:DayOfYear.taxonomy # freq=3763623 freq=127216
-AndHighMedDayTaxoFacets: +3 +1950 +facets:DayOfYear.taxonomy # freq=1148799 freq=89746
-AndHighMedDayTaxoFacets: +there +market +facets:DayOfYear.taxonomy # freq=956153 freq=118467
-AndHighMedDayTaxoFacets: +new +mid +facets:DayOfYear.taxonomy # freq=1657293 freq=126355
-AndHighMedDayTaxoFacets: +or +sent +facets:DayOfYear.taxonomy # freq=1858841 freq=103620
-AndHighMedDayTaxoFacets: +may +pp +facets:DayOfYear.taxonomy # freq=1071932 freq=204742
-AndHighMedDayTaxoFacets: +the +flagicon +facets:DayOfYear.taxonomy # freq=8217362 freq=107428
-AndHighMedDayTaxoFacets: +who +genre +facets:DayOfYear.taxonomy # freq=1196171 freq=121233
-AndHighMedDayTaxoFacets: +last +library +facets:DayOfYear.taxonomy # freq=958437 freq=138468
-AndHighMedDayTaxoFacets: +and +none +facets:DayOfYear.taxonomy # freq=7318061 freq=100192
-AndHighMedDayTaxoFacets: +an +majority +facets:DayOfYear.taxonomy # freq=2628056 freq=105058
-AndHighMedDayTaxoFacets: +it +religion +facets:DayOfYear.taxonomy # freq=2675552 freq=96655
-AndHighMedDayTaxoFacets: +first +brown +facets:DayOfYear.taxonomy # freq=1933372 freq=116178
-AndHighMedDayTaxoFacets: +more +standard +facets:DayOfYear.taxonomy # freq=963533 freq=185039
-AndHighMedDayTaxoFacets: +into +process +facets:DayOfYear.taxonomy # freq=888684 freq=152588
-AndHighMedDayTaxoFacets: +for +website +facets:DayOfYear.taxonomy # freq=4380011 freq=435941
-AndHighMedDayTaxoFacets: +name +parts +facets:DayOfYear.taxonomy # freq=2827713 freq=123891
-AndHighMedDayTaxoFacets: +for +few +facets:DayOfYear.taxonomy # freq=4380011 freq=226422
-AndHighMedDayTaxoFacets: +web +available +facets:DayOfYear.taxonomy # freq=1118334 freq=175514
-AndHighMedDayTaxoFacets: +other +christian +facets:DayOfYear.taxonomy # freq=1269961 freq=140312
-AndHighMedDayTaxoFacets: +2 +imperial +facets:DayOfYear.taxonomy # freq=1549245 freq=86508
-AndHighMedDayTaxoFacets: +at +space +facets:DayOfYear.taxonomy # freq=2857534 freq=163436
-AndHighMedDayTaxoFacets: +but +paul +facets:DayOfYear.taxonomy # freq=1456553 freq=207229
-AndHighMedDayTaxoFacets: +into +70 +facets:DayOfYear.taxonomy # freq=888684 freq=90305
-AndHighMedDayTaxoFacets: +s +mdash +facets:DayOfYear.taxonomy # freq=1581243 freq=111708
-AndHighMedDayTaxoFacets: +5 +brown +facets:DayOfYear.taxonomy # freq=891361 freq=116178
-AndHighMedDayTaxoFacets: +2005 +hill +facets:DayOfYear.taxonomy # freq=835460 freq=133714
-AndHighMedDayTaxoFacets: +2006 +eight +facets:DayOfYear.taxonomy # freq=889954 freq=106268
-AndHighMedDayTaxoFacets: +two +era +facets:DayOfYear.taxonomy # freq=1104053 freq=95989
-AndHighMedDayTaxoFacets: +time +100 +facets:DayOfYear.taxonomy # freq=1032071 freq=268978
-AndHighMedDayTaxoFacets: +title +70 +facets:DayOfYear.taxonomy # freq=2397378 freq=90305
-AndHighMedDayTaxoFacets: +3 +empire +facets:DayOfYear.taxonomy # freq=1148799 freq=143207
-AndHighMedDayTaxoFacets: +in +di +facets:DayOfYear.taxonomy # freq=7320987 freq=83139
-AndHighMedDayTaxoFacets: +and +included +facets:DayOfYear.taxonomy # freq=7318061 freq=216978
-AndHighMedDayTaxoFacets: +that +play +facets:DayOfYear.taxonomy # freq=2931020 freq=210199
-AndHighMedDayTaxoFacets: +an +might +facets:DayOfYear.taxonomy # freq=2628056 freq=114290
-AndHighMedDayTaxoFacets: +other +country +facets:DayOfYear.taxonomy # freq=1269961 freq=420052
-AndHighMedDayTaxoFacets: +also +success +facets:DayOfYear.taxonomy # freq=1959419 freq=112195
-AndHighMedDayTaxoFacets: +also +27 +facets:DayOfYear.taxonomy # freq=1959419 freq=383042
-AndHighMedDayTaxoFacets: +more +stations +facets:DayOfYear.taxonomy # freq=963533 freq=92011
-AndHighMedDayTaxoFacets: +they +system +facets:DayOfYear.taxonomy # freq=1021945 freq=412862
-AndHighMedDayTaxoFacets: +in +31 +facets:DayOfYear.taxonomy # freq=7320987 freq=298349
-AndHighMedDayTaxoFacets: +all +provided +facets:DayOfYear.taxonomy # freq=1203572 freq=110088
-AndHighMedDayTaxoFacets: +i +u.s +facets:DayOfYear.taxonomy # freq=956148 freq=428534
-AndHighMedDayTaxoFacets: +a +certain +facets:DayOfYear.taxonomy # freq=6560531 freq=105714
-AndHighMedDayTaxoFacets: +his +summary +facets:DayOfYear.taxonomy # freq=1777780 freq=106702
-AndHighMedDayTaxoFacets: +2009 +america +facets:DayOfYear.taxonomy # freq=887702 freq=240374
-AndHighMedDayTaxoFacets: +1 +chicago +facets:DayOfYear.taxonomy # freq=1641090 freq=117756
-AndHighMedDayTaxoFacets: +other +2000 +facets:DayOfYear.taxonomy # freq=1269961 freq=499639
-AndHighMedDayTaxoFacets: +year +men +facets:DayOfYear.taxonomy # freq=1235231 freq=182445
-AndHighMedDayTaxoFacets: +4 +upon +facets:DayOfYear.taxonomy # freq=986452 freq=169174
-AndHighMedDayTaxoFacets: +in +seems +facets:DayOfYear.taxonomy # freq=7320987 freq=83963
-AndHighMedDayTaxoFacets: +he +bank +facets:DayOfYear.taxonomy # freq=1659434 freq=88080
-AndHighMedDayTaxoFacets: +name +both +facets:DayOfYear.taxonomy # freq=2827713 freq=534900
-AndHighMedDayTaxoFacets: +publisher +e +facets:DayOfYear.taxonomy # freq=1289029 freq=408741
-AndHighMedDayTaxoFacets: +who +computer +facets:DayOfYear.taxonomy # freq=1196171 freq=126524
-AndHighMedDayTaxoFacets: +about +type +facets:DayOfYear.taxonomy # freq=850283 freq=318210
-AndHighMedDayTaxoFacets: +this +people +facets:DayOfYear.taxonomy # freq=2224932 freq=790960
-AndHighMedDayTaxoFacets: +their +1978 +facets:DayOfYear.taxonomy # freq=1158682 freq=135223
-AndHighMedDayTaxoFacets: +url +museum +facets:DayOfYear.taxonomy # freq=1513595 freq=135250
-AndHighMedDayTaxoFacets: +4 +least +facets:DayOfYear.taxonomy # freq=986452 freq=146209
-AndHighMedDayTaxoFacets: +2011 +money +facets:DayOfYear.taxonomy # freq=871410 freq=100440
-AndHighMedDayTaxoFacets: +first +referred +facets:DayOfYear.taxonomy # freq=1933372 freq=94811
-AndHighMedDayTaxoFacets: +he +20 +facets:DayOfYear.taxonomy # freq=1659434 freq=624967
-AndHighMedDayTaxoFacets: +were +events +facets:DayOfYear.taxonomy # freq=1524630 freq=158248
-AndHighMedDayTaxoFacets: +it +because +facets:DayOfYear.taxonomy # freq=2675552 freq=413003
-AndHighMedDayTaxoFacets: +accessdate +large +facets:DayOfYear.taxonomy # freq=1228887 freq=308888
-AndHighMedDayTaxoFacets: +there +usa +facets:DayOfYear.taxonomy # freq=956153 freq=191220
-AndHighMedDayTaxoFacets: +he +association +facets:DayOfYear.taxonomy # freq=1659434 freq=247156
-AndHighMedDayTaxoFacets: +2010 +rest +facets:DayOfYear.taxonomy # freq=950573 freq=95113
-AndHighMedDayTaxoFacets: +he +face +facets:DayOfYear.taxonomy # freq=1659434 freq=95144
-AndHighMedDayTaxoFacets: +title +out +facets:DayOfYear.taxonomy # freq=2397378 freq=733775
-AndHighMedDayTaxoFacets: +first +christian +facets:DayOfYear.taxonomy # freq=1933372 freq=140312
-AndHighMedDayTaxoFacets: +has +april +facets:DayOfYear.taxonomy # freq=1502961 freq=587542
-AndHighMedDayTaxoFacets: +in +very +facets:DayOfYear.taxonomy # freq=7320987 freq=354898
-AndHighMedDayTaxoFacets: +no +century +facets:DayOfYear.taxonomy # freq=1045000 freq=385541
-AndHighMedDayTaxoFacets: +accessdate +recording +facets:DayOfYear.taxonomy # freq=1228887 freq=90757
-AndHighMedDayTaxoFacets: +by +55 +facets:DayOfYear.taxonomy # freq=3826691 freq=110526
-AndHighMedDayTaxoFacets: +2005 +54 +facets:DayOfYear.taxonomy # freq=835460 freq=101462
-AndHighMedDayTaxoFacets: +this +x +facets:DayOfYear.taxonomy # freq=2224932 freq=272695
-AndHighMedDayTaxoFacets: +url +following +facets:DayOfYear.taxonomy # freq=1513595 freq=416515
-AndHighMedDayTaxoFacets: +s +per +facets:DayOfYear.taxonomy # freq=1581243 freq=283568
-AndHighMedDayTaxoFacets: +2005 +bureau +facets:DayOfYear.taxonomy # freq=835460 freq=83671
-AndHighMedDayTaxoFacets: +1 +09 +facets:DayOfYear.taxonomy # freq=1641090 freq=296300
-AndHighMedDayTaxoFacets: +title +buildings +facets:DayOfYear.taxonomy # freq=2397378 freq=89046
-AndHighMedDayTaxoFacets: +by +appears +facets:DayOfYear.taxonomy # freq=3826691 freq=104511
-AndHighMedDayTaxoFacets: +year +taken +facets:DayOfYear.taxonomy # freq=1235231 freq=166217
-AndHighMedDayTaxoFacets: +on +size +facets:DayOfYear.taxonomy # freq=4074624 freq=237662
-AndHighMedDayTaxoFacets: +2005 +thomas +facets:DayOfYear.taxonomy # freq=835460 freq=191625
-AndHighMedDayTaxoFacets: +2008 +chicago +facets:DayOfYear.taxonomy # freq=831253 freq=117756
-AndHighMedDayTaxoFacets: +2 +1991 +facets:DayOfYear.taxonomy # freq=1549245 freq=207589
-AndHighMedDayTaxoFacets: +only +2003 +facets:DayOfYear.taxonomy # freq=875561 freq=456990
-AndHighMedDayTaxoFacets: +their +found +facets:DayOfYear.taxonomy # freq=1158682 freq=313247
-AndHighMedDayTaxoFacets: +for +long +facets:DayOfYear.taxonomy # freq=4380011 freq=385787
-AndHighMedDayTaxoFacets: +2011 +low +facets:DayOfYear.taxonomy # freq=871410 freq=157852
-AndHighMedDayTaxoFacets: +for +iii +facets:DayOfYear.taxonomy # freq=4380011 freq=123618
-AndHighMedDayTaxoFacets: +is +1990s +facets:DayOfYear.taxonomy # freq=4074455 freq=83166
-AndHighMedDayTaxoFacets: +some +instead +facets:DayOfYear.taxonomy # freq=839919 freq=149345
-AndHighMedDayTaxoFacets: +publisher +historical +facets:DayOfYear.taxonomy # freq=1289029 freq=159636
-AndHighMedDayTaxoFacets: +are +please +facets:DayOfYear.taxonomy # freq=1877802 freq=229602
-AndHighMedDayTaxoFacets: +who +brown +facets:DayOfYear.taxonomy # freq=1196171 freq=116178
-AndHighMedDayTaxoFacets: +an +professional +facets:DayOfYear.taxonomy # freq=2628056 freq=138520
-AndHighMedDayTaxoFacets: +name +security +facets:DayOfYear.taxonomy # freq=2827713 freq=89382
-AndHighMedDayTaxoFacets: +name +8 +facets:DayOfYear.taxonomy # freq=2827713 freq=635822
-AndHighMedDayTaxoFacets: +from +china +facets:DayOfYear.taxonomy # freq=3224339 freq=130849
-AndHighMedDayTaxoFacets: +a +early +facets:DayOfYear.taxonomy # freq=6560531 freq=482793
-AndHighMedDayTaxoFacets: +cite +changes +facets:DayOfYear.taxonomy # freq=1741194 freq=105677
-AndHighMedDayTaxoFacets: +it +debate +facets:DayOfYear.taxonomy # freq=2675552 freq=177827
-AndHighMedDayTaxoFacets: +by +total +facets:DayOfYear.taxonomy # freq=3826691 freq=230013
-AndHighMedDayTaxoFacets: +it +event +facets:DayOfYear.taxonomy # freq=2675552 freq=114340
-AndHighMedDayTaxoFacets: +2005 +cup +facets:DayOfYear.taxonomy # freq=835460 freq=141942
-AndHighMedDayTaxoFacets: +publisher +1950 +facets:DayOfYear.taxonomy # freq=1289029 freq=89746
-AndHighMedDayTaxoFacets: +no +christian +facets:DayOfYear.taxonomy # freq=1045000 freq=140312
-AndHighMedDayTaxoFacets: +from +forces +facets:DayOfYear.taxonomy # freq=3224339 freq=152939
-AndHighMedDayTaxoFacets: +when +between +facets:DayOfYear.taxonomy # freq=1027487 freq=630650
-AndHighMedDayTaxoFacets: +its +words +facets:DayOfYear.taxonomy # freq=1173450 freq=104783
-AndHighMedDayTaxoFacets: +a +she +facets:DayOfYear.taxonomy # freq=6560531 freq=426267
-AndHighMedDayTaxoFacets: +s +align +facets:DayOfYear.taxonomy # freq=1581243 freq=300455
-AndHighMedDayTaxoFacets: +http +served +facets:DayOfYear.taxonomy # freq=3493581 freq=188351
-AndHighMedDayTaxoFacets: +of +finally +facets:DayOfYear.taxonomy # freq=8184358 freq=99185
-AndHighMedDayTaxoFacets: +some +pre +facets:DayOfYear.taxonomy # freq=839919 freq=90549
-AndHighMedDayTaxoFacets: +which +am +facets:DayOfYear.taxonomy # freq=1963428 freq=127152
-AndHighMedDayTaxoFacets: +with +governor +facets:DayOfYear.taxonomy # freq=3709421 freq=102274
-AndHighMedDayTaxoFacets: +publisher +f.c +facets:DayOfYear.taxonomy # freq=1289029 freq=83548
-AndHighMedDayTaxoFacets: +on +player +facets:DayOfYear.taxonomy # freq=4074624 freq=241451
-AndHighMedDayTaxoFacets: +time +including +facets:DayOfYear.taxonomy # freq=1032071 freq=521324
-AndHighMedDayTaxoFacets: +work +1950 +facets:DayOfYear.taxonomy # freq=853422 freq=89746
-AndHighMedDayTaxoFacets: +http +now +facets:DayOfYear.taxonomy # freq=3493581 freq=484114
-AndHighMedDayTaxoFacets: +is +separate +facets:DayOfYear.taxonomy # freq=4074455 freq=88604
-AndHighMedDayTaxoFacets: +be +having +facets:DayOfYear.taxonomy # freq=2051702 freq=213416
-AndHighMedDayTaxoFacets: +its +practice +facets:DayOfYear.taxonomy # freq=1173450 freq=93287
-AndHighMedDayTaxoFacets: +new +30 +facets:DayOfYear.taxonomy # freq=1657293 freq=488930
-AndHighMedDayTaxoFacets: +date +most +facets:DayOfYear.taxonomy # freq=2020626 freq=819634
-AndHighMedDayTaxoFacets: +by +railway +facets:DayOfYear.taxonomy # freq=3826691 freq=125543
-AndHighMedDayTaxoFacets: +that +related +facets:DayOfYear.taxonomy # freq=2931020 freq=174856
-AndHighMedDayTaxoFacets: +other +data +facets:DayOfYear.taxonomy # freq=1269961 freq=159657
-AndHighMedDayTaxoFacets: +an +daily +facets:DayOfYear.taxonomy # freq=2628056 freq=111717
-AndHighMedDayTaxoFacets: +web +performance +facets:DayOfYear.taxonomy # freq=1118334 freq=130862
-AndHighMedDayTaxoFacets: +their +engine +facets:DayOfYear.taxonomy # freq=1158682 freq=100930
-AndHighMedDayTaxoFacets: +states +found +facets:DayOfYear.taxonomy # freq=1034872 freq=313247
-AndHighMedDayTaxoFacets: +name +takes +facets:DayOfYear.taxonomy # freq=2827713 freq=95889
-AndHighMedDayTaxoFacets: +cite +editor +facets:DayOfYear.taxonomy # freq=1741194 freq=119419
-AndHighMedDayTaxoFacets: +last +canadian +facets:DayOfYear.taxonomy # freq=958437 freq=181906
-AndHighMedDayTaxoFacets: +2 +jersey +facets:DayOfYear.taxonomy # freq=1549245 freq=88847
-AndHighMedDayTaxoFacets: +5 +far +facets:DayOfYear.taxonomy # freq=891361 freq=143873
-AndHighMedDayTaxoFacets: +it +3rd +facets:DayOfYear.taxonomy # freq=2675552 freq=90723
-AndHighMedDayTaxoFacets: +ref +say +facets:DayOfYear.taxonomy # freq=3793973 freq=110895
-AndHighMedDayTaxoFacets: +be +forces +facets:DayOfYear.taxonomy # freq=2051702 freq=152939
-AndHighMedDayTaxoFacets: +2010 +where +facets:DayOfYear.taxonomy # freq=950573 freq=630647
-AndHighMedDayTaxoFacets: +states +earlier +facets:DayOfYear.taxonomy # freq=1034872 freq=100372
-AndHighMedDayTaxoFacets: +has +organization +facets:DayOfYear.taxonomy # freq=1502961 freq=119614
-AndHighMedDayTaxoFacets: +its +fiction +facets:DayOfYear.taxonomy # freq=1173450 freq=87227
-AndHighMedDayTaxoFacets: +it +star +facets:DayOfYear.taxonomy # freq=2675552 freq=195768
-AndHighMedDayTaxoFacets: +have +speed +facets:DayOfYear.taxonomy # freq=1297121 freq=99899
-AndHighMedDayTaxoFacets: +into +2nd +facets:DayOfYear.taxonomy # freq=888684 freq=167463
-AndHighMedDayTaxoFacets: +name +having +facets:DayOfYear.taxonomy # freq=2827713 freq=213416
-AndHighMedDayTaxoFacets: +his +head +facets:DayOfYear.taxonomy # freq=1777780 freq=194682
-AndHighMedDayTaxoFacets: +when +change +facets:DayOfYear.taxonomy # freq=1027487 freq=182336
-AndHighMedDayTaxoFacets: +2005 +edit +facets:DayOfYear.taxonomy # freq=835460 freq=129064
-AndHighMedDayTaxoFacets: +about +mass +facets:DayOfYear.taxonomy # freq=850283 freq=82794
-AndHighMedDayTaxoFacets: +not +profile +facets:DayOfYear.taxonomy # freq=1713264 freq=86788
-AndHighMedDayTaxoFacets: +of +mayor +facets:DayOfYear.taxonomy # freq=8184358 freq=88578
-AndHighMedDayTaxoFacets: +no +woman +facets:DayOfYear.taxonomy # freq=1045000 freq=92071
-AndHighMedDayTaxoFacets: +from +these +facets:DayOfYear.taxonomy # freq=3224339 freq=623267
-AndHighMedDayTaxoFacets: +2005 +literature +facets:DayOfYear.taxonomy # freq=835460 freq=96743
-AndHighMedDayTaxoFacets: +an +07 +facets:DayOfYear.taxonomy # freq=2628056 freq=299351
-AndHighMedDayTaxoFacets: +that +age +facets:DayOfYear.taxonomy # freq=2931020 freq=395368
-AndHighMedDayTaxoFacets: +2008 +august +facets:DayOfYear.taxonomy # freq=831253 freq=527806
-AndHighMedDayTaxoFacets: +date +type +facets:DayOfYear.taxonomy # freq=2020626 freq=318210
-AndHighMedDayTaxoFacets: +other +most +facets:DayOfYear.taxonomy # freq=1269961 freq=819634
-AndHighMedDayTaxoFacets: +his +mark +facets:DayOfYear.taxonomy # freq=1777780 freq=160033
-AndHighMedDayTaxoFacets: +was +elected +facets:DayOfYear.taxonomy # freq=3763623 freq=119941
-AndHighMedDayTaxoFacets: +title +parliament +facets:DayOfYear.taxonomy # freq=2397378 freq=127008
-AndHighMedDayTaxoFacets: +been +27 +facets:DayOfYear.taxonomy # freq=1041183 freq=383042
-AndHighMedDayTaxoFacets: +publisher +western +facets:DayOfYear.taxonomy # freq=1289029 freq=232781
-AndHighMedDayTaxoFacets: +its +done +facets:DayOfYear.taxonomy # freq=1173450 freq=102033
-AndHighMedDayTaxoFacets: +more +web.archive.org +facets:DayOfYear.taxonomy # freq=963533 freq=95902
-AndHighMedDayTaxoFacets: +date +half +facets:DayOfYear.taxonomy # freq=2020626 freq=155387
-AndHighMedDayTaxoFacets: +that +lower +facets:DayOfYear.taxonomy # freq=2931020 freq=127260
-AndHighMedDayTaxoFacets: +more +already +facets:DayOfYear.taxonomy # freq=963533 freq=126694
-AndHighMedDayTaxoFacets: +for +report +facets:DayOfYear.taxonomy # freq=4380011 freq=153204
-AndHighMedDayTaxoFacets: +5 +ed +facets:DayOfYear.taxonomy # freq=891361 freq=134224
-AndHighMedDayTaxoFacets: +http +1965 +facets:DayOfYear.taxonomy # freq=3493581 freq=104539
-AndHighMedDayTaxoFacets: +s +debate +facets:DayOfYear.taxonomy # freq=1581243 freq=177827
-AndHighMedDayTaxoFacets: +only +official +facets:DayOfYear.taxonomy # freq=875561 freq=326177
-AndHighMedDayTaxoFacets: +2006 +seat +facets:DayOfYear.taxonomy # freq=889954 freq=91288
-AndHighMedDayTaxoFacets: +in +27 +facets:DayOfYear.taxonomy # freq=7320987 freq=383042
-AndHighMedDayTaxoFacets: +cite +fields +facets:DayOfYear.taxonomy # freq=1741194 freq=86938
-AndHighMedDayTaxoFacets: +states +remained +facets:DayOfYear.taxonomy # freq=1034872 freq=107736
-AndHighMedDayTaxoFacets: +for +hold +facets:DayOfYear.taxonomy # freq=4380011 freq=82579
-AndHighMedDayTaxoFacets: +2011 +joseph +facets:DayOfYear.taxonomy # freq=871410 freq=121533
-AndHighMedDayTaxoFacets: +2009 +met +facets:DayOfYear.taxonomy # freq=887702 freq=84001
-AndHighMedDayTaxoFacets: +an +31 +facets:DayOfYear.taxonomy # freq=2628056 freq=298349
-AndHighMedDayTaxoFacets: +there +hill +facets:DayOfYear.taxonomy # freq=956153 freq=133714
-AndHighMedDayTaxoFacets: +3 +allowed +facets:DayOfYear.taxonomy # freq=1148799 freq=98720
-AndHighMedDayTaxoFacets: +4 +table +facets:DayOfYear.taxonomy # freq=986452 freq=99163
-AndHighMedDayTaxoFacets: +accessdate +later +facets:DayOfYear.taxonomy # freq=1228887 freq=604921
-AndHighMedDayTaxoFacets: +2008 +rather +facets:DayOfYear.taxonomy # freq=831253 freq=174136
-AndHighMedDayTaxoFacets: +also +late +facets:DayOfYear.taxonomy # freq=1959419 freq=243636
-AndHighMedDayTaxoFacets: +2008 +60 +facets:DayOfYear.taxonomy # freq=831253 freq=118403
-AndHighMedDayTaxoFacets: +1 +why +facets:DayOfYear.taxonomy # freq=1641090 freq=108161
-AndHighMedDayTaxoFacets: +new +winning +facets:DayOfYear.taxonomy # freq=1657293 freq=95704
-AndHighMedDayTaxoFacets: +accessdate +towards +facets:DayOfYear.taxonomy # freq=1228887 freq=95574
-AndHighMedDayTaxoFacets: +date +t +facets:DayOfYear.taxonomy # freq=2020626 freq=262832
-AndHighMedDayTaxoFacets: +2 +nbsp +facets:DayOfYear.taxonomy # freq=1549245 freq=506054
-AndHighMedDayTaxoFacets: +time +website +facets:DayOfYear.taxonomy # freq=1032071 freq=435941
-AndHighMedDayTaxoFacets: +5 +republic +facets:DayOfYear.taxonomy # freq=891361 freq=166154
-AndHighMedDayTaxoFacets: +were +hold +facets:DayOfYear.taxonomy # freq=1524630 freq=82579
-AndHighMedDayTaxoFacets: +the +whom +facets:DayOfYear.taxonomy # freq=8217362 freq=95520
-AndHighMedDayTaxoFacets: +http +free +facets:DayOfYear.taxonomy # freq=3493581 freq=270199
-AndHighMedDayTaxoFacets: +his +self +facets:DayOfYear.taxonomy # freq=1777780 freq=135012
-AndHighMedDayTaxoFacets: +with +music +facets:DayOfYear.taxonomy # freq=3709421 freq=473240
-AndHighMedDayTaxoFacets: +is +academy +facets:DayOfYear.taxonomy # freq=4074455 freq=119055
-AndHighMedDayTaxoFacets: +year +appearance +facets:DayOfYear.taxonomy # freq=1235231 freq=89229
-AndHighMedDayTaxoFacets: +year +square +facets:DayOfYear.taxonomy # freq=1235231 freq=123538
-AndHighMedDayTaxoFacets: +i +h +facets:DayOfYear.taxonomy # freq=956148 freq=241946
-AndHighMedDayTaxoFacets: +by +35 +facets:DayOfYear.taxonomy # freq=3826691 freq=155506
-AndHighMedDayTaxoFacets: +2005 +sports +facets:DayOfYear.taxonomy # freq=835460 freq=178542
-AndHighMedDayTaxoFacets: +united +series +facets:DayOfYear.taxonomy # freq=1196944 freq=521861
-AndHighMedDayTaxoFacets: +may +congress +facets:DayOfYear.taxonomy # freq=1071932 freq=92382
-AndHighMedDayTaxoFacets: +title +la +facets:DayOfYear.taxonomy # freq=2397378 freq=232610
-AndHighMedDayTaxoFacets: +its +category:american +facets:DayOfYear.taxonomy # freq=1173450 freq=107823
-AndHighMedDayTaxoFacets: +the +lake +facets:DayOfYear.taxonomy # freq=8217362 freq=131603
-AndHighMedDayTaxoFacets: +who +foundation +facets:DayOfYear.taxonomy # freq=1196171 freq=107123
-AndHighMedDayTaxoFacets: +3 +57 +facets:DayOfYear.taxonomy # freq=1148799 freq=93708
-AndHighMedDayTaxoFacets: +date +flag +facets:DayOfYear.taxonomy # freq=2020626 freq=104210
-AndHighMedDayTaxoFacets: +10 +dq +facets:DayOfYear.taxonomy # freq=918339 freq=88557
-AndHighMedDayTaxoFacets: +that +study +facets:DayOfYear.taxonomy # freq=2931020 freq=137170
-AndHighMedDayTaxoFacets: +first +france +facets:DayOfYear.taxonomy # freq=1933372 freq=220058
-AndHighMedDayTaxoFacets: +on +culture +facets:DayOfYear.taxonomy # freq=4074624 freq=157773
-AndHighMedDayTaxoFacets: +to +1984 +facets:DayOfYear.taxonomy # freq=6155577 freq=161404
-AndHighMedDayTaxoFacets: +all +u.s +facets:DayOfYear.taxonomy # freq=1203572 freq=428534
-AndHighMedDayTaxoFacets: +name +era +facets:DayOfYear.taxonomy # freq=2827713 freq=95989
-AndHighMedDayTaxoFacets: +url +02 +facets:DayOfYear.taxonomy # freq=1513595 freq=319783
-AndHighMedDayTaxoFacets: +a +teams +facets:DayOfYear.taxonomy # freq=6560531 freq=105245
-AndHighMedDayTaxoFacets: +name +paul +facets:DayOfYear.taxonomy # freq=2827713 freq=207229
-AndHighMedDayTaxoFacets: +2008 +command +facets:DayOfYear.taxonomy # freq=831253 freq=87496
-AndHighMedDayTaxoFacets: +after +today +facets:DayOfYear.taxonomy # freq=1247398 freq=168864
-AndHighMedDayTaxoFacets: +no +native +facets:DayOfYear.taxonomy # freq=1045000 freq=129103
-AndHighMedDayTaxoFacets: +into +st +facets:DayOfYear.taxonomy # freq=888684 freq=309092
-AndHighMedDayTaxoFacets: +accessdate +m +facets:DayOfYear.taxonomy # freq=1228887 freq=441232
-AndHighMedDayTaxoFacets: +a +heart +facets:DayOfYear.taxonomy # freq=6560531 freq=95365
-AndHighMedDayTaxoFacets: +2010 +1986 +facets:DayOfYear.taxonomy # freq=950573 freq=167724
-AndHighMedDayTaxoFacets: +2008 +remained +facets:DayOfYear.taxonomy # freq=831253 freq=107736
-AndHighMedDayTaxoFacets: +this +college +facets:DayOfYear.taxonomy # freq=2224932 freq=278094
-AndHighMedDayTaxoFacets: +date +note +facets:DayOfYear.taxonomy # freq=2020626 freq=194472
-AndHighMedDayTaxoFacets: +5 +coast +facets:DayOfYear.taxonomy # freq=891361 freq=119047
-AndHighMedDayTaxoFacets: +time +sometimes +facets:DayOfYear.taxonomy # freq=1032071 freq=144078
-AndHighMedDayTaxoFacets: +3 +look +facets:DayOfYear.taxonomy # freq=1148799 freq=91122
-AndHighMedDayTaxoFacets: +states +people +facets:DayOfYear.taxonomy # freq=1034872 freq=790960
-AndHighMedDayTaxoFacets: +to +specific +facets:DayOfYear.taxonomy # freq=6155577 freq=93622
-AndHighMedDayTaxoFacets: +year +between +facets:DayOfYear.taxonomy # freq=1235231 freq=630650
-AndHighMedDayTaxoFacets: +publisher +led +facets:DayOfYear.taxonomy # freq=1289029 freq=210033
-AndHighMedDayTaxoFacets: +a +given +facets:DayOfYear.taxonomy # freq=6560531 freq=235719
-AndHighMedDayTaxoFacets: +2008 +stations +facets:DayOfYear.taxonomy # freq=831253 freq=92011
-AndHighMedDayTaxoFacets: +his +england +facets:DayOfYear.taxonomy # freq=1777780 freq=317884
-AndHighMedDayTaxoFacets: +states +geo +facets:DayOfYear.taxonomy # freq=1034872 freq=83404
-AndHighMedDayTaxoFacets: +at +1960 +facets:DayOfYear.taxonomy # freq=2857534 freq=109083
-AndHighMedDayTaxoFacets: +be +60 +facets:DayOfYear.taxonomy # freq=2051702 freq=118403
-AndHighMedDayTaxoFacets: +there +schools +facets:DayOfYear.taxonomy # freq=956153 freq=141308
-AndHighMedDayTaxoFacets: +that +value +facets:DayOfYear.taxonomy # freq=2931020 freq=86806
-AndHighMedDayTaxoFacets: +no +needed +facets:DayOfYear.taxonomy # freq=1045000 freq=281051
-AndHighMedDayTaxoFacets: +2011 +31 +facets:DayOfYear.taxonomy # freq=871410 freq=298349
-AndHighMedDayTaxoFacets: +year +16 +facets:DayOfYear.taxonomy # freq=1235231 freq=540539
-AndHighMedDayTaxoFacets: +title +set +facets:DayOfYear.taxonomy # freq=2397378 freq=294255
-AndHighMedDayTaxoFacets: +work +sport +facets:DayOfYear.taxonomy # freq=853422 freq=106696
-AndHighMedDayTaxoFacets: +all +42 +facets:DayOfYear.taxonomy # freq=1203572 freq=124253
-OrHighMedDayTaxoFacets: there background +facets:DayOfYear.taxonomy # freq=956153 freq=314229
-OrHighMedDayTaxoFacets: be important +facets:DayOfYear.taxonomy # freq=2051702 freq=195851
-OrHighMedDayTaxoFacets: name cd +facets:DayOfYear.taxonomy # freq=2827713 freq=87105
-OrHighMedDayTaxoFacets: when regular +facets:DayOfYear.taxonomy # freq=1027487 freq=93809
-OrHighMedDayTaxoFacets: 1 called +facets:DayOfYear.taxonomy # freq=1641090 freq=454580
-OrHighMedDayTaxoFacets: may force +facets:DayOfYear.taxonomy # freq=1071932 freq=198556
-OrHighMedDayTaxoFacets: 1 regular +facets:DayOfYear.taxonomy # freq=1641090 freq=93809
-OrHighMedDayTaxoFacets: s 1986 +facets:DayOfYear.taxonomy # freq=1581243 freq=167724
-OrHighMedDayTaxoFacets: 2011 co +facets:DayOfYear.taxonomy # freq=871410 freq=209086
-OrHighMedDayTaxoFacets: he artist +facets:DayOfYear.taxonomy # freq=1659434 freq=210591
-OrHighMedDayTaxoFacets: 2009 him +facets:DayOfYear.taxonomy # freq=887702 freq=507350
-OrHighMedDayTaxoFacets: at interest +facets:DayOfYear.taxonomy # freq=2857534 freq=108551
-OrHighMedDayTaxoFacets: and 1959 +facets:DayOfYear.taxonomy # freq=7318061 freq=87097
-OrHighMedDayTaxoFacets: had few +facets:DayOfYear.taxonomy # freq=1246743 freq=226422
-OrHighMedDayTaxoFacets: this era +facets:DayOfYear.taxonomy # freq=2224932 freq=95989
-OrHighMedDayTaxoFacets: also video +facets:DayOfYear.taxonomy # freq=1959419 freq=202380
-OrHighMedDayTaxoFacets: into capital +facets:DayOfYear.taxonomy # freq=888684 freq=120421
-OrHighMedDayTaxoFacets: who los +facets:DayOfYear.taxonomy # freq=1196171 freq=145404
-OrHighMedDayTaxoFacets: that ii +facets:DayOfYear.taxonomy # freq=2931020 freq=340800
-OrHighMedDayTaxoFacets: as working +facets:DayOfYear.taxonomy # freq=3925535 freq=144617
-OrHighMedDayTaxoFacets: accessdate status +facets:DayOfYear.taxonomy # freq=1228887 freq=133818
-OrHighMedDayTaxoFacets: not put +facets:DayOfYear.taxonomy # freq=1713264 freq=139882
-OrHighMedDayTaxoFacets: cite soviet +facets:DayOfYear.taxonomy # freq=1741194 freq=89070
-OrHighMedDayTaxoFacets: see reading +facets:DayOfYear.taxonomy # freq=1044180 freq=101214
-OrHighMedDayTaxoFacets: all area +facets:DayOfYear.taxonomy # freq=1203572 freq=559023
-OrHighMedDayTaxoFacets: his influence +facets:DayOfYear.taxonomy # freq=1777780 freq=83101
-OrHighMedDayTaxoFacets: new less +facets:DayOfYear.taxonomy # freq=1657293 freq=170266
-OrHighMedDayTaxoFacets: states 14 +facets:DayOfYear.taxonomy # freq=1034872 freq=534005
-OrHighMedDayTaxoFacets: no april +facets:DayOfYear.taxonomy # freq=1045000 freq=587542
-OrHighMedDayTaxoFacets: http wife +facets:DayOfYear.taxonomy # freq=3493581 freq=130807
-OrHighMedDayTaxoFacets: had stories +facets:DayOfYear.taxonomy # freq=1246743 freq=110223
-OrHighMedDayTaxoFacets: this established +facets:DayOfYear.taxonomy # freq=2224932 freq=282471
-OrHighMedDayTaxoFacets: other source +facets:DayOfYear.taxonomy # freq=1269961 freq=231838
-OrHighMedDayTaxoFacets: 1 alone +facets:DayOfYear.taxonomy # freq=1641090 freq=93166
-OrHighMedDayTaxoFacets: and per +facets:DayOfYear.taxonomy # freq=7318061 freq=283568
-OrHighMedDayTaxoFacets: into larger +facets:DayOfYear.taxonomy # freq=888684 freq=87424
-OrHighMedDayTaxoFacets: to book +facets:DayOfYear.taxonomy # freq=6155577 freq=617297
-OrHighMedDayTaxoFacets: at london +facets:DayOfYear.taxonomy # freq=2857534 freq=348918
-OrHighMedDayTaxoFacets: at km +facets:DayOfYear.taxonomy # freq=2857534 freq=233831
-OrHighMedDayTaxoFacets: in convert +facets:DayOfYear.taxonomy # freq=7320987 freq=267974
-OrHighMedDayTaxoFacets: s yet +facets:DayOfYear.taxonomy # freq=1581243 freq=100857
-OrHighMedDayTaxoFacets: 1 1973 +facets:DayOfYear.taxonomy # freq=1641090 freq=125985
-OrHighMedDayTaxoFacets: 1 yet +facets:DayOfYear.taxonomy # freq=1641090 freq=100857
-OrHighMedDayTaxoFacets: 3 preserved +facets:DayOfYear.taxonomy # freq=1148799 freq=111088
-OrHighMedDayTaxoFacets: when various +facets:DayOfYear.taxonomy # freq=1027487 freq=224593
-OrHighMedDayTaxoFacets: his result +facets:DayOfYear.taxonomy # freq=1777780 freq=276803
-OrHighMedDayTaxoFacets: into film +facets:DayOfYear.taxonomy # freq=888684 freq=432758
-OrHighMedDayTaxoFacets: was leader +facets:DayOfYear.taxonomy # freq=3763623 freq=127591
-OrHighMedDayTaxoFacets: see list +facets:DayOfYear.taxonomy # freq=1044180 freq=585922
-OrHighMedDayTaxoFacets: first institute +facets:DayOfYear.taxonomy # freq=1933372 freq=136311
-OrHighMedDayTaxoFacets: work got +facets:DayOfYear.taxonomy # freq=853422 freq=92640
-OrHighMedDayTaxoFacets: had rule +facets:DayOfYear.taxonomy # freq=1246743 freq=86729
-OrHighMedDayTaxoFacets: 1 thought +facets:DayOfYear.taxonomy # freq=1641090 freq=108963
-OrHighMedDayTaxoFacets: an hard +facets:DayOfYear.taxonomy # freq=2628056 freq=90149
-OrHighMedDayTaxoFacets: only 1972 +facets:DayOfYear.taxonomy # freq=875561 freq=130791
-OrHighMedDayTaxoFacets: was american +facets:DayOfYear.taxonomy # freq=3763623 freq=758337
-OrHighMedDayTaxoFacets: 2009 lines +facets:DayOfYear.taxonomy # freq=887702 freq=96969
-OrHighMedDayTaxoFacets: no followed +facets:DayOfYear.taxonomy # freq=1045000 freq=121848
-OrHighMedDayTaxoFacets: had five +facets:DayOfYear.taxonomy # freq=1246743 freq=262923
-OrHighMedDayTaxoFacets: was q +facets:DayOfYear.taxonomy # freq=3763623 freq=149271
-OrHighMedDayTaxoFacets: cite wikipedia +facets:DayOfYear.taxonomy # freq=1741194 freq=149673
-OrHighMedDayTaxoFacets: other already +facets:DayOfYear.taxonomy # freq=1269961 freq=126694
-OrHighMedDayTaxoFacets: it keep +facets:DayOfYear.taxonomy # freq=2675552 freq=177996
-OrHighMedDayTaxoFacets: states t +facets:DayOfYear.taxonomy # freq=1034872 freq=262832
-OrHighMedDayTaxoFacets: 1 listed +facets:DayOfYear.taxonomy # freq=1641090 freq=94990
-OrHighMedDayTaxoFacets: there modify +facets:DayOfYear.taxonomy # freq=956153 freq=109819
-OrHighMedDayTaxoFacets: url win +facets:DayOfYear.taxonomy # freq=1513595 freq=121070
-OrHighMedDayTaxoFacets: may 39 +facets:DayOfYear.taxonomy # freq=1071932 freq=132689
-OrHighMedDayTaxoFacets: two charles +facets:DayOfYear.taxonomy # freq=1104053 freq=204987
-OrHighMedDayTaxoFacets: also appears +facets:DayOfYear.taxonomy # freq=1959419 freq=104511
-OrHighMedDayTaxoFacets: more rowspan +facets:DayOfYear.taxonomy # freq=963533 freq=124637
-OrHighMedDayTaxoFacets: web north +facets:DayOfYear.taxonomy # freq=1118334 freq=564195
-OrHighMedDayTaxoFacets: 1 smith +facets:DayOfYear.taxonomy # freq=1641090 freq=126344
-OrHighMedDayTaxoFacets: 2010 2000 +facets:DayOfYear.taxonomy # freq=950573 freq=499639
-OrHighMedDayTaxoFacets: they features +facets:DayOfYear.taxonomy # freq=1021945 freq=156867
-OrHighMedDayTaxoFacets: 2 project +facets:DayOfYear.taxonomy # freq=1549245 freq=180139
-OrHighMedDayTaxoFacets: http instead +facets:DayOfYear.taxonomy # freq=3493581 freq=149345
-OrHighMedDayTaxoFacets: by am +facets:DayOfYear.taxonomy # freq=3826691 freq=127152
-OrHighMedDayTaxoFacets: it pacific +facets:DayOfYear.taxonomy # freq=2675552 freq=107648
-OrHighMedDayTaxoFacets: states times +facets:DayOfYear.taxonomy # freq=1034872 freq=407155
-OrHighMedDayTaxoFacets: name middle +facets:DayOfYear.taxonomy # freq=2827713 freq=156728
-OrHighMedDayTaxoFacets: is 1988 +facets:DayOfYear.taxonomy # freq=4074455 freq=181327
-OrHighMedDayTaxoFacets: 5 c +facets:DayOfYear.taxonomy # freq=891361 freq=444247
-OrHighMedDayTaxoFacets: their court +facets:DayOfYear.taxonomy # freq=1158682 freq=169309
-OrHighMedDayTaxoFacets: they double +facets:DayOfYear.taxonomy # freq=1021945 freq=87304
-OrHighMedDayTaxoFacets: in george +facets:DayOfYear.taxonomy # freq=7320987 freq=256196
-OrHighMedDayTaxoFacets: after appears +facets:DayOfYear.taxonomy # freq=1247398 freq=104511
-OrHighMedDayTaxoFacets: is thomas +facets:DayOfYear.taxonomy # freq=4074455 freq=191625
-OrHighMedDayTaxoFacets: about specific +facets:DayOfYear.taxonomy # freq=850283 freq=93622
-OrHighMedDayTaxoFacets: be captain +facets:DayOfYear.taxonomy # freq=2051702 freq=91635
-OrHighMedDayTaxoFacets: be journal +facets:DayOfYear.taxonomy # freq=2051702 freq=348162
-OrHighMedDayTaxoFacets: this month +facets:DayOfYear.taxonomy # freq=2224932 freq=162128
-OrHighMedDayTaxoFacets: last given +facets:DayOfYear.taxonomy # freq=958437 freq=235719
-OrHighMedDayTaxoFacets: from running +facets:DayOfYear.taxonomy # freq=3224339 freq=101764
-OrHighMedDayTaxoFacets: 2008 liberal +facets:DayOfYear.taxonomy # freq=831253 freq=93070
-OrHighMedDayTaxoFacets: i island +facets:DayOfYear.taxonomy # freq=956148 freq=203023
-OrHighMedDayTaxoFacets: or pp +facets:DayOfYear.taxonomy # freq=1858841 freq=204742
-OrHighMedDayTaxoFacets: which earth +facets:DayOfYear.taxonomy # freq=1963428 freq=110512
-OrHighMedDayTaxoFacets: united school +facets:DayOfYear.taxonomy # freq=1196944 freq=462166
-OrHighMedDayTaxoFacets: at fall +facets:DayOfYear.taxonomy # freq=2857534 freq=103379
-OrHighMedDayTaxoFacets: by talk +facets:DayOfYear.taxonomy # freq=3826691 freq=364194
-OrHighMedDayTaxoFacets: title appropriate +facets:DayOfYear.taxonomy # freq=2397378 freq=135343
-OrHighMedDayTaxoFacets: first data +facets:DayOfYear.taxonomy # freq=1933372 freq=159657
-OrHighMedDayTaxoFacets: by community +facets:DayOfYear.taxonomy # freq=3826691 freq=225571
-OrHighMedDayTaxoFacets: it anti +facets:DayOfYear.taxonomy # freq=2675552 freq=99993
-OrHighMedDayTaxoFacets: 2005 would +facets:DayOfYear.taxonomy # freq=835460 freq=690480
-OrHighMedDayTaxoFacets: no archive +facets:DayOfYear.taxonomy # freq=1045000 freq=215381
-OrHighMedDayTaxoFacets: had 11 +facets:DayOfYear.taxonomy # freq=1246743 freq=730505
-OrHighMedDayTaxoFacets: which 978 +facets:DayOfYear.taxonomy # freq=1963428 freq=101276
-OrHighMedDayTaxoFacets: accessdate seems +facets:DayOfYear.taxonomy # freq=1228887 freq=83963
-OrHighMedDayTaxoFacets: 2011 commission +facets:DayOfYear.taxonomy # freq=871410 freq=91476
-OrHighMedDayTaxoFacets: that county +facets:DayOfYear.taxonomy # freq=2931020 freq=521126
-OrHighMedDayTaxoFacets: they hard +facets:DayOfYear.taxonomy # freq=1021945 freq=90149
-OrHighMedDayTaxoFacets: first historic +facets:DayOfYear.taxonomy # freq=1933372 freq=112292
-OrHighMedDayTaxoFacets: this category +facets:DayOfYear.taxonomy # freq=2224932 freq=595446
-OrHighMedDayTaxoFacets: its counties +facets:DayOfYear.taxonomy # freq=1173450 freq=87574
-OrHighMedDayTaxoFacets: year 1963 +facets:DayOfYear.taxonomy # freq=1235231 freq=96439
-OrHighMedDayTaxoFacets: this include +facets:DayOfYear.taxonomy # freq=2224932 freq=276466
-OrHighMedDayTaxoFacets: one british +facets:DayOfYear.taxonomy # freq=1527689 freq=417307
-OrHighMedDayTaxoFacets: was world +facets:DayOfYear.taxonomy # freq=3763623 freq=808563
-OrHighMedDayTaxoFacets: the references +facets:DayOfYear.taxonomy # freq=8217362 freq=760306
-OrHighMedDayTaxoFacets: its 56 +facets:DayOfYear.taxonomy # freq=1173450 freq=96215
-OrHighMedDayTaxoFacets: their son +facets:DayOfYear.taxonomy # freq=1158682 freq=202340
-OrHighMedDayTaxoFacets: the federal +facets:DayOfYear.taxonomy # freq=8217362 freq=166274
-OrHighMedDayTaxoFacets: with jpg +facets:DayOfYear.taxonomy # freq=3709421 freq=322278
-OrHighMedDayTaxoFacets: on training +facets:DayOfYear.taxonomy # freq=4074624 freq=107271
-OrHighMedDayTaxoFacets: for famous +facets:DayOfYear.taxonomy # freq=4380011 freq=139092
-OrHighMedDayTaxoFacets: work run +facets:DayOfYear.taxonomy # freq=853422 freq=183609
-OrHighMedDayTaxoFacets: which start +facets:DayOfYear.taxonomy # freq=1963428 freq=233925
-OrHighMedDayTaxoFacets: and author +facets:DayOfYear.taxonomy # freq=7318061 freq=567768
-OrHighMedDayTaxoFacets: name mother +facets:DayOfYear.taxonomy # freq=2827713 freq=122930
-OrHighMedDayTaxoFacets: who current +facets:DayOfYear.taxonomy # freq=1196171 freq=217174
-OrHighMedDayTaxoFacets: s vote +facets:DayOfYear.taxonomy # freq=1581243 freq=96871
-OrHighMedDayTaxoFacets: 4 51 +facets:DayOfYear.taxonomy # freq=986452 freq=108800
-OrHighMedDayTaxoFacets: 2011 special +facets:DayOfYear.taxonomy # freq=871410 freq=198917
-OrHighMedDayTaxoFacets: accessdate st +facets:DayOfYear.taxonomy # freq=1228887 freq=309092
-OrHighMedDayTaxoFacets: about must +facets:DayOfYear.taxonomy # freq=850283 freq=228491
-OrHighMedDayTaxoFacets: had census +facets:DayOfYear.taxonomy # freq=1246743 freq=205166
-OrHighMedDayTaxoFacets: publisher 56 +facets:DayOfYear.taxonomy # freq=1289029 freq=96215
-OrHighMedDayTaxoFacets: other 12 +facets:DayOfYear.taxonomy # freq=1269961 freq=774572
-OrHighMedDayTaxoFacets: or 22 +facets:DayOfYear.taxonomy # freq=1858841 freq=502778
-OrHighMedDayTaxoFacets: of deletion +facets:DayOfYear.taxonomy # freq=8184358 freq=166633
-OrHighMedDayTaxoFacets: as married +facets:DayOfYear.taxonomy # freq=3925535 freq=156752
-OrHighMedDayTaxoFacets: also do +facets:DayOfYear.taxonomy # freq=1959419 freq=511178
-OrHighMedDayTaxoFacets: of larger +facets:DayOfYear.taxonomy # freq=8184358 freq=87424
-OrHighMedDayTaxoFacets: the wikipedia:persondata +facets:DayOfYear.taxonomy # freq=8217362 freq=222385
-OrHighMedDayTaxoFacets: be books +facets:DayOfYear.taxonomy # freq=2051702 freq=341376
-OrHighMedDayTaxoFacets: url george +facets:DayOfYear.taxonomy # freq=1513595 freq=256196
-OrHighMedDayTaxoFacets: accessdate del +facets:DayOfYear.taxonomy # freq=1228887 freq=82614
-OrHighMedDayTaxoFacets: about command +facets:DayOfYear.taxonomy # freq=850283 freq=87496
-OrHighMedDayTaxoFacets: there soon +facets:DayOfYear.taxonomy # freq=956153 freq=123657
-OrHighMedDayTaxoFacets: url special +facets:DayOfYear.taxonomy # freq=1513595 freq=198917
-OrHighMedDayTaxoFacets: may authority +facets:DayOfYear.taxonomy # freq=1071932 freq=85540
-OrHighMedDayTaxoFacets: url ever +facets:DayOfYear.taxonomy # freq=1513595 freq=128732
-OrHighMedDayTaxoFacets: see 1987 +facets:DayOfYear.taxonomy # freq=1044180 freq=172453
-OrHighMedDayTaxoFacets: his ended +facets:DayOfYear.taxonomy # freq=1777780 freq=84664
-OrHighMedDayTaxoFacets: who prime +facets:DayOfYear.taxonomy # freq=1196171 freq=96945
-OrHighMedDayTaxoFacets: a success +facets:DayOfYear.taxonomy # freq=6560531 freq=112195
-OrHighMedDayTaxoFacets: cite elected +facets:DayOfYear.taxonomy # freq=1741194 freq=119941
-OrHighMedDayTaxoFacets: 2008 without +facets:DayOfYear.taxonomy # freq=831253 freq=249926
-OrHighMedDayTaxoFacets: after km +facets:DayOfYear.taxonomy # freq=1247398 freq=233831
-OrHighMedDayTaxoFacets: no fields +facets:DayOfYear.taxonomy # freq=1045000 freq=86938
-OrHighMedDayTaxoFacets: the financial +facets:DayOfYear.taxonomy # freq=8217362 freq=82536
-OrHighMedDayTaxoFacets: had features +facets:DayOfYear.taxonomy # freq=1246743 freq=156867
-OrHighMedDayTaxoFacets: into dead +facets:DayOfYear.taxonomy # freq=888684 freq=171386
-OrHighMedDayTaxoFacets: of caused +facets:DayOfYear.taxonomy # freq=8184358 freq=86397
-OrHighMedDayTaxoFacets: as changes +facets:DayOfYear.taxonomy # freq=3925535 freq=105677
-OrHighMedDayTaxoFacets: no president +facets:DayOfYear.taxonomy # freq=1045000 freq=263341
-OrHighMedDayTaxoFacets: one within +facets:DayOfYear.taxonomy # freq=1527689 freq=291049
-OrHighMedDayTaxoFacets: at mark +facets:DayOfYear.taxonomy # freq=2857534 freq=160033
-OrHighMedDayTaxoFacets: first down +facets:DayOfYear.taxonomy # freq=1933372 freq=280662
-OrHighMedDayTaxoFacets: be leader +facets:DayOfYear.taxonomy # freq=2051702 freq=127591
-OrHighMedDayTaxoFacets: were know +facets:DayOfYear.taxonomy # freq=1524630 freq=129655
-OrHighMedDayTaxoFacets: s england +facets:DayOfYear.taxonomy # freq=1581243 freq=317884
-OrHighMedDayTaxoFacets: one set +facets:DayOfYear.taxonomy # freq=1527689 freq=294255
-OrHighMedDayTaxoFacets: 5 flight +facets:DayOfYear.taxonomy # freq=891361 freq=84316
-OrHighMedDayTaxoFacets: i works +facets:DayOfYear.taxonomy # freq=956148 freq=199177
-OrHighMedDayTaxoFacets: was 1982 +facets:DayOfYear.taxonomy # freq=3763623 freq=153269
-OrHighMedDayTaxoFacets: but 57 +facets:DayOfYear.taxonomy # freq=1456553 freq=93708
-OrHighMedDayTaxoFacets: date coord +facets:DayOfYear.taxonomy # freq=2020626 freq=180590
-OrHighMedDayTaxoFacets: cite science +facets:DayOfYear.taxonomy # freq=1741194 freq=219988
-OrHighMedDayTaxoFacets: two past +facets:DayOfYear.taxonomy # freq=1104053 freq=126130
-OrHighMedDayTaxoFacets: first albums +facets:DayOfYear.taxonomy # freq=1933372 freq=118322
-OrHighMedDayTaxoFacets: its 14 +facets:DayOfYear.taxonomy # freq=1173450 freq=534005
-OrHighMedDayTaxoFacets: when rowspan +facets:DayOfYear.taxonomy # freq=1027487 freq=124637
-OrHighMedDayTaxoFacets: for league +facets:DayOfYear.taxonomy # freq=4380011 freq=270223
-OrHighMedDayTaxoFacets: to keep +facets:DayOfYear.taxonomy # freq=6155577 freq=177996
-OrHighMedDayTaxoFacets: a baseball +facets:DayOfYear.taxonomy # freq=6560531 freq=93326
-OrHighMedDayTaxoFacets: publisher colspan +facets:DayOfYear.taxonomy # freq=1289029 freq=134521
-OrHighMedDayTaxoFacets: when release +facets:DayOfYear.taxonomy # freq=1027487 freq=189375
-OrHighMedDayTaxoFacets: see down +facets:DayOfYear.taxonomy # freq=1044180 freq=280662
-OrHighMedDayTaxoFacets: date does +facets:DayOfYear.taxonomy # freq=2020626 freq=232202
-OrHighMedDayTaxoFacets: s boston +facets:DayOfYear.taxonomy # freq=1581243 freq=85235
-OrHighMedDayTaxoFacets: but center +facets:DayOfYear.taxonomy # freq=1456553 freq=489673
-OrHighMedDayTaxoFacets: some originally +facets:DayOfYear.taxonomy # freq=839919 freq=168282
-OrHighMedDayTaxoFacets: all movement +facets:DayOfYear.taxonomy # freq=1203572 freq=131692
-OrHighMedDayTaxoFacets: an human +facets:DayOfYear.taxonomy # freq=2628056 freq=182617
-OrHighMedDayTaxoFacets: time life +facets:DayOfYear.taxonomy # freq=1032071 freq=477007
-OrHighMedDayTaxoFacets: first bridge +facets:DayOfYear.taxonomy # freq=1933372 freq=92398
-OrHighMedDayTaxoFacets: one comments +facets:DayOfYear.taxonomy # freq=1527689 freq=185637
-OrHighMedDayTaxoFacets: he background +facets:DayOfYear.taxonomy # freq=1659434 freq=314229
-OrHighMedDayTaxoFacets: 2006 1988 +facets:DayOfYear.taxonomy # freq=889954 freq=181327
-OrHighMedDayTaxoFacets: http fiction +facets:DayOfYear.taxonomy # freq=3493581 freq=87227
-OrHighMedDayTaxoFacets: 4 case +facets:DayOfYear.taxonomy # freq=986452 freq=207307
-OrHighMedDayTaxoFacets: there mike +facets:DayOfYear.taxonomy # freq=956153 freq=91795
-OrHighMedDayTaxoFacets: there 29 +facets:DayOfYear.taxonomy # freq=956153 freq=372091
-OrHighMedDayTaxoFacets: 2010 near +facets:DayOfYear.taxonomy # freq=950573 freq=254492
-OrHighMedDayTaxoFacets: url channel +facets:DayOfYear.taxonomy # freq=1513595 freq=101401
-OrHighMedDayTaxoFacets: two robert +facets:DayOfYear.taxonomy # freq=1104053 freq=246405
-OrHighMedDayTaxoFacets: or public +facets:DayOfYear.taxonomy # freq=1858841 freq=368868
-OrHighMedDayTaxoFacets: other robert +facets:DayOfYear.taxonomy # freq=1269961 freq=246405
-OrHighMedDayTaxoFacets: ref germany +facets:DayOfYear.taxonomy # freq=3793973 freq=190478
-OrHighMedDayTaxoFacets: one english +facets:DayOfYear.taxonomy # freq=1527689 freq=412061
-OrHighMedDayTaxoFacets: no cd +facets:DayOfYear.taxonomy # freq=1045000 freq=87105
-OrHighMedDayTaxoFacets: publisher what +facets:DayOfYear.taxonomy # freq=1289029 freq=394675
-OrHighMedDayTaxoFacets: their win +facets:DayOfYear.taxonomy # freq=1158682 freq=121070
-OrHighMedDayTaxoFacets: an 1959 +facets:DayOfYear.taxonomy # freq=2628056 freq=87097
-OrHighMedDayTaxoFacets: but digital +facets:DayOfYear.taxonomy # freq=1456553 freq=82650
-OrHighMedDayTaxoFacets: but 30 +facets:DayOfYear.taxonomy # freq=1456553 freq=488930
-OrHighMedDayTaxoFacets: work information +facets:DayOfYear.taxonomy # freq=853422 freq=353153
-OrHighMedDayTaxoFacets: by population +facets:DayOfYear.taxonomy # freq=3826691 freq=374481
-OrHighMedDayTaxoFacets: in post +facets:DayOfYear.taxonomy # freq=7320987 freq=218570
-OrHighMedDayTaxoFacets: who birth +facets:DayOfYear.taxonomy # freq=1196171 freq=425138
-OrHighMedDayTaxoFacets: who multiple +facets:DayOfYear.taxonomy # freq=1196171 freq=89684
-OrHighMedDayTaxoFacets: ref trade +facets:DayOfYear.taxonomy # freq=3793973 freq=106384
-OrHighMedDayTaxoFacets: after lord +facets:DayOfYear.taxonomy # freq=1247398 freq=106633
-OrHighMedDayTaxoFacets: to significant +facets:DayOfYear.taxonomy # freq=6155577 freq=111574
-OrHighMedDayTaxoFacets: also 1976 +facets:DayOfYear.taxonomy # freq=1959419 freq=134555
-OrHighMedDayTaxoFacets: which awards +facets:DayOfYear.taxonomy # freq=1963428 freq=159679
-OrHighMedDayTaxoFacets: by blue +facets:DayOfYear.taxonomy # freq=3826691 freq=156658
-OrHighMedDayTaxoFacets: that cause +facets:DayOfYear.taxonomy # freq=2931020 freq=83898
-OrHighMedDayTaxoFacets: about began +facets:DayOfYear.taxonomy # freq=850283 freq=276036
-OrHighMedDayTaxoFacets: other entire +facets:DayOfYear.taxonomy # freq=1269961 freq=97485
-OrHighMedDayTaxoFacets: has internet +facets:DayOfYear.taxonomy # freq=1502961 freq=85510
-OrHighMedDayTaxoFacets: url highest +facets:DayOfYear.taxonomy # freq=1513595 freq=91072
-OrHighMedDayTaxoFacets: an stage +facets:DayOfYear.taxonomy # freq=2628056 freq=113041
-OrHighMedDayTaxoFacets: title imagesize +facets:DayOfYear.taxonomy # freq=2397378 freq=82746
-OrHighMedDayTaxoFacets: see span +facets:DayOfYear.taxonomy # freq=1044180 freq=146676
-OrHighMedDayTaxoFacets: states 2007 +facets:DayOfYear.taxonomy # freq=1034872 freq=801586
-OrHighMedDayTaxoFacets: in clear +facets:DayOfYear.taxonomy # freq=7320987 freq=109812
-OrHighMedDayTaxoFacets: with jean +facets:DayOfYear.taxonomy # freq=3709421 freq=84299
-OrHighMedDayTaxoFacets: other dq +facets:DayOfYear.taxonomy # freq=1269961 freq=88557
-OrHighMedDayTaxoFacets: from chris +facets:DayOfYear.taxonomy # freq=3224339 freq=85523
-OrHighMedDayTaxoFacets: no next +facets:DayOfYear.taxonomy # freq=1045000 freq=259039
-OrHighMedDayTaxoFacets: for musical +facets:DayOfYear.taxonomy # freq=4380011 freq=132600
-OrHighMedDayTaxoFacets: see came +facets:DayOfYear.taxonomy # freq=1044180 freq=197126
-OrHighMedDayTaxoFacets: two wales +facets:DayOfYear.taxonomy # freq=1104053 freq=103595
-OrHighMedDayTaxoFacets: new eastern +facets:DayOfYear.taxonomy # freq=1657293 freq=176853
-OrHighMedDayTaxoFacets: 2 marriage +facets:DayOfYear.taxonomy # freq=1549245 freq=97658
-OrHighMedDayTaxoFacets: 2009 forces +facets:DayOfYear.taxonomy # freq=887702 freq=152939
-OrHighMedDayTaxoFacets: at any +facets:DayOfYear.taxonomy # freq=2857534 freq=483514
-OrHighMedDayTaxoFacets: as live +facets:DayOfYear.taxonomy # freq=3925535 freq=242147
-OrHighMedDayTaxoFacets: see academy +facets:DayOfYear.taxonomy # freq=1044180 freq=119055
-OrHighMedDayTaxoFacets: their get +facets:DayOfYear.taxonomy # freq=1158682 freq=187847
-OrHighMedDayTaxoFacets: about via +facets:DayOfYear.taxonomy # freq=850283 freq=109090
-OrHighMedDayTaxoFacets: only fields +facets:DayOfYear.taxonomy # freq=875561 freq=86938
-OrHighMedDayTaxoFacets: time central +facets:DayOfYear.taxonomy # freq=1032071 freq=272531
-OrHighMedDayTaxoFacets: two my +facets:DayOfYear.taxonomy # freq=1104053 freq=274256
-OrHighMedDayTaxoFacets: with land +facets:DayOfYear.taxonomy # freq=3709421 freq=230284
-OrHighMedDayTaxoFacets: two financial +facets:DayOfYear.taxonomy # freq=1104053 freq=82536
-OrHighMedDayTaxoFacets: was convert +facets:DayOfYear.taxonomy # freq=3763623 freq=267974
-OrHighMedDayTaxoFacets: not course +facets:DayOfYear.taxonomy # freq=1713264 freq=106126
-OrHighMedDayTaxoFacets: 10 producer +facets:DayOfYear.taxonomy # freq=918339 freq=137098
-OrHighMedDayTaxoFacets: 3 52 +facets:DayOfYear.taxonomy # freq=1148799 freq=108395
-OrHighMedDayTaxoFacets: 2008 final +facets:DayOfYear.taxonomy # freq=831253 freq=230006
-OrHighMedDayTaxoFacets: from sir +facets:DayOfYear.taxonomy # freq=3224339 freq=107709
-OrHighMedDayTaxoFacets: to majority +facets:DayOfYear.taxonomy # freq=6155577 freq=105058
-OrHighMedDayTaxoFacets: work published +facets:DayOfYear.taxonomy # freq=853422 freq=243548
-OrHighMedDayTaxoFacets: but might +facets:DayOfYear.taxonomy # freq=1456553 freq=114290
-OrHighMedDayTaxoFacets: has radio +facets:DayOfYear.taxonomy # freq=1502961 freq=183866
-OrHighMedDayTaxoFacets: of 45 +facets:DayOfYear.taxonomy # freq=8184358 freq=180879
-OrHighMedDayTaxoFacets: some africa +facets:DayOfYear.taxonomy # freq=839919 freq=124511
-OrHighMedDayTaxoFacets: title club +facets:DayOfYear.taxonomy # freq=2397378 freq=232173
-OrHighMedDayTaxoFacets: his bgcolor +facets:DayOfYear.taxonomy # freq=1777780 freq=124305
-OrHighMedDayTaxoFacets: that opened +facets:DayOfYear.taxonomy # freq=2931020 freq=140033
-OrHighMedDayTaxoFacets: new station +facets:DayOfYear.taxonomy # freq=1657293 freq=239572
-OrHighMedDayTaxoFacets: were value +facets:DayOfYear.taxonomy # freq=1524630 freq=86806
-OrHighMedDayTaxoFacets: time end +facets:DayOfYear.taxonomy # freq=1032071 freq=526636
-OrHighMedDayTaxoFacets: date start +facets:DayOfYear.taxonomy # freq=2020626 freq=233925
-OrHighMedDayTaxoFacets: 3 across +facets:DayOfYear.taxonomy # freq=1148799 freq=134478
-OrHighMedDayTaxoFacets: 1 j +facets:DayOfYear.taxonomy # freq=1641090 freq=327713
-OrHighMedDayTaxoFacets: the ever +facets:DayOfYear.taxonomy # freq=8217362 freq=128732
-OrHighMedDayTaxoFacets: s archive +facets:DayOfYear.taxonomy # freq=1581243 freq=215381
-OrHighMedDayTaxoFacets: date style +facets:DayOfYear.taxonomy # freq=2020626 freq=606000
-OrHighMedDayTaxoFacets: 2010 caused +facets:DayOfYear.taxonomy # freq=950573 freq=86397
-OrHighMedDayTaxoFacets: or past +facets:DayOfYear.taxonomy # freq=1858841 freq=126130
-OrHighMedDayTaxoFacets: also edits +facets:DayOfYear.taxonomy # freq=1959419 freq=134321
-OrHighMedDayTaxoFacets: http stated +facets:DayOfYear.taxonomy # freq=3493581 freq=89795
-OrHighMedDayTaxoFacets: publisher association +facets:DayOfYear.taxonomy # freq=1289029 freq=247156
-OrHighMedDayTaxoFacets: other europe +facets:DayOfYear.taxonomy # freq=1269961 freq=188671
-OrHighMedDayTaxoFacets: work japan +facets:DayOfYear.taxonomy # freq=853422 freq=163103
-OrHighMedDayTaxoFacets: been committee +facets:DayOfYear.taxonomy # freq=1041183 freq=108636
-OrHighMedDayTaxoFacets: about five +facets:DayOfYear.taxonomy # freq=850283 freq=262923
-OrHighMedDayTaxoFacets: the throughout +facets:DayOfYear.taxonomy # freq=8217362 freq=143603
-OrHighMedDayTaxoFacets: first studies +facets:DayOfYear.taxonomy # freq=1933372 freq=128020
-OrHighMedDayTaxoFacets: his university +facets:DayOfYear.taxonomy # freq=1777780 freq=636959
-OrHighMedDayTaxoFacets: there legal +facets:DayOfYear.taxonomy # freq=956153 freq=90645
-OrHighMedDayTaxoFacets: all italian +facets:DayOfYear.taxonomy # freq=1203572 freq=107082
-OrHighMedDayTaxoFacets: may buildings +facets:DayOfYear.taxonomy # freq=1071932 freq=89046
-OrHighMedDayTaxoFacets: with day +facets:DayOfYear.taxonomy # freq=3709421 freq=402096
-OrHighMedDayTaxoFacets: is code +facets:DayOfYear.taxonomy # freq=4074455 freq=170156
-OrHighMedDayTaxoFacets: date asia +facets:DayOfYear.taxonomy # freq=2020626 freq=90307
-OrHighMedDayTaxoFacets: and thumb +facets:DayOfYear.taxonomy # freq=7318061 freq=672667
-OrHighMedDayTaxoFacets: 10 1970 +facets:DayOfYear.taxonomy # freq=918339 freq=139043
-OrHighMedDayTaxoFacets: from generated +facets:DayOfYear.taxonomy # freq=3224339 freq=97908
-OrHighMedDayTaxoFacets: for light +facets:DayOfYear.taxonomy # freq=4380011 freq=161671
-OrHighMedDayTaxoFacets: about 1970 +facets:DayOfYear.taxonomy # freq=850283 freq=139043
-OrHighMedDayTaxoFacets: states start +facets:DayOfYear.taxonomy # freq=1034872 freq=233925
-OrHighMedDayTaxoFacets: 2 sir +facets:DayOfYear.taxonomy # freq=1549245 freq=107709
-OrHighMedDayTaxoFacets: from information +facets:DayOfYear.taxonomy # freq=3224339 freq=353153
-OrHighMedDayTaxoFacets: 3 reflist +facets:DayOfYear.taxonomy # freq=1148799 freq=561253
-OrHighMedDayTaxoFacets: year modern +facets:DayOfYear.taxonomy # freq=1235231 freq=218831
-OrHighMedDayTaxoFacets: states successful +facets:DayOfYear.taxonomy # freq=1034872 freq=106021
-OrHighMedDayTaxoFacets: on local +facets:DayOfYear.taxonomy # freq=4074624 freq=299012
-OrHighMedDayTaxoFacets: also production +facets:DayOfYear.taxonomy # freq=1959419 freq=191554
-OrHighMedDayTaxoFacets: ref white +facets:DayOfYear.taxonomy # freq=3793973 freq=299411
-OrHighMedDayTaxoFacets: that too +facets:DayOfYear.taxonomy # freq=2931020 freq=161626
-OrHighMedDayTaxoFacets: 2 20 +facets:DayOfYear.taxonomy # freq=1549245 freq=624967
-OrHighMedDayTaxoFacets: 2008 strong +facets:DayOfYear.taxonomy # freq=831253 freq=125611
-OrHighMedDayTaxoFacets: no list +facets:DayOfYear.taxonomy # freq=1045000 freq=585922
-OrHighMedDayTaxoFacets: first label +facets:DayOfYear.taxonomy # freq=1933372 freq=159161
-OrHighMedDayTaxoFacets: see metadata +facets:DayOfYear.taxonomy # freq=1044180 freq=298533
-OrHighMedDayTaxoFacets: they before +facets:DayOfYear.taxonomy # freq=1021945 freq=580481
-OrHighMedDayTaxoFacets: been volume +facets:DayOfYear.taxonomy # freq=1041183 freq=312846
-OrHighMedDayTaxoFacets: last division +facets:DayOfYear.taxonomy # freq=958437 freq=182624
-OrHighMedDayTaxoFacets: new 1988 +facets:DayOfYear.taxonomy # freq=1657293 freq=181327
-OrHighMedDayTaxoFacets: its single +facets:DayOfYear.taxonomy # freq=1173450 freq=283824
-OrHighMedDayTaxoFacets: accessdate awards +facets:DayOfYear.taxonomy # freq=1228887 freq=159679
-OrHighMedDayTaxoFacets: of 1974 +facets:DayOfYear.taxonomy # freq=8184358 freq=132835
-OrHighMedDayTaxoFacets: and st +facets:DayOfYear.taxonomy # freq=7318061 freq=309092
-OrHighMedDayTaxoFacets: which 2002 +facets:DayOfYear.taxonomy # freq=1963428 freq=406953
-OrHighMedDayTaxoFacets: 10 role +facets:DayOfYear.taxonomy # freq=918339 freq=208579
-OrHighMedDayTaxoFacets: 2008 infobox +facets:DayOfYear.taxonomy # freq=831253 freq=524810
-OrHighMedDayTaxoFacets: by units +facets:DayOfYear.taxonomy # freq=3826691 freq=118189
-OrHighMedDayTaxoFacets: see reported +facets:DayOfYear.taxonomy # freq=1044180 freq=91533
-OrHighMedDayTaxoFacets: were love +facets:DayOfYear.taxonomy # freq=1524630 freq=177242
-OrHighMedDayTaxoFacets: their london +facets:DayOfYear.taxonomy # freq=1158682 freq=348918
-OrHighMedDayTaxoFacets: who persondata +facets:DayOfYear.taxonomy # freq=1196171 freq=246119
-OrHighMedDayTaxoFacets: be uk +facets:DayOfYear.taxonomy # freq=2051702 freq=319211
-OrHighMedDayTaxoFacets: for f +facets:DayOfYear.taxonomy # freq=4380011 freq=278015
-OrHighMedDayTaxoFacets: only hold +facets:DayOfYear.taxonomy # freq=875561 freq=82579
-OrHighMedDayTaxoFacets: new way +facets:DayOfYear.taxonomy # freq=1657293 freq=318344
-OrHighMedDayTaxoFacets: which lines +facets:DayOfYear.taxonomy # freq=1963428 freq=96969
-OrHighMedDayTaxoFacets: has div +facets:DayOfYear.taxonomy # freq=1502961 freq=206057
-OrHighMedDayTaxoFacets: all francisco +facets:DayOfYear.taxonomy # freq=1203572 freq=83200
-OrHighMedDayTaxoFacets: from per +facets:DayOfYear.taxonomy # freq=3224339 freq=283568
-OrHighMedDayTaxoFacets: it marriage +facets:DayOfYear.taxonomy # freq=2675552 freq=97658
-OrHighMedDayTaxoFacets: states small +facets:DayOfYear.taxonomy # freq=1034872 freq=581643
-OrHighMedDayTaxoFacets: 2011 july +facets:DayOfYear.taxonomy # freq=871410 freq=529655
-OrHighMedDayTaxoFacets: and mid +facets:DayOfYear.taxonomy # freq=7318061 freq=126355
-OrHighMedDayTaxoFacets: year copy +facets:DayOfYear.taxonomy # freq=1235231 freq=95252
-OrHighMedDayTaxoFacets: not ft +facets:DayOfYear.taxonomy # freq=1713264 freq=88505
-OrHighMedDayTaxoFacets: this 1988 +facets:DayOfYear.taxonomy # freq=2224932 freq=181327
-OrHighMedDayTaxoFacets: accessdate father +facets:DayOfYear.taxonomy # freq=1228887 freq=175393
-OrHighMedDayTaxoFacets: this continued +facets:DayOfYear.taxonomy # freq=2224932 freq=151209
-OrHighMedDayTaxoFacets: with union +facets:DayOfYear.taxonomy # freq=3709421 freq=214164
-OrHighMedDayTaxoFacets: 2011 festival +facets:DayOfYear.taxonomy # freq=871410 freq=85717
-OrHighMedDayTaxoFacets: states hall +facets:DayOfYear.taxonomy # freq=1034872 freq=177247
-OrHighMedDayTaxoFacets: after thomas +facets:DayOfYear.taxonomy # freq=1247398 freq=191625
-OrHighMedDayTaxoFacets: 2 god +facets:DayOfYear.taxonomy # freq=1549245 freq=97443
-OrHighMedDayTaxoFacets: states owned +facets:DayOfYear.taxonomy # freq=1034872 freq=93981
-OrHighMedDayTaxoFacets: were european +facets:DayOfYear.taxonomy # freq=1524630 freq=193975
-OrHighMedDayTaxoFacets: have jack +facets:DayOfYear.taxonomy # freq=1297121 freq=91552
-OrHighMedDayTaxoFacets: time majority +facets:DayOfYear.taxonomy # freq=1032071 freq=105058
-OrHighMedDayTaxoFacets: were went +facets:DayOfYear.taxonomy # freq=1524630 freq=172677
-OrHighMedDayTaxoFacets: only game +facets:DayOfYear.taxonomy # freq=875561 freq=315157
-OrHighMedDayTaxoFacets: a review +facets:DayOfYear.taxonomy # freq=6560531 freq=240157
-OrHighMedDayTaxoFacets: united thomas +facets:DayOfYear.taxonomy # freq=1196944 freq=191625
-OrHighMedDayTaxoFacets: may off +facets:DayOfYear.taxonomy # freq=1071932 freq=315473
-OrHighMedDayTaxoFacets: url persondata +facets:DayOfYear.taxonomy # freq=1513595 freq=246119
-OrHighMedDayTaxoFacets: new hill +facets:DayOfYear.taxonomy # freq=1657293 freq=133714
-OrHighMedDayTaxoFacets: at ice +facets:DayOfYear.taxonomy # freq=2857534 freq=87086
-OrHighMedDayTaxoFacets: 2008 fourth +facets:DayOfYear.taxonomy # freq=831253 freq=102351
-OrHighMedDayTaxoFacets: for 3rd +facets:DayOfYear.taxonomy # freq=4380011 freq=90723
-OrHighMedDayTaxoFacets: more cross +facets:DayOfYear.taxonomy # freq=963533 freq=127216
-OrHighMedDayTaxoFacets: not index.php +facets:DayOfYear.taxonomy # freq=1713264 freq=126813
-OrHighMedDayTaxoFacets: but census +facets:DayOfYear.taxonomy # freq=1456553 freq=205166
-OrHighMedDayTaxoFacets: work replaced +facets:DayOfYear.taxonomy # freq=853422 freq=112506
-OrHighMedDayTaxoFacets: some groups +facets:DayOfYear.taxonomy # freq=839919 freq=146670
-OrHighMedDayTaxoFacets: 10 collection +facets:DayOfYear.taxonomy # freq=918339 freq=110483
-OrHighMedDayTaxoFacets: not opening +facets:DayOfYear.taxonomy # freq=1713264 freq=84576
-OrHighMedDayTaxoFacets: see september +facets:DayOfYear.taxonomy # freq=1044180 freq=553409
-OrHighMedDayTaxoFacets: 4 steve +facets:DayOfYear.taxonomy # freq=986452 freq=84364
-OrHighMedDayTaxoFacets: ref appears +facets:DayOfYear.taxonomy # freq=3793973 freq=104511
-OrHighMedDayTaxoFacets: a named +facets:DayOfYear.taxonomy # freq=6560531 freq=310150
-OrHighMedDayTaxoFacets: which pre +facets:DayOfYear.taxonomy # freq=1963428 freq=90549
-OrHighMedDayTaxoFacets: has stone +facets:DayOfYear.taxonomy # freq=1502961 freq=92132
-OrHighMedDayTaxoFacets: to energy +facets:DayOfYear.taxonomy # freq=6155577 freq=91150
-OrHighMedDayTaxoFacets: not should +facets:DayOfYear.taxonomy # freq=1713264 freq=401379
-OrHighMedDayTaxoFacets: 2010 media +facets:DayOfYear.taxonomy # freq=950573 freq=206574
-OrHighMedDayTaxoFacets: was behind +facets:DayOfYear.taxonomy # freq=3763623 freq=112070
-OrHighMedDayTaxoFacets: that black +facets:DayOfYear.taxonomy # freq=2931020 freq=256526
-OrHighMedDayTaxoFacets: are itself +facets:DayOfYear.taxonomy # freq=1877802 freq=138231
-OrHighMedDayTaxoFacets: only 90 +facets:DayOfYear.taxonomy # freq=875561 freq=116206
-OrHighMedDayTaxoFacets: 4 main +facets:DayOfYear.taxonomy # freq=986452 freq=470429
-OrHighMedDayTaxoFacets: with august +facets:DayOfYear.taxonomy # freq=3709421 freq=527806
-OrHighMedDayTaxoFacets: have age +facets:DayOfYear.taxonomy # freq=1297121 freq=395368
-OrHighMedDayTaxoFacets: time citation +facets:DayOfYear.taxonomy # freq=1032071 freq=291478
-OrHighMedDayTaxoFacets: his notes +facets:DayOfYear.taxonomy # freq=1777780 freq=210029
-OrHighMedDayTaxoFacets: year 17 +facets:DayOfYear.taxonomy # freq=1235231 freq=507396
-OrHighMedDayTaxoFacets: i bbc +facets:DayOfYear.taxonomy # freq=956148 freq=138548
-OrHighMedDayTaxoFacets: name 1984 +facets:DayOfYear.taxonomy # freq=2827713 freq=161404
-OrHighMedDayTaxoFacets: his greek +facets:DayOfYear.taxonomy # freq=1777780 freq=94348
-OrHighMedDayTaxoFacets: cite votes +facets:DayOfYear.taxonomy # freq=1741194 freq=93844
-OrHighMedDayTaxoFacets: be fire +facets:DayOfYear.taxonomy # freq=2051702 freq=133712
-OrHighMedDayTaxoFacets: in sometimes +facets:DayOfYear.taxonomy # freq=7320987 freq=144078
-OrHighMedDayTaxoFacets: last better +facets:DayOfYear.taxonomy # freq=958437 freq=125889
-OrHighMedDayTaxoFacets: by considered +facets:DayOfYear.taxonomy # freq=3826691 freq=186840
-OrHighMedDayTaxoFacets: no leading +facets:DayOfYear.taxonomy # freq=1045000 freq=120945
-OrHighMedDayTaxoFacets: name influence +facets:DayOfYear.taxonomy # freq=2827713 freq=83101
-OrHighMedDayTaxoFacets: 2009 power +facets:DayOfYear.taxonomy # freq=887702 freq=262586
-OrHighMedDayTaxoFacets: is institute +facets:DayOfYear.taxonomy # freq=4074455 freq=136311
-OrHighMedDayTaxoFacets: into doi +facets:DayOfYear.taxonomy # freq=888684 freq=170085
-OrHighMedDayTaxoFacets: into short +facets:DayOfYear.taxonomy # freq=888684 freq=465205
-OrHighMedDayTaxoFacets: were gr +facets:DayOfYear.taxonomy # freq=1524630 freq=83712
-OrHighMedDayTaxoFacets: has 16 +facets:DayOfYear.taxonomy # freq=1502961 freq=540539
-OrHighMedDayTaxoFacets: this towards +facets:DayOfYear.taxonomy # freq=2224932 freq=95574
-OrHighMedDayTaxoFacets: the div +facets:DayOfYear.taxonomy # freq=8217362 freq=206057
-OrHighMedDayTaxoFacets: its jean +facets:DayOfYear.taxonomy # freq=1173450 freq=84299
-OrHighMedDayTaxoFacets: their continued +facets:DayOfYear.taxonomy # freq=1158682 freq=151209
-OrHighMedDayTaxoFacets: publisher come +facets:DayOfYear.taxonomy # freq=1289029 freq=139047
-OrHighMedDayTaxoFacets: name yet +facets:DayOfYear.taxonomy # freq=2827713 freq=100857
-OrHighMedDayTaxoFacets: be before +facets:DayOfYear.taxonomy # freq=2051702 freq=580481
-OrHighMedDayTaxoFacets: ref britain +facets:DayOfYear.taxonomy # freq=3793973 freq=101080
-OrHighMedDayTaxoFacets: 10 returned +facets:DayOfYear.taxonomy # freq=918339 freq=141639
-OrHighMedDayTaxoFacets: 2006 02 +facets:DayOfYear.taxonomy # freq=889954 freq=319783
-OrHighMedDayTaxoFacets: 2011 daughter +facets:DayOfYear.taxonomy # freq=871410 freq=103883
-OrHighMedDayTaxoFacets: be independent +facets:DayOfYear.taxonomy # freq=2051702 freq=164766
-OrHighMedDayTaxoFacets: more self +facets:DayOfYear.taxonomy # freq=963533 freq=135012
-OrHighMedDayTaxoFacets: in particular +facets:DayOfYear.taxonomy # freq=7320987 freq=103643
-OrHighMedDayTaxoFacets: which non +facets:DayOfYear.taxonomy # freq=1963428 freq=348142
-OrHighMedDayTaxoFacets: his birth +facets:DayOfYear.taxonomy # freq=1777780 freq=425138
-OrHighMedDayTaxoFacets: ref stations +facets:DayOfYear.taxonomy # freq=3793973 freq=92011
-OrHighMedDayTaxoFacets: united include +facets:DayOfYear.taxonomy # freq=1196944 freq=276466
-OrHighMedDayTaxoFacets: http flight +facets:DayOfYear.taxonomy # freq=3493581 freq=84316
-OrHighMedDayTaxoFacets: http singles +facets:DayOfYear.taxonomy # freq=3493581 freq=89221
-OrHighMedDayTaxoFacets: year northern +facets:DayOfYear.taxonomy # freq=1235231 freq=194363
-OrHighMedDayTaxoFacets: been htm +facets:DayOfYear.taxonomy # freq=1041183 freq=191479
-OrHighMedDayTaxoFacets: one alone +facets:DayOfYear.taxonomy # freq=1527689 freq=93166
-OrHighMedDayTaxoFacets: their systems +facets:DayOfYear.taxonomy # freq=1158682 freq=134476
-OrHighMedDayTaxoFacets: to yet +facets:DayOfYear.taxonomy # freq=6155577 freq=100857
-OrHighMedDayTaxoFacets: see leader +facets:DayOfYear.taxonomy # freq=1044180 freq=127591
-OrHighMedDayTaxoFacets: on seen +facets:DayOfYear.taxonomy # freq=4074624 freq=173530
-OrHighMedDayTaxoFacets: has 200px +facets:DayOfYear.taxonomy # freq=1502961 freq=102661
-OrHighMedDayTaxoFacets: that 56 +facets:DayOfYear.taxonomy # freq=2931020 freq=96215
-OrHighMedDayTaxoFacets: about women +facets:DayOfYear.taxonomy # freq=850283 freq=128847
-OrHighMedDayTaxoFacets: only michael +facets:DayOfYear.taxonomy # freq=875561 freq=217311
-OrHighMedDayTaxoFacets: 2009 provided +facets:DayOfYear.taxonomy # freq=887702 freq=110088
-OrHighMedDayTaxoFacets: with show +facets:DayOfYear.taxonomy # freq=3709421 freq=293934
-OrHighMedDayTaxoFacets: 2011 utc +facets:DayOfYear.taxonomy # freq=871410 freq=450225
-OrHighMedDayTaxoFacets: which give +facets:DayOfYear.taxonomy # freq=1963428 freq=116375
-OrHighMedDayTaxoFacets: 2010 support +facets:DayOfYear.taxonomy # freq=950573 freq=236989
-OrHighMedDayTaxoFacets: 4 very +facets:DayOfYear.taxonomy # freq=986452 freq=354898
-OrHighMedDayTaxoFacets: 2 foreign +facets:DayOfYear.taxonomy # freq=1549245 freq=109174
-OrHighMedDayTaxoFacets: were 59 +facets:DayOfYear.taxonomy # freq=1524630 freq=93856
-OrHighMedDayTaxoFacets: 2010 take +facets:DayOfYear.taxonomy # freq=950573 freq=224260
-OrHighMedDayTaxoFacets: by york +facets:DayOfYear.taxonomy # freq=3826691 freq=521383
-OrHighMedDayTaxoFacets: http kingdom +facets:DayOfYear.taxonomy # freq=3493581 freq=299825
-OrHighMedDayTaxoFacets: only brother +facets:DayOfYear.taxonomy # freq=875561 freq=110146
-OrHighMedDayTaxoFacets: no died +facets:DayOfYear.taxonomy # freq=1045000 freq=202125
-OrHighMedDayTaxoFacets: other november +facets:DayOfYear.taxonomy # freq=1269961 freq=527131
-OrHighMedDayTaxoFacets: 2008 system +facets:DayOfYear.taxonomy # freq=831253 freq=412862
-OrHighMedDayTaxoFacets: 5 still +facets:DayOfYear.taxonomy # freq=891361 freq=332543
-OrHighMedDayTaxoFacets: by required +facets:DayOfYear.taxonomy # freq=3826691 freq=100578
-OrHighMedDayTaxoFacets: title era +facets:DayOfYear.taxonomy # freq=2397378 freq=95989
-OrHighMedDayTaxoFacets: 3 larger +facets:DayOfYear.taxonomy # freq=1148799 freq=87424
-OrHighMedDayTaxoFacets: into within +facets:DayOfYear.taxonomy # freq=888684 freq=291049
-OrHighMedDayTaxoFacets: http where +facets:DayOfYear.taxonomy # freq=3493581 freq=630647
-OrHighMedDayTaxoFacets: united say +facets:DayOfYear.taxonomy # freq=1196944 freq=110895
-OrHighMedDayTaxoFacets: no second +facets:DayOfYear.taxonomy # freq=1045000 freq=505575
-OrHighMedDayTaxoFacets: work 1998 +facets:DayOfYear.taxonomy # freq=853422 freq=300506
-OrHighMedDayTaxoFacets: 1 think +facets:DayOfYear.taxonomy # freq=1641090 freq=129332
-OrHighMedDayTaxoFacets: by b +facets:DayOfYear.taxonomy # freq=3826691 freq=369454
-OrHighMedDayTaxoFacets: 4 thumb +facets:DayOfYear.taxonomy # freq=986452 freq=672667
-OrHighMedDayTaxoFacets: be usa +facets:DayOfYear.taxonomy # freq=2051702 freq=191220
-OrHighMedDayTaxoFacets: not african +facets:DayOfYear.taxonomy # freq=1713264 freq=128682
-OrHighMedDayTaxoFacets: 1 president +facets:DayOfYear.taxonomy # freq=1641090 freq=263341
-OrHighMedDayTaxoFacets: 4 worked +facets:DayOfYear.taxonomy # freq=986452 freq=119896
-OrHighMedDayTaxoFacets: http added +facets:DayOfYear.taxonomy # freq=3493581 freq=138409
-OrHighMedDayTaxoFacets: s deletion +facets:DayOfYear.taxonomy # freq=1581243 freq=166633
-OrHighMedDayTaxoFacets: time nbsp +facets:DayOfYear.taxonomy # freq=1032071 freq=506054
-OrHighMedDayTaxoFacets: when 02 +facets:DayOfYear.taxonomy # freq=1027487 freq=319783
-OrHighMedDayTaxoFacets: may la +facets:DayOfYear.taxonomy # freq=1071932 freq=232610
-OrHighMedDayTaxoFacets: 2 royal +facets:DayOfYear.taxonomy # freq=1549245 freq=211710
-OrHighMedDayTaxoFacets: from office +facets:DayOfYear.taxonomy # freq=3224339 freq=225338
-OrHighMedDayTaxoFacets: and 22 +facets:DayOfYear.taxonomy # freq=7318061 freq=502778
-OrHighMedDayTaxoFacets: cite order +facets:DayOfYear.taxonomy # freq=1741194 freq=360915
-OrHighMedDayTaxoFacets: of upper +facets:DayOfYear.taxonomy # freq=8184358 freq=86379
-OrHighMedDayTaxoFacets: all htm +facets:DayOfYear.taxonomy # freq=1203572 freq=191479
-OrHighMedDayTaxoFacets: he towards +facets:DayOfYear.taxonomy # freq=1659434 freq=95574
-OrHighMedDayTaxoFacets: are traditional +facets:DayOfYear.taxonomy # freq=1877802 freq=110425
-OrHighMedDayTaxoFacets: a team +facets:DayOfYear.taxonomy # freq=6560531 freq=379028
-OrHighMedDayTaxoFacets: or imagesize +facets:DayOfYear.taxonomy # freq=1858841 freq=82746
-OrHighMedDayTaxoFacets: date regular +facets:DayOfYear.taxonomy # freq=2020626 freq=93809
-OrHighMedDayTaxoFacets: or birth_date +facets:DayOfYear.taxonomy # freq=1858841 freq=122665
-OrHighMedDayTaxoFacets: name each +facets:DayOfYear.taxonomy # freq=2827713 freq=354583
-OrHighMedDayTaxoFacets: but begin +facets:DayOfYear.taxonomy # freq=1456553 freq=104303
-OrHighMedDayTaxoFacets: 2 developed +facets:DayOfYear.taxonomy # freq=1549245 freq=151220
-OrHighMedDayTaxoFacets: ref note +facets:DayOfYear.taxonomy # freq=3793973 freq=194472
-OrHighMedDayTaxoFacets: united programs +facets:DayOfYear.taxonomy # freq=1196944 freq=83974
+MedTermDayTaxoFacets: most +facets:taxonomy:DayOfYear # freq=819634
+MedTermDayTaxoFacets: up +facets:taxonomy:DayOfYear # freq=818546
+MedTermDayTaxoFacets: world +facets:taxonomy:DayOfYear # freq=808563
+MedTermDayTaxoFacets: 2007 +facets:taxonomy:DayOfYear # freq=801586
+MedTermDayTaxoFacets: during +facets:taxonomy:DayOfYear # freq=798114
+MedTermDayTaxoFacets: people +facets:taxonomy:DayOfYear # freq=790960
+MedTermDayTaxoFacets: years +facets:taxonomy:DayOfYear # freq=789628
+MedTermDayTaxoFacets: such +facets:taxonomy:DayOfYear # freq=787877
+MedTermDayTaxoFacets: 12 +facets:taxonomy:DayOfYear # freq=774572
+MedTermDayTaxoFacets: over +facets:taxonomy:DayOfYear # freq=774312
+MedTermDayTaxoFacets: can +facets:taxonomy:DayOfYear # freq=765163
+MedTermDayTaxoFacets: references +facets:taxonomy:DayOfYear # freq=760306
+MedTermDayTaxoFacets: city +facets:taxonomy:DayOfYear # freq=760272
+MedTermDayTaxoFacets: 6 +facets:taxonomy:DayOfYear # freq=759234
+MedTermDayTaxoFacets: american +facets:taxonomy:DayOfYear # freq=758337
+MedTermDayTaxoFacets: news +facets:taxonomy:DayOfYear # freq=756063
+MedTermDayTaxoFacets: history +facets:taxonomy:DayOfYear # freq=755471
+MedTermDayTaxoFacets: 0 +facets:taxonomy:DayOfYear # freq=754451
+MedTermDayTaxoFacets: made +facets:taxonomy:DayOfYear # freq=742313
+MedTermDayTaxoFacets: out +facets:taxonomy:DayOfYear # freq=733775
+MedTermDayTaxoFacets: 11 +facets:taxonomy:DayOfYear # freq=730505
+MedTermDayTaxoFacets: used +facets:taxonomy:DayOfYear # freq=708455
+MedTermDayTaxoFacets: links +facets:taxonomy:DayOfYear # freq=703350
+MedTermDayTaxoFacets: state +facets:taxonomy:DayOfYear # freq=702598
+MedTermDayTaxoFacets: many +facets:taxonomy:DayOfYear # freq=694439
+MedTermDayTaxoFacets: would +facets:taxonomy:DayOfYear # freq=690480
+MedTermDayTaxoFacets: page +facets:taxonomy:DayOfYear # freq=681036
+MedTermDayTaxoFacets: national +facets:taxonomy:DayOfYear # freq=677281
+MedTermDayTaxoFacets: than +facets:taxonomy:DayOfYear # freq=676864
+MedTermDayTaxoFacets: thumb +facets:taxonomy:DayOfYear # freq=672667
+MedTermDayTaxoFacets: 7 +facets:taxonomy:DayOfYear # freq=660220
+MedTermDayTaxoFacets: place +facets:taxonomy:DayOfYear # freq=654158
+MedTermDayTaxoFacets: de +facets:taxonomy:DayOfYear # freq=652242
+MedTermDayTaxoFacets: if +facets:taxonomy:DayOfYear # freq=640551
+MedTermDayTaxoFacets: university +facets:taxonomy:DayOfYear # freq=636959
+MedTermDayTaxoFacets: 8 +facets:taxonomy:DayOfYear # freq=635822
+MedTermDayTaxoFacets: external +facets:taxonomy:DayOfYear # freq=635450
+MedTermDayTaxoFacets: between +facets:taxonomy:DayOfYear # freq=630650
+MedTermDayTaxoFacets: where +facets:taxonomy:DayOfYear # freq=630647
+MedTermDayTaxoFacets: right +facets:taxonomy:DayOfYear # freq=630423
+MedTermDayTaxoFacets: 20 +facets:taxonomy:DayOfYear # freq=624967
+MedTermDayTaxoFacets: under +facets:taxonomy:DayOfYear # freq=623872
+MedTermDayTaxoFacets: these +facets:taxonomy:DayOfYear # freq=623267
+MedTermDayTaxoFacets: march +facets:taxonomy:DayOfYear # freq=620393
+MedTermDayTaxoFacets: br +facets:taxonomy:DayOfYear # freq=617824
+MedTermDayTaxoFacets: book +facets:taxonomy:DayOfYear # freq=617297
+MedTermDayTaxoFacets: p +facets:taxonomy:DayOfYear # freq=616159
+MedTermDayTaxoFacets: article +facets:taxonomy:DayOfYear # freq=610650
+MedTermDayTaxoFacets: known +facets:taxonomy:DayOfYear # freq=607158
+MedTermDayTaxoFacets: then +facets:taxonomy:DayOfYear # freq=606159
+MedTermDayTaxoFacets: style +facets:taxonomy:DayOfYear # freq=606000
+MedTermDayTaxoFacets: later +facets:taxonomy:DayOfYear # freq=604921
+MedTermDayTaxoFacets: three +facets:taxonomy:DayOfYear # freq=598349
+MedTermDayTaxoFacets: use +facets:taxonomy:DayOfYear # freq=597053
+MedTermDayTaxoFacets: category +facets:taxonomy:DayOfYear # freq=595446
+MedTermDayTaxoFacets: john +facets:taxonomy:DayOfYear # freq=594461
+MedTermDayTaxoFacets: part +facets:taxonomy:DayOfYear # freq=594224
+MedTermDayTaxoFacets: left +facets:taxonomy:DayOfYear # freq=593967
+MedTermDayTaxoFacets: 2004 +facets:taxonomy:DayOfYear # freq=593934
+MedTermDayTaxoFacets: 15 +facets:taxonomy:DayOfYear # freq=592407
+MedTermDayTaxoFacets: december +facets:taxonomy:DayOfYear # freq=590171
+MedTermDayTaxoFacets: april +facets:taxonomy:DayOfYear # freq=587542
+MedTermDayTaxoFacets: list +facets:taxonomy:DayOfYear # freq=585922
+MedTermDayTaxoFacets: 18 +facets:taxonomy:DayOfYear # freq=585631
+MedTermDayTaxoFacets: small +facets:taxonomy:DayOfYear # freq=581643
+MedTermDayTaxoFacets: january +facets:taxonomy:DayOfYear # freq=581309
+MedTermDayTaxoFacets: before +facets:taxonomy:DayOfYear # freq=580481
+MedTermDayTaxoFacets: being +facets:taxonomy:DayOfYear # freq=580185
+MedTermDayTaxoFacets: well +facets:taxonomy:DayOfYear # freq=580011
+MedTermDayTaxoFacets: id +facets:taxonomy:DayOfYear # freq=579566
+MedTermDayTaxoFacets: while +facets:taxonomy:DayOfYear # freq=579117
+MedTermDayTaxoFacets: 9 +facets:taxonomy:DayOfYear # freq=574434
+MedTermDayTaxoFacets: death +facets:taxonomy:DayOfYear # freq=568895
+MedTermDayTaxoFacets: author +facets:taxonomy:DayOfYear # freq=567768
+MedTermDayTaxoFacets: however +facets:taxonomy:DayOfYear # freq=566494
+MedTermDayTaxoFacets: october +facets:taxonomy:DayOfYear # freq=566229
+MedTermDayTaxoFacets: north +facets:taxonomy:DayOfYear # freq=564195
+MedTermDayTaxoFacets: so +facets:taxonomy:DayOfYear # freq=562598
+MedTermDayTaxoFacets: reflist +facets:taxonomy:DayOfYear # freq=561253
+MedTermDayTaxoFacets: south +facets:taxonomy:DayOfYear # freq=560468
+MedTermDayTaxoFacets: area +facets:taxonomy:DayOfYear # freq=559023
+MedTermDayTaxoFacets: class +facets:taxonomy:DayOfYear # freq=556838
+MedTermDayTaxoFacets: september +facets:taxonomy:DayOfYear # freq=553409
+MedTermDayTaxoFacets: war +facets:taxonomy:DayOfYear # freq=547417
+MedTermDayTaxoFacets: image +facets:taxonomy:DayOfYear # freq=541747
+MedTermDayTaxoFacets: 16 +facets:taxonomy:DayOfYear # freq=540539
+MedTermDayTaxoFacets: both +facets:taxonomy:DayOfYear # freq=534900
+MedTermDayTaxoFacets: 14 +facets:taxonomy:DayOfYear # freq=534005
+MedTermDayTaxoFacets: 13 +facets:taxonomy:DayOfYear # freq=530419
+MedTermDayTaxoFacets: july +facets:taxonomy:DayOfYear # freq=529655
+MedTermDayTaxoFacets: august +facets:taxonomy:DayOfYear # freq=527806
+MedTermDayTaxoFacets: november +facets:taxonomy:DayOfYear # freq=527131
+MedTermDayTaxoFacets: end +facets:taxonomy:DayOfYear # freq=526636
+MedTermDayTaxoFacets: february +facets:taxonomy:DayOfYear # freq=524886
+MedTermDayTaxoFacets: infobox +facets:taxonomy:DayOfYear # freq=524810
+MedTermDayTaxoFacets: june +facets:taxonomy:DayOfYear # freq=522519
+MedTermDayTaxoFacets: series +facets:taxonomy:DayOfYear # freq=521861
+MedTermDayTaxoFacets: york +facets:taxonomy:DayOfYear # freq=521383
+MedTermDayTaxoFacets: including +facets:taxonomy:DayOfYear # freq=521324
+MedTermDayTaxoFacets: county +facets:taxonomy:DayOfYear # freq=521126
+MedTermDayTaxoFacets: them +facets:taxonomy:DayOfYear # freq=520298
+MedTermDayTaxoFacets: her +facets:taxonomy:DayOfYear # freq=518717
+MedTermDayTaxoFacets: through +facets:taxonomy:DayOfYear # freq=514966
+MedTermDayTaxoFacets: do +facets:taxonomy:DayOfYear # freq=511178
+MedTermDayTaxoFacets: 17 +facets:taxonomy:DayOfYear # freq=507396
+MedTermDayTaxoFacets: him +facets:taxonomy:DayOfYear # freq=507350
+MedTermDayTaxoFacets: nbsp +facets:taxonomy:DayOfYear # freq=506054
+MedTermDayTaxoFacets: second +facets:taxonomy:DayOfYear # freq=505575
+MedTermDayTaxoFacets: 22 +facets:taxonomy:DayOfYear # freq=502778
+MedTermDayTaxoFacets: html +facets:taxonomy:DayOfYear # freq=500198
+MedTermDayTaxoFacets: 2000 +facets:taxonomy:DayOfYear # freq=499639
+MedTermDayTaxoFacets: 25 +facets:taxonomy:DayOfYear # freq=491957
+MedTermDayTaxoFacets: location +facets:taxonomy:DayOfYear # freq=489791
+MedTermDayTaxoFacets: will +facets:taxonomy:DayOfYear # freq=489711
+MedTermDayTaxoFacets: center +facets:taxonomy:DayOfYear # freq=489673
+MedTermDayTaxoFacets: 30 +facets:taxonomy:DayOfYear # freq=488930
+MedTermDayTaxoFacets: since +facets:taxonomy:DayOfYear # freq=485325
+MedTermDayTaxoFacets: 19 +facets:taxonomy:DayOfYear # freq=484187
+MedTermDayTaxoFacets: now +facets:taxonomy:DayOfYear # freq=484114
+MedTermDayTaxoFacets: any +facets:taxonomy:DayOfYear # freq=483514
+MedTermDayTaxoFacets: early +facets:taxonomy:DayOfYear # freq=482793
+MedTermDayTaxoFacets: 21 +facets:taxonomy:DayOfYear # freq=482314
+MedTermDayTaxoFacets: high +facets:taxonomy:DayOfYear # freq=482152
+MedTermDayTaxoFacets: like +facets:taxonomy:DayOfYear # freq=479390
+MedTermDayTaxoFacets: life +facets:taxonomy:DayOfYear # freq=477007
+MedTermDayTaxoFacets: general +facets:taxonomy:DayOfYear # freq=476690
+MedTermDayTaxoFacets: music +facets:taxonomy:DayOfYear # freq=473240
+MedTermDayTaxoFacets: number +facets:taxonomy:DayOfYear # freq=473154
+MedTermDayTaxoFacets: 24 +facets:taxonomy:DayOfYear # freq=470708
+MedTermDayTaxoFacets: main +facets:taxonomy:DayOfYear # freq=470429
+MedTermDayTaxoFacets: isbn +facets:taxonomy:DayOfYear # freq=467574
+MedTermDayTaxoFacets: pages +facets:taxonomy:DayOfYear # freq=466290
+MedTermDayTaxoFacets: became +facets:taxonomy:DayOfYear # freq=465594
+MedTermDayTaxoFacets: short +facets:taxonomy:DayOfYear # freq=465205
+MedTermDayTaxoFacets: school +facets:taxonomy:DayOfYear # freq=462166
+MedTermDayTaxoFacets: you +facets:taxonomy:DayOfYear # freq=461587
+MedTermDayTaxoFacets: 23 +facets:taxonomy:DayOfYear # freq=457097
+MedTermDayTaxoFacets: 2003 +facets:taxonomy:DayOfYear # freq=456990
+MedTermDayTaxoFacets: called +facets:taxonomy:DayOfYear # freq=454580
+MedTermDayTaxoFacets: utc +facets:taxonomy:DayOfYear # freq=450225
+MedTermDayTaxoFacets: n +facets:taxonomy:DayOfYear # freq=449994
+MedTermDayTaxoFacets: c +facets:taxonomy:DayOfYear # freq=444247
+MedTermDayTaxoFacets: group +facets:taxonomy:DayOfYear # freq=442503
+MedTermDayTaxoFacets: m +facets:taxonomy:DayOfYear # freq=441232
+MedTermDayTaxoFacets: several +facets:taxonomy:DayOfYear # freq=436129
+MedTermDayTaxoFacets: website +facets:taxonomy:DayOfYear # freq=435941
+MedTermDayTaxoFacets: film +facets:taxonomy:DayOfYear # freq=432758
+MedTermDayTaxoFacets: west +facets:taxonomy:DayOfYear # freq=431006
+MedTermDayTaxoFacets: u.s +facets:taxonomy:DayOfYear # freq=428534
+MedTermDayTaxoFacets: she +facets:taxonomy:DayOfYear # freq=426267
+MedTermDayTaxoFacets: until +facets:taxonomy:DayOfYear # freq=425389
+MedTermDayTaxoFacets: birth +facets:taxonomy:DayOfYear # freq=425138
+MedTermDayTaxoFacets: us +facets:taxonomy:DayOfYear # freq=421210
+MedTermDayTaxoFacets: same +facets:taxonomy:DayOfYear # freq=420741
+MedTermDayTaxoFacets: country +facets:taxonomy:DayOfYear # freq=420052
+MedTermDayTaxoFacets: international +facets:taxonomy:DayOfYear # freq=418261
+MedTermDayTaxoFacets: british +facets:taxonomy:DayOfYear # freq=417307
+MedTermDayTaxoFacets: language +facets:taxonomy:DayOfYear # freq=416771
+MedTermDayTaxoFacets: following +facets:taxonomy:DayOfYear # freq=416515
+MedTermDayTaxoFacets: because +facets:taxonomy:DayOfYear # freq=413003
+MedTermDayTaxoFacets: system +facets:taxonomy:DayOfYear # freq=412862
+MedTermDayTaxoFacets: english +facets:taxonomy:DayOfYear # freq=412061
+MedTermDayTaxoFacets: 2001 +facets:taxonomy:DayOfYear # freq=410364
+MedTermDayTaxoFacets: e +facets:taxonomy:DayOfYear # freq=408741
+MedTermDayTaxoFacets: times +facets:taxonomy:DayOfYear # freq=407155
+MedTermDayTaxoFacets: 2002 +facets:taxonomy:DayOfYear # freq=406953
+MedTermDayTaxoFacets: names +facets:taxonomy:DayOfYear # freq=404796
+MedTermDayTaxoFacets: w +facets:taxonomy:DayOfYear # freq=404764
+MedTermDayTaxoFacets: day +facets:taxonomy:DayOfYear # freq=402096
+MedTermDayTaxoFacets: should +facets:taxonomy:DayOfYear # freq=401379
+MedTermDayTaxoFacets: against +facets:taxonomy:DayOfYear # freq=399228
+MedTermDayTaxoFacets: press +facets:taxonomy:DayOfYear # freq=398988
+MedTermDayTaxoFacets: based +facets:taxonomy:DayOfYear # freq=398415
+MedTermDayTaxoFacets: age +facets:taxonomy:DayOfYear # freq=395368
+MedTermDayTaxoFacets: what +facets:taxonomy:DayOfYear # freq=394675
+MedTermDayTaxoFacets: party +facets:taxonomy:DayOfYear # freq=394410
+MedTermDayTaxoFacets: company +facets:taxonomy:DayOfYear # freq=391520
+MedTermDayTaxoFacets: four +facets:taxonomy:DayOfYear # freq=389818
+MedTermDayTaxoFacets: 28 +facets:taxonomy:DayOfYear # freq=389552
+MedTermDayTaxoFacets: 26 +facets:taxonomy:DayOfYear # freq=389026
+MedTermDayTaxoFacets: family +facets:taxonomy:DayOfYear # freq=387175
+MedTermDayTaxoFacets: long +facets:taxonomy:DayOfYear # freq=385787
+MedTermDayTaxoFacets: century +facets:taxonomy:DayOfYear # freq=385541
+MedTermDayTaxoFacets: government +facets:taxonomy:DayOfYear # freq=384004
+MedTermDayTaxoFacets: 27 +facets:taxonomy:DayOfYear # freq=383042
+MedTermDayTaxoFacets: old +facets:taxonomy:DayOfYear # freq=381809
+MedTermDayTaxoFacets: team +facets:taxonomy:DayOfYear # freq=379028
+MedTermDayTaxoFacets: house +facets:taxonomy:DayOfYear # freq=377336
+MedTermDayTaxoFacets: population +facets:taxonomy:DayOfYear # freq=374481
+MedTermDayTaxoFacets: 29 +facets:taxonomy:DayOfYear # freq=372091
+MedTermDayTaxoFacets: b +facets:taxonomy:DayOfYear # freq=369454
+MedTermDayTaxoFacets: public +facets:taxonomy:DayOfYear # freq=368868
+MedTermDayTaxoFacets: home +facets:taxonomy:DayOfYear # freq=367819
+MedTermDayTaxoFacets: top +facets:taxonomy:DayOfYear # freq=364628
+MedTermDayTaxoFacets: east +facets:taxonomy:DayOfYear # freq=364582
+MedTermDayTaxoFacets: talk +facets:taxonomy:DayOfYear # freq=364194
+MedTermDayTaxoFacets: order +facets:taxonomy:DayOfYear # freq=360915
+MedTermDayTaxoFacets: line +facets:taxonomy:DayOfYear # freq=360442
+MedTermDayTaxoFacets: could +facets:taxonomy:DayOfYear # freq=356679
+MedTermDayTaxoFacets: 2012 +facets:taxonomy:DayOfYear # freq=355641
+MedTermDayTaxoFacets: description +facets:taxonomy:DayOfYear # freq=355070
+MedTermDayTaxoFacets: very +facets:taxonomy:DayOfYear # freq=354898
+MedTermDayTaxoFacets: each +facets:taxonomy:DayOfYear # freq=354583
+MedTermDayTaxoFacets: information +facets:taxonomy:DayOfYear # freq=353153
+MedTermDayTaxoFacets: another +facets:taxonomy:DayOfYear # freq=352496
+MedTermDayTaxoFacets: born +facets:taxonomy:DayOfYear # freq=352196
+MedTermDayTaxoFacets: back +facets:taxonomy:DayOfYear # freq=349276
+MedTermDayTaxoFacets: london +facets:taxonomy:DayOfYear # freq=348918
+MedTermDayTaxoFacets: just +facets:taxonomy:DayOfYear # freq=348911
+MedTermDayTaxoFacets: town +facets:taxonomy:DayOfYear # freq=348598
+MedTermDayTaxoFacets: journal +facets:taxonomy:DayOfYear # freq=348162
+MedTermDayTaxoFacets: non +facets:taxonomy:DayOfYear # freq=348142
+MedTermDayTaxoFacets: color +facets:taxonomy:DayOfYear # freq=347941
+MedTermDayTaxoFacets: 01 +facets:taxonomy:DayOfYear # freq=347922
+MedTermDayTaxoFacets: great +facets:taxonomy:DayOfYear # freq=347499
+MedTermDayTaxoFacets: although +facets:taxonomy:DayOfYear # freq=341432
+MedTermDayTaxoFacets: books +facets:taxonomy:DayOfYear # freq=341376
+MedTermDayTaxoFacets: ii +facets:taxonomy:DayOfYear # freq=340800
+MedTermDayTaxoFacets: major +facets:taxonomy:DayOfYear # freq=340345
+MedTermDayTaxoFacets: further +facets:taxonomy:DayOfYear # freq=339350
+MedTermDayTaxoFacets: 1999 +facets:taxonomy:DayOfYear # freq=334887
+MedTermDayTaxoFacets: around +facets:taxonomy:DayOfYear # freq=334840
+MedTermDayTaxoFacets: best +facets:taxonomy:DayOfYear # freq=334550
+MedTermDayTaxoFacets: former +facets:taxonomy:DayOfYear # freq=332750
+MedTermDayTaxoFacets: still +facets:taxonomy:DayOfYear # freq=332543
+MedTermDayTaxoFacets: album +facets:taxonomy:DayOfYear # freq=331360
+MedTermDayTaxoFacets: stub +facets:taxonomy:DayOfYear # freq=329768
+MedTermDayTaxoFacets: did +facets:taxonomy:DayOfYear # freq=328303
+MedTermDayTaxoFacets: j +facets:taxonomy:DayOfYear # freq=327713
+MedTermDayTaxoFacets: even +facets:taxonomy:DayOfYear # freq=326231
+MedTermDayTaxoFacets: official +facets:taxonomy:DayOfYear # freq=326177
+MedTermDayTaxoFacets: original +facets:taxonomy:DayOfYear # freq=323521
+MedTermDayTaxoFacets: user +facets:taxonomy:DayOfYear # freq=323242
+MedTermDayTaxoFacets: alternative +facets:taxonomy:DayOfYear # freq=322536
+MedTermDayTaxoFacets: released +facets:taxonomy:DayOfYear # freq=322473
+MedTermDayTaxoFacets: jpg +facets:taxonomy:DayOfYear # freq=322278
+MedTermDayTaxoFacets: issue +facets:taxonomy:DayOfYear # freq=322106
+MedTermDayTaxoFacets: own +facets:taxonomy:DayOfYear # freq=321703
+MedTermDayTaxoFacets: season +facets:taxonomy:DayOfYear # freq=320228
+MedTermDayTaxoFacets: those +facets:taxonomy:DayOfYear # freq=320013
+MedTermDayTaxoFacets: 02 +facets:taxonomy:DayOfYear # freq=319783
+MedTermDayTaxoFacets: uk +facets:taxonomy:DayOfYear # freq=319211
+MedTermDayTaxoFacets: way +facets:taxonomy:DayOfYear # freq=318344
+MedTermDayTaxoFacets: type +facets:taxonomy:DayOfYear # freq=318210
+MedTermDayTaxoFacets: 03 +facets:taxonomy:DayOfYear # freq=318112
+MedTermDayTaxoFacets: england +facets:taxonomy:DayOfYear # freq=317884
+MedTermDayTaxoFacets: much +facets:taxonomy:DayOfYear # freq=317670
+MedTermDayTaxoFacets: off +facets:taxonomy:DayOfYear # freq=315473
+MedTermDayTaxoFacets: game +facets:taxonomy:DayOfYear # freq=315157
+MedTermDayTaxoFacets: background +facets:taxonomy:DayOfYear # freq=314229
+MedTermDayTaxoFacets: 04 +facets:taxonomy:DayOfYear # freq=313827
+MedTermDayTaxoFacets: found +facets:taxonomy:DayOfYear # freq=313247
+MedTermDayTaxoFacets: volume +facets:taxonomy:DayOfYear # freq=312846
+MedTermDayTaxoFacets: named +facets:taxonomy:DayOfYear # freq=310150
+MedTermDayTaxoFacets: service +facets:taxonomy:DayOfYear # freq=309976
+MedTermDayTaxoFacets: d +facets:taxonomy:DayOfYear # freq=309729
+MedTermDayTaxoFacets: st +facets:taxonomy:DayOfYear # freq=309092
+MedTermDayTaxoFacets: large +facets:taxonomy:DayOfYear # freq=308888
+MedTermDayTaxoFacets: often +facets:taxonomy:DayOfYear # freq=307684
+MedTermDayTaxoFacets: 06 +facets:taxonomy:DayOfYear # freq=305698
+MedTermDayTaxoFacets: 05 +facets:taxonomy:DayOfYear # freq=302860
+MedTermDayTaxoFacets: 1998 +facets:taxonomy:DayOfYear # freq=300506
+MedTermDayTaxoFacets: align +facets:taxonomy:DayOfYear # freq=300455
+MedTermDayTaxoFacets: kingdom +facets:taxonomy:DayOfYear # freq=299825
+MedTermDayTaxoFacets: using +facets:taxonomy:DayOfYear # freq=299474
+MedTermDayTaxoFacets: white +facets:taxonomy:DayOfYear # freq=299411
+MedTermDayTaxoFacets: 07 +facets:taxonomy:DayOfYear # freq=299351
+MedTermDayTaxoFacets: district +facets:taxonomy:DayOfYear # freq=299108
+MedTermDayTaxoFacets: local +facets:taxonomy:DayOfYear # freq=299012
+MedTermDayTaxoFacets: metadata +facets:taxonomy:DayOfYear # freq=298533
+MedTermDayTaxoFacets: 31 +facets:taxonomy:DayOfYear # freq=298349
+MedTermDayTaxoFacets: 08 +facets:taxonomy:DayOfYear # freq=297258
+MedTermDayTaxoFacets: 09 +facets:taxonomy:DayOfYear # freq=296300
+MedTermDayTaxoFacets: r +facets:taxonomy:DayOfYear # freq=296283
+MedTermDayTaxoFacets: set +facets:taxonomy:DayOfYear # freq=294255
+MedTermDayTaxoFacets: show +facets:taxonomy:DayOfYear # freq=293934
+MedTermDayTaxoFacets: david +facets:taxonomy:DayOfYear # freq=292847
+MedTermDayTaxoFacets: make +facets:taxonomy:DayOfYear # freq=292607
+MedTermDayTaxoFacets: story +facets:taxonomy:DayOfYear # freq=292404
+MedTermDayTaxoFacets: citation +facets:taxonomy:DayOfYear # freq=291478
+MedTermDayTaxoFacets: within +facets:taxonomy:DayOfYear # freq=291049
+MedTermDayTaxoFacets: due +facets:taxonomy:DayOfYear # freq=290531
+MedTermDayTaxoFacets: link +facets:taxonomy:DayOfYear # freq=287552
+MedTermDayTaxoFacets: 1997 +facets:taxonomy:DayOfYear # freq=286789
+MedTermDayTaxoFacets: members +facets:taxonomy:DayOfYear # freq=286028
+MedTermDayTaxoFacets: william +facets:taxonomy:DayOfYear # freq=284592
+MedTermDayTaxoFacets: along +facets:taxonomy:DayOfYear # freq=284442
+MedTermDayTaxoFacets: v +facets:taxonomy:DayOfYear # freq=284318
+MedTermDayTaxoFacets: located +facets:taxonomy:DayOfYear # freq=283899
+MedTermDayTaxoFacets: single +facets:taxonomy:DayOfYear # freq=283824
+MedTermDayTaxoFacets: per +facets:taxonomy:DayOfYear # freq=283568
+MedTermDayTaxoFacets: established +facets:taxonomy:DayOfYear # freq=282471
+MedTermDayTaxoFacets: james +facets:taxonomy:DayOfYear # freq=281597
+MedTermDayTaxoFacets: needed +facets:taxonomy:DayOfYear # freq=281051
+MedTermDayTaxoFacets: down +facets:taxonomy:DayOfYear # freq=280662
+MedTermDayTaxoFacets: present +facets:taxonomy:DayOfYear # freq=278449
+MedTermDayTaxoFacets: man +facets:taxonomy:DayOfYear # freq=278112
+MedTermDayTaxoFacets: college +facets:taxonomy:DayOfYear # freq=278094
+MedTermDayTaxoFacets: f +facets:taxonomy:DayOfYear # freq=278015
+MedTermDayTaxoFacets: site +facets:taxonomy:DayOfYear # freq=277788
+MedTermDayTaxoFacets: football +facets:taxonomy:DayOfYear # freq=277738
+MedTermDayTaxoFacets: en +facets:taxonomy:DayOfYear # freq=277463
+MedTermDayTaxoFacets: result +facets:taxonomy:DayOfYear # freq=276803
+MedTermDayTaxoFacets: include +facets:taxonomy:DayOfYear # freq=276466
+MedTermDayTaxoFacets: began +facets:taxonomy:DayOfYear # freq=276036
+MedTermDayTaxoFacets: my +facets:taxonomy:DayOfYear # freq=274256
+MedTermDayTaxoFacets: x +facets:taxonomy:DayOfYear # freq=272695
+MedTermDayTaxoFacets: central +facets:taxonomy:DayOfYear # freq=272531
+MedTermDayTaxoFacets: band +facets:taxonomy:DayOfYear # freq=272207
+MedTermDayTaxoFacets: 1996 +facets:taxonomy:DayOfYear # freq=271980
+MedTermDayTaxoFacets: form +facets:taxonomy:DayOfYear # freq=271966
+MedTermDayTaxoFacets: member +facets:taxonomy:DayOfYear # freq=271607
+MedTermDayTaxoFacets: television +facets:taxonomy:DayOfYear # freq=271426
+MedTermDayTaxoFacets: league +facets:taxonomy:DayOfYear # freq=270223
+MedTermDayTaxoFacets: free +facets:taxonomy:DayOfYear # freq=270199
+MedTermDayTaxoFacets: political +facets:taxonomy:DayOfYear # freq=269665
+MedTermDayTaxoFacets: font +facets:taxonomy:DayOfYear # freq=269439
+MedTermDayTaxoFacets: 100 +facets:taxonomy:DayOfYear # freq=268978
+MedTermDayTaxoFacets: convert +facets:taxonomy:DayOfYear # freq=267974
+MedTermDayTaxoFacets: red +facets:taxonomy:DayOfYear # freq=266177
+MedTermDayTaxoFacets: president +facets:taxonomy:DayOfYear # freq=263341
+MedTermDayTaxoFacets: five +facets:taxonomy:DayOfYear # freq=262923
+MedTermDayTaxoFacets: t +facets:taxonomy:DayOfYear # freq=262832
+MedTermDayTaxoFacets: power +facets:taxonomy:DayOfYear # freq=262586
+MedTermDayTaxoFacets: river +facets:taxonomy:DayOfYear # freq=262231
+MedTermDayTaxoFacets: we +facets:taxonomy:DayOfYear # freq=261001
+MedTermDayTaxoFacets: song +facets:taxonomy:DayOfYear # freq=260741
+MedTermDayTaxoFacets: next +facets:taxonomy:DayOfYear # freq=259039
+MedTermDayTaxoFacets: articles +facets:taxonomy:DayOfYear # freq=258949
+MedTermDayTaxoFacets: point +facets:taxonomy:DayOfYear # freq=258471
+MedTermDayTaxoFacets: text +facets:taxonomy:DayOfYear # freq=257803
+MedTermDayTaxoFacets: according +facets:taxonomy:DayOfYear # freq=256949
+MedTermDayTaxoFacets: black +facets:taxonomy:DayOfYear # freq=256526
+MedTermDayTaxoFacets: george +facets:taxonomy:DayOfYear # freq=256196
+MedTermDayTaxoFacets: different +facets:taxonomy:DayOfYear # freq=255951
+MedTermDayTaxoFacets: ndash +facets:taxonomy:DayOfYear # freq=255747
+MedTermDayTaxoFacets: third +facets:taxonomy:DayOfYear # freq=255690
+MedTermDayTaxoFacets: tv +facets:taxonomy:DayOfYear # freq=255429
+MedTermDayTaxoFacets: law +facets:taxonomy:DayOfYear # freq=255248
+MedTermDayTaxoFacets: canada +facets:taxonomy:DayOfYear # freq=254867
+MedTermDayTaxoFacets: near +facets:taxonomy:DayOfYear # freq=254492
+MedTermDayTaxoFacets: built +facets:taxonomy:DayOfYear # freq=254491
+MedTermDayTaxoFacets: 1995 +facets:taxonomy:DayOfYear # freq=252837
+MedTermDayTaxoFacets: how +facets:taxonomy:DayOfYear # freq=252284
+MedTermDayTaxoFacets: record +facets:taxonomy:DayOfYear # freq=250484
+MedTermDayTaxoFacets: french +facets:taxonomy:DayOfYear # freq=250453
+MedTermDayTaxoFacets: air +facets:taxonomy:DayOfYear # freq=250411
+MedTermDayTaxoFacets: king +facets:taxonomy:DayOfYear # freq=250321
+MedTermDayTaxoFacets: without +facets:taxonomy:DayOfYear # freq=249926
+MedTermDayTaxoFacets: though +facets:taxonomy:DayOfYear # freq=248968
+MedTermDayTaxoFacets: played +facets:taxonomy:DayOfYear # freq=248191
+MedTermDayTaxoFacets: park +facets:taxonomy:DayOfYear # freq=247801
+MedTermDayTaxoFacets: took +facets:taxonomy:DayOfYear # freq=247388
+MedTermDayTaxoFacets: association +facets:taxonomy:DayOfYear # freq=247156
+MedTermDayTaxoFacets: military +facets:taxonomy:DayOfYear # freq=246727
+MedTermDayTaxoFacets: robert +facets:taxonomy:DayOfYear # freq=246405
+MedTermDayTaxoFacets: above +facets:taxonomy:DayOfYear # freq=246135
+MedTermDayTaxoFacets: persondata +facets:taxonomy:DayOfYear # freq=246119
+MedTermDayTaxoFacets: career +facets:taxonomy:DayOfYear # freq=245439
+MedTermDayTaxoFacets: version +facets:taxonomy:DayOfYear # freq=244541
+MedTermDayTaxoFacets: again +facets:taxonomy:DayOfYear # freq=244255
+MedTermDayTaxoFacets: late +facets:taxonomy:DayOfYear # freq=243636
+MedTermDayTaxoFacets: published +facets:taxonomy:DayOfYear # freq=243548
+MedTermDayTaxoFacets: live +facets:taxonomy:DayOfYear # freq=242147
+MedTermDayTaxoFacets: h +facets:taxonomy:DayOfYear # freq=241946
+MedTermDayTaxoFacets: good +facets:taxonomy:DayOfYear # freq=241649
+MedTermDayTaxoFacets: player +facets:taxonomy:DayOfYear # freq=241451
+MedTermDayTaxoFacets: others +facets:taxonomy:DayOfYear # freq=240487
+MedTermDayTaxoFacets: america +facets:taxonomy:DayOfYear # freq=240374
+MedTermDayTaxoFacets: review +facets:taxonomy:DayOfYear # freq=240157
+MedTermDayTaxoFacets: station +facets:taxonomy:DayOfYear # freq=239572
+MedTermDayTaxoFacets: among +facets:taxonomy:DayOfYear # freq=238986
+MedTermDayTaxoFacets: section +facets:taxonomy:DayOfYear # freq=238874
+MedTermDayTaxoFacets: border +facets:taxonomy:DayOfYear # freq=238540
+MedTermDayTaxoFacets: your +facets:taxonomy:DayOfYear # freq=237723
+MedTermDayTaxoFacets: size +facets:taxonomy:DayOfYear # freq=237662
+MedTermDayTaxoFacets: births +facets:taxonomy:DayOfYear # freq=237033
+MedTermDayTaxoFacets: support +facets:taxonomy:DayOfYear # freq=236989
+MedTermDayTaxoFacets: german +facets:taxonomy:DayOfYear # freq=236721
+MedTermDayTaxoFacets: california +facets:taxonomy:DayOfYear # freq=236086
+MedTermDayTaxoFacets: given +facets:taxonomy:DayOfYear # freq=235719
+MedTermDayTaxoFacets: commons +facets:taxonomy:DayOfYear # freq=235235
+MedTermDayTaxoFacets: 1994 +facets:taxonomy:DayOfYear # freq=235100
+MedTermDayTaxoFacets: start +facets:taxonomy:DayOfYear # freq=233925
+MedTermDayTaxoFacets: km +facets:taxonomy:DayOfYear # freq=233831
+MedTermDayTaxoFacets: said +facets:taxonomy:DayOfYear # freq=233066
+MedTermDayTaxoFacets: western +facets:taxonomy:DayOfYear # freq=232781
+MedTermDayTaxoFacets: won +facets:taxonomy:DayOfYear # freq=232751
+MedTermDayTaxoFacets: la +facets:taxonomy:DayOfYear # freq=232610
+MedTermDayTaxoFacets: held +facets:taxonomy:DayOfYear # freq=232354
+MedTermDayTaxoFacets: children +facets:taxonomy:DayOfYear # freq=232342
+MedTermDayTaxoFacets: does +facets:taxonomy:DayOfYear # freq=232202
+MedTermDayTaxoFacets: club +facets:taxonomy:DayOfYear # freq=232173
+MedTermDayTaxoFacets: source +facets:taxonomy:DayOfYear # freq=231838
+MedTermDayTaxoFacets: church +facets:taxonomy:DayOfYear # freq=231667
+MedTermDayTaxoFacets: format +facets:taxonomy:DayOfYear # freq=231300
+MedTermDayTaxoFacets: example +facets:taxonomy:DayOfYear # freq=230457
+MedTermDayTaxoFacets: development +facets:taxonomy:DayOfYear # freq=230286
+MedTermDayTaxoFacets: land +facets:taxonomy:DayOfYear # freq=230284
+MedTermDayTaxoFacets: total +facets:taxonomy:DayOfYear # freq=230013
+MedTermDayTaxoFacets: final +facets:taxonomy:DayOfYear # freq=230006
+MedTermDayTaxoFacets: 50 +facets:taxonomy:DayOfYear # freq=229614
+MedTermDayTaxoFacets: please +facets:taxonomy:DayOfYear # freq=229602
+MedTermDayTaxoFacets: region +facets:taxonomy:DayOfYear # freq=229561
+MedTermDayTaxoFacets: here +facets:taxonomy:DayOfYear # freq=229505
+MedTermDayTaxoFacets: me +facets:taxonomy:DayOfYear # freq=229204
+MedTermDayTaxoFacets: caption +facets:taxonomy:DayOfYear # freq=229172
+MedTermDayTaxoFacets: must +facets:taxonomy:DayOfYear # freq=228491
+MedTermDayTaxoFacets: army +facets:taxonomy:DayOfYear # freq=228105
+MedTermDayTaxoFacets: l +facets:taxonomy:DayOfYear # freq=227974
+MedTermDayTaxoFacets: side +facets:taxonomy:DayOfYear # freq=227747
+MedTermDayTaxoFacets: society +facets:taxonomy:DayOfYear # freq=226742
+MedTermDayTaxoFacets: full +facets:taxonomy:DayOfYear # freq=226457
+MedTermDayTaxoFacets: few +facets:taxonomy:DayOfYear # freq=226422
+MedTermDayTaxoFacets: records +facets:taxonomy:DayOfYear # freq=225886
+MedTermDayTaxoFacets: below +facets:taxonomy:DayOfYear # freq=225843
+MedTermDayTaxoFacets: community +facets:taxonomy:DayOfYear # freq=225571
+MedTermDayTaxoFacets: office +facets:taxonomy:DayOfYear # freq=225338
+MedTermDayTaxoFacets: 1992 +facets:taxonomy:DayOfYear # freq=225200
+MedTermDayTaxoFacets: road +facets:taxonomy:DayOfYear # freq=225050
+MedTermDayTaxoFacets: research +facets:taxonomy:DayOfYear # freq=224925
+MedTermDayTaxoFacets: various +facets:taxonomy:DayOfYear # freq=224593
+MedTermDayTaxoFacets: take +facets:taxonomy:DayOfYear # freq=224260
+MedTermDayTaxoFacets: wikipedia:persondata +facets:taxonomy:DayOfYear # freq=222385
+MedTermDayTaxoFacets: 1990 +facets:taxonomy:DayOfYear # freq=222154
+MedTermDayTaxoFacets: 40 +facets:taxonomy:DayOfYear # freq=221687
+MedTermDayTaxoFacets: created +facets:taxonomy:DayOfYear # freq=220831
+MedTermDayTaxoFacets: 1993 +facets:taxonomy:DayOfYear # freq=220776
+MedTermDayTaxoFacets: france +facets:taxonomy:DayOfYear # freq=220058
+MedTermDayTaxoFacets: science +facets:taxonomy:DayOfYear # freq=219988
+MedTermDayTaxoFacets: every +facets:taxonomy:DayOfYear # freq=219884
+MedTermDayTaxoFacets: become +facets:taxonomy:DayOfYear # freq=219753
+MedTermDayTaxoFacets: modern +facets:taxonomy:DayOfYear # freq=218831
+MedTermDayTaxoFacets: post +facets:taxonomy:DayOfYear # freq=218570
+MedTermDayTaxoFacets: games +facets:taxonomy:DayOfYear # freq=218434
+MedTermDayTaxoFacets: michael +facets:taxonomy:DayOfYear # freq=217311
+MedTermDayTaxoFacets: current +facets:taxonomy:DayOfYear # freq=217174
+MedTermDayTaxoFacets: included +facets:taxonomy:DayOfYear # freq=216978
+MedTermDayTaxoFacets: ja +facets:taxonomy:DayOfYear # freq=216549
+MedTermDayTaxoFacets: magazine +facets:taxonomy:DayOfYear # freq=215725
+MedTermDayTaxoFacets: position +facets:taxonomy:DayOfYear # freq=215493
+MedTermDayTaxoFacets: australia +facets:taxonomy:DayOfYear # freq=215391
+MedTermDayTaxoFacets: archive +facets:taxonomy:DayOfYear # freq=215381
+MedTermDayTaxoFacets: union +facets:taxonomy:DayOfYear # freq=214164
+MedTermDayTaxoFacets: having +facets:taxonomy:DayOfYear # freq=213416
+MedTermDayTaxoFacets: g +facets:taxonomy:DayOfYear # freq=212936
+MedTermDayTaxoFacets: popular +facets:taxonomy:DayOfYear # freq=212493
+MedTermDayTaxoFacets: royal +facets:taxonomy:DayOfYear # freq=211710
+MedTermDayTaxoFacets: period +facets:taxonomy:DayOfYear # freq=211690
+MedTermDayTaxoFacets: little +facets:taxonomy:DayOfYear # freq=211124
+MedTermDayTaxoFacets: wikitable +facets:taxonomy:DayOfYear # freq=210990
+MedTermDayTaxoFacets: rock +facets:taxonomy:DayOfYear # freq=210815
+MedTermDayTaxoFacets: artist +facets:taxonomy:DayOfYear # freq=210591
+MedTermDayTaxoFacets: play +facets:taxonomy:DayOfYear # freq=210199
+MedTermDayTaxoFacets: led +facets:taxonomy:DayOfYear # freq=210033
+MedTermDayTaxoFacets: notes +facets:taxonomy:DayOfYear # freq=210029
+MedTermDayTaxoFacets: water +facets:taxonomy:DayOfYear # freq=209444
+MedTermDayTaxoFacets: business +facets:taxonomy:DayOfYear # freq=209353
+MedTermDayTaxoFacets: art +facets:taxonomy:DayOfYear # freq=209322
+MedTermDayTaxoFacets: common +facets:taxonomy:DayOfYear # freq=209310
+MedTermDayTaxoFacets: co +facets:taxonomy:DayOfYear # freq=209086
+MedTermDayTaxoFacets: education +facets:taxonomy:DayOfYear # freq=208909
+MedTermDayTaxoFacets: role +facets:taxonomy:DayOfYear # freq=208579
+MedTermDayTaxoFacets: 1991 +facets:taxonomy:DayOfYear # freq=207589
+MedTermDayTaxoFacets: case +facets:taxonomy:DayOfYear # freq=207307
+MedTermDayTaxoFacets: paul +facets:taxonomy:DayOfYear # freq=207229
+MedTermDayTaxoFacets: media +facets:taxonomy:DayOfYear # freq=206574
+MedTermDayTaxoFacets: div +facets:taxonomy:DayOfYear # freq=206057
+MedTermDayTaxoFacets: census +facets:taxonomy:DayOfYear # freq=205166
+MedTermDayTaxoFacets: charles +facets:taxonomy:DayOfYear # freq=204987
+MedTermDayTaxoFacets: written +facets:taxonomy:DayOfYear # freq=204891
+MedTermDayTaxoFacets: pp +facets:taxonomy:DayOfYear # freq=204742
+MedTermDayTaxoFacets: green +facets:taxonomy:DayOfYear # freq=203371
+MedTermDayTaxoFacets: island +facets:taxonomy:DayOfYear # freq=203023
+MedTermDayTaxoFacets: never +facets:taxonomy:DayOfYear # freq=203017
+MedTermDayTaxoFacets: making +facets:taxonomy:DayOfYear # freq=203003
+MedTermDayTaxoFacets: term +facets:taxonomy:DayOfYear # freq=202691
+MedTermDayTaxoFacets: video +facets:taxonomy:DayOfYear # freq=202380
+MedTermDayTaxoFacets: son +facets:taxonomy:DayOfYear # freq=202340
+MedTermDayTaxoFacets: discussion +facets:taxonomy:DayOfYear # freq=202145
+MedTermDayTaxoFacets: died +facets:taxonomy:DayOfYear # freq=202125
+MedTermDayTaxoFacets: view +facets:taxonomy:DayOfYear # freq=201593
+MedTermDayTaxoFacets: street +facets:taxonomy:DayOfYear # freq=200985
+MedTermDayTaxoFacets: council +facets:taxonomy:DayOfYear # freq=200706
+MedTermDayTaxoFacets: re +facets:taxonomy:DayOfYear # freq=199632
+MedTermDayTaxoFacets: award +facets:taxonomy:DayOfYear # freq=199318
+MedTermDayTaxoFacets: works +facets:taxonomy:DayOfYear # freq=199177
+MedTermDayTaxoFacets: special +facets:taxonomy:DayOfYear # freq=198917
+MedTermDayTaxoFacets: force +facets:taxonomy:DayOfYear # freq=198556
+MedTermDayTaxoFacets: six +facets:taxonomy:DayOfYear # freq=197970
+MedTermDayTaxoFacets: came +facets:taxonomy:DayOfYear # freq=197126
+MedTermDayTaxoFacets: building +facets:taxonomy:DayOfYear # freq=196508
+MedTermDayTaxoFacets: young +facets:taxonomy:DayOfYear # freq=196428
+MedTermDayTaxoFacets: together +facets:taxonomy:DayOfYear # freq=195949
+MedTermDayTaxoFacets: important +facets:taxonomy:DayOfYear # freq=195851
+MedTermDayTaxoFacets: star +facets:taxonomy:DayOfYear # freq=195768
+MedTermDayTaxoFacets: similar +facets:taxonomy:DayOfYear # freq=195171
+MedTermDayTaxoFacets: received +facets:taxonomy:DayOfYear # freq=194983
+MedTermDayTaxoFacets: sup +facets:taxonomy:DayOfYear # freq=194723
+MedTermDayTaxoFacets: head +facets:taxonomy:DayOfYear # freq=194682
+AndHighHighDayTaxoFacets: +of +s +facets:taxonomy:DayOfYear # freq=8184358 freq=1581243
+AndHighHighDayTaxoFacets: +date +he +facets:taxonomy:DayOfYear # freq=2020626 freq=1659434
+AndHighHighDayTaxoFacets: +cite +2005 +facets:taxonomy:DayOfYear # freq=1741194 freq=835460
+AndHighHighDayTaxoFacets: +i +10 +facets:taxonomy:DayOfYear # freq=956148 freq=918339
+AndHighHighDayTaxoFacets: +date +2009 +facets:taxonomy:DayOfYear # freq=2020626 freq=887702
+AndHighHighDayTaxoFacets: +for +cite +facets:taxonomy:DayOfYear # freq=4380011 freq=1741194
+AndHighHighDayTaxoFacets: +as +its +facets:taxonomy:DayOfYear # freq=3925535 freq=1173450
+AndHighHighDayTaxoFacets: +which +2011 +facets:taxonomy:DayOfYear # freq=1963428 freq=871410
+AndHighHighDayTaxoFacets: +have +see +facets:taxonomy:DayOfYear # freq=1297121 freq=1044180
+AndHighHighDayTaxoFacets: +first +accessdate +facets:taxonomy:DayOfYear # freq=1933372 freq=1228887
+AndHighHighDayTaxoFacets: +also +no +facets:taxonomy:DayOfYear # freq=1959419 freq=1045000
+AndHighHighDayTaxoFacets: +first +new +facets:taxonomy:DayOfYear # freq=1933372 freq=1657293
+AndHighHighDayTaxoFacets: +publisher +web +facets:taxonomy:DayOfYear # freq=1289029 freq=1118334
+AndHighHighDayTaxoFacets: +states +work +facets:taxonomy:DayOfYear # freq=1034872 freq=853422
+AndHighHighDayTaxoFacets: +more +work +facets:taxonomy:DayOfYear # freq=963533 freq=853422
+AndHighHighDayTaxoFacets: +1 +their +facets:taxonomy:DayOfYear # freq=1641090 freq=1158682
+AndHighHighDayTaxoFacets: +http +an +facets:taxonomy:DayOfYear # freq=3493581 freq=2628056
+AndHighHighDayTaxoFacets: +year +5 +facets:taxonomy:DayOfYear # freq=1235231 freq=891361
+AndHighHighDayTaxoFacets: +4 +there +facets:taxonomy:DayOfYear # freq=986452 freq=956153
+AndHighHighDayTaxoFacets: +s +who +facets:taxonomy:DayOfYear # freq=1581243 freq=1196171
+AndHighHighDayTaxoFacets: +who +may +facets:taxonomy:DayOfYear # freq=1196171 freq=1071932
+AndHighHighDayTaxoFacets: +united +time +facets:taxonomy:DayOfYear # freq=1196944 freq=1032071
+AndHighHighDayTaxoFacets: +other +no +facets:taxonomy:DayOfYear # freq=1269961 freq=1045000
+AndHighHighDayTaxoFacets: +time +when +facets:taxonomy:DayOfYear # freq=1032071 freq=1027487
+AndHighHighDayTaxoFacets: +that +cite +facets:taxonomy:DayOfYear # freq=2931020 freq=1741194
+AndHighHighDayTaxoFacets: +to +its +facets:taxonomy:DayOfYear # freq=6155577 freq=1173450
+AndHighHighDayTaxoFacets: +2011 +2008 +facets:taxonomy:DayOfYear # freq=871410 freq=831253
+AndHighHighDayTaxoFacets: +been +2005 +facets:taxonomy:DayOfYear # freq=1041183 freq=835460
+AndHighHighDayTaxoFacets: +1 +year +facets:taxonomy:DayOfYear # freq=1641090 freq=1235231
+AndHighHighDayTaxoFacets: +was +more +facets:taxonomy:DayOfYear # freq=3763623 freq=963533
+AndHighHighDayTaxoFacets: +3 +2005 +facets:taxonomy:DayOfYear # freq=1148799 freq=835460
+AndHighHighDayTaxoFacets: +a +they +facets:taxonomy:DayOfYear # freq=6560531 freq=1021945
+AndHighHighDayTaxoFacets: +s +time +facets:taxonomy:DayOfYear # freq=1581243 freq=1032071
+AndHighHighDayTaxoFacets: +in +2011 +facets:taxonomy:DayOfYear # freq=7320987 freq=871410
+AndHighHighDayTaxoFacets: +a +work +facets:taxonomy:DayOfYear # freq=6560531 freq=853422
+AndHighHighDayTaxoFacets: +they +4 +facets:taxonomy:DayOfYear # freq=1021945 freq=986452
+AndHighHighDayTaxoFacets: +and +2 +facets:taxonomy:DayOfYear # freq=7318061 freq=1549245
+AndHighHighDayTaxoFacets: +to +an +facets:taxonomy:DayOfYear # freq=6155577 freq=2628056
+AndHighHighDayTaxoFacets: +an +which +facets:taxonomy:DayOfYear # freq=2628056 freq=1963428
+AndHighHighDayTaxoFacets: +was +also +facets:taxonomy:DayOfYear # freq=3763623 freq=1959419
+AndHighHighDayTaxoFacets: +this +see +facets:taxonomy:DayOfYear # freq=2224932 freq=1044180
+AndHighHighDayTaxoFacets: +all +2010 +facets:taxonomy:DayOfYear # freq=1203572 freq=950573
+AndHighHighDayTaxoFacets: +2 +2010 +facets:taxonomy:DayOfYear # freq=1549245 freq=950573
+AndHighHighDayTaxoFacets: +first +work +facets:taxonomy:DayOfYear # freq=1933372 freq=853422
+AndHighHighDayTaxoFacets: +he +10 +facets:taxonomy:DayOfYear # freq=1659434 freq=918339
+AndHighHighDayTaxoFacets: +http +that +facets:taxonomy:DayOfYear # freq=3493581 freq=2931020
+AndHighHighDayTaxoFacets: +new +2011 +facets:taxonomy:DayOfYear # freq=1657293 freq=871410
+AndHighHighDayTaxoFacets: +as +by +facets:taxonomy:DayOfYear # freq=3925535 freq=3826691
+AndHighHighDayTaxoFacets: +there +2008 +facets:taxonomy:DayOfYear # freq=956153 freq=831253
+AndHighHighDayTaxoFacets: +is +they +facets:taxonomy:DayOfYear # freq=4074455 freq=1021945
+AndHighHighDayTaxoFacets: +2010 +2011 +facets:taxonomy:DayOfYear # freq=950573 freq=871410
+AndHighHighDayTaxoFacets: +accessdate +2005 +facets:taxonomy:DayOfYear # freq=1228887 freq=835460
+AndHighHighDayTaxoFacets: +at +this +facets:taxonomy:DayOfYear # freq=2857534 freq=2224932
+AndHighHighDayTaxoFacets: +as +some +facets:taxonomy:DayOfYear # freq=3925535 freq=839919
+AndHighHighDayTaxoFacets: +after +all +facets:taxonomy:DayOfYear # freq=1247398 freq=1203572
+AndHighHighDayTaxoFacets: +year +they +facets:taxonomy:DayOfYear # freq=1235231 freq=1021945
+AndHighHighDayTaxoFacets: +1 +accessdate +facets:taxonomy:DayOfYear # freq=1641090 freq=1228887
+AndHighHighDayTaxoFacets: +on +web +facets:taxonomy:DayOfYear # freq=4074624 freq=1118334
+AndHighHighDayTaxoFacets: +first +5 +facets:taxonomy:DayOfYear # freq=1933372 freq=891361
+AndHighHighDayTaxoFacets: +he +but +facets:taxonomy:DayOfYear # freq=1659434 freq=1456553
+AndHighHighDayTaxoFacets: +title +when +facets:taxonomy:DayOfYear # freq=2397378 freq=1027487
+AndHighHighDayTaxoFacets: +who +two +facets:taxonomy:DayOfYear # freq=1196171 freq=1104053
+AndHighHighDayTaxoFacets: +last +2006 +facets:taxonomy:DayOfYear # freq=958437 freq=889954
+AndHighHighDayTaxoFacets: +from +name +facets:taxonomy:DayOfYear # freq=3224339 freq=2827713
+AndHighHighDayTaxoFacets: +new +i +facets:taxonomy:DayOfYear # freq=1657293 freq=956148
+AndHighHighDayTaxoFacets: +was +publisher +facets:taxonomy:DayOfYear # freq=3763623 freq=1289029
+AndHighHighDayTaxoFacets: +and +not +facets:taxonomy:DayOfYear # freq=7318061 freq=1713264
+AndHighHighDayTaxoFacets: +is +their +facets:taxonomy:DayOfYear # freq=4074455 freq=1158682
+AndHighHighDayTaxoFacets: +ref +that +facets:taxonomy:DayOfYear # freq=3793973 freq=2931020
+AndHighHighDayTaxoFacets: +of +for +facets:taxonomy:DayOfYear # freq=8184358 freq=4380011
+AndHighHighDayTaxoFacets: +name +which +facets:taxonomy:DayOfYear # freq=2827713 freq=1963428
+AndHighHighDayTaxoFacets: +after +2008 +facets:taxonomy:DayOfYear # freq=1247398 freq=831253
+AndHighHighDayTaxoFacets: +that +an +facets:taxonomy:DayOfYear # freq=2931020 freq=2628056
+AndHighHighDayTaxoFacets: +by +2006 +facets:taxonomy:DayOfYear # freq=3826691 freq=889954
+AndHighHighDayTaxoFacets: +that +or +facets:taxonomy:DayOfYear # freq=2931020 freq=1858841
+AndHighHighDayTaxoFacets: +be +which +facets:taxonomy:DayOfYear # freq=2051702 freq=1963428
+AndHighHighDayTaxoFacets: +with +2010 +facets:taxonomy:DayOfYear # freq=3709421 freq=950573
+AndHighHighDayTaxoFacets: +by +with +facets:taxonomy:DayOfYear # freq=3826691 freq=3709421
+AndHighHighDayTaxoFacets: +by +4 +facets:taxonomy:DayOfYear # freq=3826691 freq=986452
+AndHighHighDayTaxoFacets: +was +cite +facets:taxonomy:DayOfYear # freq=3763623 freq=1741194
+AndHighHighDayTaxoFacets: +was +they +facets:taxonomy:DayOfYear # freq=3763623 freq=1021945
+AndHighHighDayTaxoFacets: +on +was +facets:taxonomy:DayOfYear # freq=4074624 freq=3763623
+AndHighHighDayTaxoFacets: +is +time +facets:taxonomy:DayOfYear # freq=4074455 freq=1032071
+AndHighHighDayTaxoFacets: +the +be +facets:taxonomy:DayOfYear # freq=8217362 freq=2051702
+AndHighHighDayTaxoFacets: +were +2010 +facets:taxonomy:DayOfYear # freq=1524630 freq=950573
+AndHighHighDayTaxoFacets: +they +2006 +facets:taxonomy:DayOfYear # freq=1021945 freq=889954
+AndHighHighDayTaxoFacets: +he +may +facets:taxonomy:DayOfYear # freq=1659434 freq=1071932
+AndHighHighDayTaxoFacets: +an +title +facets:taxonomy:DayOfYear # freq=2628056 freq=2397378
+AndHighHighDayTaxoFacets: +into +some +facets:taxonomy:DayOfYear # freq=888684 freq=839919
+AndHighHighDayTaxoFacets: +first +some +facets:taxonomy:DayOfYear # freq=1933372 freq=839919
+AndHighHighDayTaxoFacets: +name +new +facets:taxonomy:DayOfYear # freq=2827713 freq=1657293
+AndHighHighDayTaxoFacets: +cite +3 +facets:taxonomy:DayOfYear # freq=1741194 freq=1148799
+AndHighHighDayTaxoFacets: +to +web +facets:taxonomy:DayOfYear # freq=6155577 freq=1118334
+AndHighHighDayTaxoFacets: +for +it +facets:taxonomy:DayOfYear # freq=4380011 freq=2675552
+AndHighHighDayTaxoFacets: +year +there +facets:taxonomy:DayOfYear # freq=1235231 freq=956153
+AndHighHighDayTaxoFacets: +but +been +facets:taxonomy:DayOfYear # freq=1456553 freq=1041183
+AndHighHighDayTaxoFacets: +this +who +facets:taxonomy:DayOfYear # freq=2224932 freq=1196171
+AndHighHighDayTaxoFacets: +ref +web +facets:taxonomy:DayOfYear # freq=3793973 freq=1118334
+AndHighHighDayTaxoFacets: +cite +2011 +facets:taxonomy:DayOfYear # freq=1741194 freq=871410
+AndHighHighDayTaxoFacets: +by +he +facets:taxonomy:DayOfYear # freq=3826691 freq=1659434
+AndHighHighDayTaxoFacets: +name +first +facets:taxonomy:DayOfYear # freq=2827713 freq=1933372
+AndHighHighDayTaxoFacets: +has +about +facets:taxonomy:DayOfYear # freq=1502961 freq=850283
+AndHighHighDayTaxoFacets: +were +two +facets:taxonomy:DayOfYear # freq=1524630 freq=1104053
+AndHighHighDayTaxoFacets: +two +work +facets:taxonomy:DayOfYear # freq=1104053 freq=853422
+AndHighHighDayTaxoFacets: +he +been +facets:taxonomy:DayOfYear # freq=1659434 freq=1041183
+AndHighHighDayTaxoFacets: +from +2 +facets:taxonomy:DayOfYear # freq=3224339 freq=1549245
+AndHighHighDayTaxoFacets: +all +some +facets:taxonomy:DayOfYear # freq=1203572 freq=839919
+AndHighHighDayTaxoFacets: +on +only +facets:taxonomy:DayOfYear # freq=4074624 freq=875561
+AndHighHighDayTaxoFacets: +was +no +facets:taxonomy:DayOfYear # freq=3763623 freq=1045000
+AndHighHighDayTaxoFacets: +name +see +facets:taxonomy:DayOfYear # freq=2827713 freq=1044180
+AndHighHighDayTaxoFacets: +of +as +facets:taxonomy:DayOfYear # freq=8184358 freq=3925535
+AndHighHighDayTaxoFacets: +be +has +facets:taxonomy:DayOfYear # freq=2051702 freq=1502961
+AndHighHighDayTaxoFacets: +url +into +facets:taxonomy:DayOfYear # freq=1513595 freq=888684
+AndHighHighDayTaxoFacets: +of +2006 +facets:taxonomy:DayOfYear # freq=8184358 freq=889954
+AndHighHighDayTaxoFacets: +ref +or +facets:taxonomy:DayOfYear # freq=3793973 freq=1858841
+AndHighHighDayTaxoFacets: +by +url +facets:taxonomy:DayOfYear # freq=3826691 freq=1513595
+AndHighHighDayTaxoFacets: +3 +into +facets:taxonomy:DayOfYear # freq=1148799 freq=888684
+AndHighHighDayTaxoFacets: +which +year +facets:taxonomy:DayOfYear # freq=1963428 freq=1235231
+AndHighHighDayTaxoFacets: +at +only +facets:taxonomy:DayOfYear # freq=2857534 freq=875561
+AndHighHighDayTaxoFacets: +http +publisher +facets:taxonomy:DayOfYear # freq=3493581 freq=1289029
+AndHighHighDayTaxoFacets: +with +accessdate +facets:taxonomy:DayOfYear # freq=3709421 freq=1228887
+AndHighHighDayTaxoFacets: +had +work +facets:taxonomy:DayOfYear # freq=1246743 freq=853422
+AndHighHighDayTaxoFacets: +as +they +facets:taxonomy:DayOfYear # freq=3925535 freq=1021945
+AndHighHighDayTaxoFacets: +the +2009 +facets:taxonomy:DayOfYear # freq=8217362 freq=887702
+AndHighHighDayTaxoFacets: +are +but +facets:taxonomy:DayOfYear # freq=1877802 freq=1456553
+AndHighHighDayTaxoFacets: +other +10 +facets:taxonomy:DayOfYear # freq=1269961 freq=918339
+AndHighHighDayTaxoFacets: +two +they +facets:taxonomy:DayOfYear # freq=1104053 freq=1021945
+AndHighHighDayTaxoFacets: +all +they +facets:taxonomy:DayOfYear # freq=1203572 freq=1021945
+AndHighHighDayTaxoFacets: +2011 +about +facets:taxonomy:DayOfYear # freq=871410 freq=850283
+AndHighHighDayTaxoFacets: +name +states +facets:taxonomy:DayOfYear # freq=2827713 freq=1034872
+AndHighHighDayTaxoFacets: +were +may +facets:taxonomy:DayOfYear # freq=1524630 freq=1071932
+AndHighHighDayTaxoFacets: +the +into +facets:taxonomy:DayOfYear # freq=8217362 freq=888684
+AndHighHighDayTaxoFacets: +new +united +facets:taxonomy:DayOfYear # freq=1657293 freq=1196944
+AndHighHighDayTaxoFacets: +their +only +facets:taxonomy:DayOfYear # freq=1158682 freq=875561
+AndHighHighDayTaxoFacets: +be +10 +facets:taxonomy:DayOfYear # freq=2051702 freq=918339
+AndHighHighDayTaxoFacets: +that +not +facets:taxonomy:DayOfYear # freq=2931020 freq=1713264
+AndHighHighDayTaxoFacets: +title +all +facets:taxonomy:DayOfYear # freq=2397378 freq=1203572
+AndHighHighDayTaxoFacets: +with +have +facets:taxonomy:DayOfYear # freq=3709421 freq=1297121
+AndHighHighDayTaxoFacets: +as +been +facets:taxonomy:DayOfYear # freq=3925535 freq=1041183
+AndHighHighDayTaxoFacets: +it +more +facets:taxonomy:DayOfYear # freq=2675552 freq=963533
+AndHighHighDayTaxoFacets: +all +united +facets:taxonomy:DayOfYear # freq=1203572 freq=1196944
+AndHighHighDayTaxoFacets: +other +two +facets:taxonomy:DayOfYear # freq=1269961 freq=1104053
+AndHighHighDayTaxoFacets: +he +url +facets:taxonomy:DayOfYear # freq=1659434 freq=1513595
+AndHighHighDayTaxoFacets: +to +3 +facets:taxonomy:DayOfYear # freq=6155577 freq=1148799
+AndHighHighDayTaxoFacets: +in +from +facets:taxonomy:DayOfYear # freq=7320987 freq=3224339
+AndHighHighDayTaxoFacets: +not +there +facets:taxonomy:DayOfYear # freq=1713264 freq=956153
+AndHighHighDayTaxoFacets: +other +see +facets:taxonomy:DayOfYear # freq=1269961 freq=1044180
+AndHighHighDayTaxoFacets: +its +i +facets:taxonomy:DayOfYear # freq=1173450 freq=956148
+AndHighHighDayTaxoFacets: +as +2008 +facets:taxonomy:DayOfYear # freq=3925535 freq=831253
+AndHighHighDayTaxoFacets: +http +s +facets:taxonomy:DayOfYear # freq=3493581 freq=1581243
+AndHighHighDayTaxoFacets: +or +web +facets:taxonomy:DayOfYear # freq=1858841 freq=1118334
+AndHighHighDayTaxoFacets: +new +publisher +facets:taxonomy:DayOfYear # freq=1657293 freq=1289029
+AndHighHighDayTaxoFacets: +of +who +facets:taxonomy:DayOfYear # freq=8184358 freq=1196171
+AndHighHighDayTaxoFacets: +10 +2009 +facets:taxonomy:DayOfYear # freq=918339 freq=887702
+AndHighHighDayTaxoFacets: +that +he +facets:taxonomy:DayOfYear # freq=2931020 freq=1659434
+AndHighHighDayTaxoFacets: +url +2005 +facets:taxonomy:DayOfYear # freq=1513595 freq=835460
+AndHighHighDayTaxoFacets: +the +a +facets:taxonomy:DayOfYear # freq=8217362 freq=6560531
+AndHighHighDayTaxoFacets: +more +there +facets:taxonomy:DayOfYear # freq=963533 freq=956153
+AndHighHighDayTaxoFacets: +and +an +facets:taxonomy:DayOfYear # freq=7318061 freq=2628056
+AndHighHighDayTaxoFacets: +with +they +facets:taxonomy:DayOfYear # freq=3709421 freq=1021945
+AndHighHighDayTaxoFacets: +title +time +facets:taxonomy:DayOfYear # freq=2397378 freq=1032071
+AndHighHighDayTaxoFacets: +states +4 +facets:taxonomy:DayOfYear # freq=1034872 freq=986452
+AndHighHighDayTaxoFacets: +united +when +facets:taxonomy:DayOfYear # freq=1196944 freq=1027487
+AndHighHighDayTaxoFacets: +is +title +facets:taxonomy:DayOfYear # freq=4074455 freq=2397378
+AndHighHighDayTaxoFacets: +from +who +facets:taxonomy:DayOfYear # freq=3224339 freq=1196171
+AndHighHighDayTaxoFacets: +more +some +facets:taxonomy:DayOfYear # freq=963533 freq=839919
+AndHighHighDayTaxoFacets: +title +year +facets:taxonomy:DayOfYear # freq=2397378 freq=1235231
+AndHighHighDayTaxoFacets: +one +after +facets:taxonomy:DayOfYear # freq=1527689 freq=1247398
+AndHighHighDayTaxoFacets: +with +title +facets:taxonomy:DayOfYear # freq=3709421 freq=2397378
+AndHighHighDayTaxoFacets: +in +first +facets:taxonomy:DayOfYear # freq=7320987 freq=1933372
+AndHighHighDayTaxoFacets: +are +i +facets:taxonomy:DayOfYear # freq=1877802 freq=956148
+AndHighHighDayTaxoFacets: +the +two +facets:taxonomy:DayOfYear # freq=8217362 freq=1104053
+AndHighHighDayTaxoFacets: +but +there +facets:taxonomy:DayOfYear # freq=1456553 freq=956153
+AndHighHighDayTaxoFacets: +from +all +facets:taxonomy:DayOfYear # freq=3224339 freq=1203572
+AndHighHighDayTaxoFacets: +2 +more +facets:taxonomy:DayOfYear # freq=1549245 freq=963533
+AndHighHighDayTaxoFacets: +had +its +facets:taxonomy:DayOfYear # freq=1246743 freq=1173450
+AndHighHighDayTaxoFacets: +in +no +facets:taxonomy:DayOfYear # freq=7320987 freq=1045000
+AndHighHighDayTaxoFacets: +other +more +facets:taxonomy:DayOfYear # freq=1269961 freq=963533
+AndHighHighDayTaxoFacets: +his +united +facets:taxonomy:DayOfYear # freq=1777780 freq=1196944
+AndHighHighDayTaxoFacets: +more +last +facets:taxonomy:DayOfYear # freq=963533 freq=958437
+AndHighHighDayTaxoFacets: +ref +more +facets:taxonomy:DayOfYear # freq=3793973 freq=963533
+AndHighHighDayTaxoFacets: +ref +been +facets:taxonomy:DayOfYear # freq=3793973 freq=1041183
+AndHighHighDayTaxoFacets: +cite +time +facets:taxonomy:DayOfYear # freq=1741194 freq=1032071
+AndHighHighDayTaxoFacets: +http +3 +facets:taxonomy:DayOfYear # freq=3493581 freq=1148799
+AndHighHighDayTaxoFacets: +has +they +facets:taxonomy:DayOfYear # freq=1502961 freq=1021945
+AndHighHighDayTaxoFacets: +and +2011 +facets:taxonomy:DayOfYear # freq=7318061 freq=871410
+AndHighHighDayTaxoFacets: +be +accessdate +facets:taxonomy:DayOfYear # freq=2051702 freq=1228887
+AndHighHighDayTaxoFacets: +are +2010 +facets:taxonomy:DayOfYear # freq=1877802 freq=950573
+AndHighHighDayTaxoFacets: +at +2009 +facets:taxonomy:DayOfYear # freq=2857534 freq=887702
+AndHighHighDayTaxoFacets: +also +united +facets:taxonomy:DayOfYear # freq=1959419 freq=1196944
+AndHighHighDayTaxoFacets: +united +been +facets:taxonomy:DayOfYear # freq=1196944 freq=1041183
+AndHighHighDayTaxoFacets: +also +1 +facets:taxonomy:DayOfYear # freq=1959419 freq=1641090
+AndHighHighDayTaxoFacets: +he +last +facets:taxonomy:DayOfYear # freq=1659434 freq=958437
+AndHighHighDayTaxoFacets: +was +from +facets:taxonomy:DayOfYear # freq=3763623 freq=3224339
+AndHighHighDayTaxoFacets: +ref +when +facets:taxonomy:DayOfYear # freq=3793973 freq=1027487
+AndHighHighDayTaxoFacets: +not +they +facets:taxonomy:DayOfYear # freq=1713264 freq=1021945
+AndHighHighDayTaxoFacets: +the +other +facets:taxonomy:DayOfYear # freq=8217362 freq=1269961
+AndHighHighDayTaxoFacets: +cite +work +facets:taxonomy:DayOfYear # freq=1741194 freq=853422
+AndHighHighDayTaxoFacets: +was +were +facets:taxonomy:DayOfYear # freq=3763623 freq=1524630
+AndHighHighDayTaxoFacets: +in +after +facets:taxonomy:DayOfYear # freq=7320987 freq=1247398
+AndHighHighDayTaxoFacets: +and +first +facets:taxonomy:DayOfYear # freq=7318061 freq=1933372
+AndHighHighDayTaxoFacets: +have +their +facets:taxonomy:DayOfYear # freq=1297121 freq=1158682
+AndHighHighDayTaxoFacets: +also +4 +facets:taxonomy:DayOfYear # freq=1959419 freq=986452
+AndHighHighDayTaxoFacets: +he +2006 +facets:taxonomy:DayOfYear # freq=1659434 freq=889954
+AndHighHighDayTaxoFacets: +may +time +facets:taxonomy:DayOfYear # freq=1071932 freq=1032071
+AndHighHighDayTaxoFacets: +is +url +facets:taxonomy:DayOfYear # freq=4074455 freq=1513595
+AndHighHighDayTaxoFacets: +for +has +facets:taxonomy:DayOfYear # freq=4380011 freq=1502961
+AndHighHighDayTaxoFacets: +and +be +facets:taxonomy:DayOfYear # freq=7318061 freq=2051702
+AndHighHighDayTaxoFacets: +url +had +facets:taxonomy:DayOfYear # freq=1513595 freq=1246743
+AndHighHighDayTaxoFacets: +his +5 +facets:taxonomy:DayOfYear # freq=1777780 freq=891361
+AndHighHighDayTaxoFacets: +on +he +facets:taxonomy:DayOfYear # freq=4074624 freq=1659434
+AndHighHighDayTaxoFacets: +this +first +facets:taxonomy:DayOfYear # freq=2224932 freq=1933372
+AndHighHighDayTaxoFacets: +new +its +facets:taxonomy:DayOfYear # freq=1657293 freq=1173450
+AndHighHighDayTaxoFacets: +s +2009 +facets:taxonomy:DayOfYear # freq=1581243 freq=887702
+AndHighHighDayTaxoFacets: +see +2010 +facets:taxonomy:DayOfYear # freq=1044180 freq=950573
+AndHighHighDayTaxoFacets: +or +but +facets:taxonomy:DayOfYear # freq=1858841 freq=1456553
+AndHighHighDayTaxoFacets: +its +into +facets:taxonomy:DayOfYear # freq=1173450 freq=888684
+AndHighHighDayTaxoFacets: +on +accessdate +facets:taxonomy:DayOfYear # freq=4074624 freq=1228887
+AndHighHighDayTaxoFacets: +are +accessdate +facets:taxonomy:DayOfYear # freq=1877802 freq=1228887
+AndHighHighDayTaxoFacets: +2 +there +facets:taxonomy:DayOfYear # freq=1549245 freq=956153
+AndHighHighDayTaxoFacets: +united +3 +facets:taxonomy:DayOfYear # freq=1196944 freq=1148799
+AndHighHighDayTaxoFacets: +which +no +facets:taxonomy:DayOfYear # freq=1963428 freq=1045000
+AndHighHighDayTaxoFacets: +s +2006 +facets:taxonomy:DayOfYear # freq=1581243 freq=889954
+AndHighHighDayTaxoFacets: +ref +there +facets:taxonomy:DayOfYear # freq=3793973 freq=956153
+AndHighHighDayTaxoFacets: +he +more +facets:taxonomy:DayOfYear # freq=1659434 freq=963533
+AndHighHighDayTaxoFacets: +had +two +facets:taxonomy:DayOfYear # freq=1246743 freq=1104053
+AndHighHighDayTaxoFacets: +the +only +facets:taxonomy:DayOfYear # freq=8217362 freq=875561
+AndHighHighDayTaxoFacets: +be +about +facets:taxonomy:DayOfYear # freq=2051702 freq=850283
+AndHighHighDayTaxoFacets: +in +has +facets:taxonomy:DayOfYear # freq=7320987 freq=1502961
+AndHighHighDayTaxoFacets: +2009 +work +facets:taxonomy:DayOfYear # freq=887702 freq=853422
+AndHighHighDayTaxoFacets: +on +10 +facets:taxonomy:DayOfYear # freq=4074624 freq=918339
+AndHighHighDayTaxoFacets: +ref +2010 +facets:taxonomy:DayOfYear # freq=3793973 freq=950573
+AndHighHighDayTaxoFacets: +other +2006 +facets:taxonomy:DayOfYear # freq=1269961 freq=889954
+AndHighHighDayTaxoFacets: +with +all +facets:taxonomy:DayOfYear # freq=3709421 freq=1203572
+AndHighHighDayTaxoFacets: +in +work +facets:taxonomy:DayOfYear # freq=7320987 freq=853422
+AndHighHighDayTaxoFacets: +url +about +facets:taxonomy:DayOfYear # freq=1513595 freq=850283
+AndHighHighDayTaxoFacets: +after +some +facets:taxonomy:DayOfYear # freq=1247398 freq=839919
+AndHighHighDayTaxoFacets: +this +when +facets:taxonomy:DayOfYear # freq=2224932 freq=1027487
+AndHighHighDayTaxoFacets: +not +1 +facets:taxonomy:DayOfYear # freq=1713264 freq=1641090
+AndHighHighDayTaxoFacets: +1 +more +facets:taxonomy:DayOfYear # freq=1641090 freq=963533
+AndHighHighDayTaxoFacets: +not +2 +facets:taxonomy:DayOfYear # freq=1713264 freq=1549245
+AndHighHighDayTaxoFacets: +publisher +2005 +facets:taxonomy:DayOfYear # freq=1289029 freq=835460
+AndHighHighDayTaxoFacets: +in +at +facets:taxonomy:DayOfYear # freq=7320987 freq=2857534
+AndHighHighDayTaxoFacets: +1 +some +facets:taxonomy:DayOfYear # freq=1641090 freq=839919
+AndHighHighDayTaxoFacets: +s +its +facets:taxonomy:DayOfYear # freq=1581243 freq=1173450
+AndHighHighDayTaxoFacets: +date +more +facets:taxonomy:DayOfYear # freq=2020626 freq=963533
+AndHighHighDayTaxoFacets: +from +his +facets:taxonomy:DayOfYear # freq=3224339 freq=1777780
+AndHighHighDayTaxoFacets: +was +when +facets:taxonomy:DayOfYear # freq=3763623 freq=1027487
+AndHighHighDayTaxoFacets: +time +2010 +facets:taxonomy:DayOfYear # freq=1032071 freq=950573
+AndHighHighDayTaxoFacets: +it +2 +facets:taxonomy:DayOfYear # freq=2675552 freq=1549245
+AndHighHighDayTaxoFacets: +of +http +facets:taxonomy:DayOfYear # freq=8184358 freq=3493581
+AndHighHighDayTaxoFacets: +2 +2011 +facets:taxonomy:DayOfYear # freq=1549245 freq=871410
+AndHighHighDayTaxoFacets: +who +2009 +facets:taxonomy:DayOfYear # freq=1196171 freq=887702
+AndHighHighDayTaxoFacets: +in +2009 +facets:taxonomy:DayOfYear # freq=7320987 freq=887702
+AndHighHighDayTaxoFacets: +by +3 +facets:taxonomy:DayOfYear # freq=3826691 freq=1148799
+AndHighHighDayTaxoFacets: +when +2011 +facets:taxonomy:DayOfYear # freq=1027487 freq=871410
+AndHighHighDayTaxoFacets: +not +have +facets:taxonomy:DayOfYear # freq=1713264 freq=1297121
+AndHighHighDayTaxoFacets: +all +their +facets:taxonomy:DayOfYear # freq=1203572 freq=1158682
+AndHighHighDayTaxoFacets: +an +2005 +facets:taxonomy:DayOfYear # freq=2628056 freq=835460
+AndHighHighDayTaxoFacets: +of +is +facets:taxonomy:DayOfYear # freq=8184358 freq=4074455
+AndHighHighDayTaxoFacets: +of +url +facets:taxonomy:DayOfYear # freq=8184358 freq=1513595
+AndHighHighDayTaxoFacets: +also +year +facets:taxonomy:DayOfYear # freq=1959419 freq=1235231
+AndHighHighDayTaxoFacets: +is +new +facets:taxonomy:DayOfYear # freq=4074455 freq=1657293
+AndHighHighDayTaxoFacets: +http +name +facets:taxonomy:DayOfYear # freq=3493581 freq=2827713
+AndHighHighDayTaxoFacets: +i +into +facets:taxonomy:DayOfYear # freq=956148 freq=888684
+AndHighHighDayTaxoFacets: +are +united +facets:taxonomy:DayOfYear # freq=1877802 freq=1196944
+AndHighHighDayTaxoFacets: +or +only +facets:taxonomy:DayOfYear # freq=1858841 freq=875561
+AndHighHighDayTaxoFacets: +who +their +facets:taxonomy:DayOfYear # freq=1196171 freq=1158682
+AndHighHighDayTaxoFacets: +name +been +facets:taxonomy:DayOfYear # freq=2827713 freq=1041183
+AndHighHighDayTaxoFacets: +last +2009 +facets:taxonomy:DayOfYear # freq=958437 freq=887702
+AndHighHighDayTaxoFacets: +they +2005 +facets:taxonomy:DayOfYear # freq=1021945 freq=835460
+AndHighHighDayTaxoFacets: +new +1 +facets:taxonomy:DayOfYear # freq=1657293 freq=1641090
+AndHighHighDayTaxoFacets: +title +some +facets:taxonomy:DayOfYear # freq=2397378 freq=839919
+AndHighHighDayTaxoFacets: +name +5 +facets:taxonomy:DayOfYear # freq=2827713 freq=891361
+AndHighHighDayTaxoFacets: +and +or +facets:taxonomy:DayOfYear # freq=7318061 freq=1858841
+AndHighHighDayTaxoFacets: +3 +2006 +facets:taxonomy:DayOfYear # freq=1148799 freq=889954
+AndHighHighDayTaxoFacets: +of +has +facets:taxonomy:DayOfYear # freq=8184358 freq=1502961
+AndHighHighDayTaxoFacets: +which +i +facets:taxonomy:DayOfYear # freq=1963428 freq=956148
+AndHighHighDayTaxoFacets: +see +5 +facets:taxonomy:DayOfYear # freq=1044180 freq=891361
+AndHighHighDayTaxoFacets: +has +2011 +facets:taxonomy:DayOfYear # freq=1502961 freq=871410
+AndHighHighDayTaxoFacets: +new +accessdate +facets:taxonomy:DayOfYear # freq=1657293 freq=1228887
+AndHighHighDayTaxoFacets: +united +i +facets:taxonomy:DayOfYear # freq=1196944 freq=956148
+AndHighHighDayTaxoFacets: +are +10 +facets:taxonomy:DayOfYear # freq=1877802 freq=918339
+AndHighHighDayTaxoFacets: +the +is +facets:taxonomy:DayOfYear # freq=8217362 freq=4074455
+AndHighHighDayTaxoFacets: +other +web +facets:taxonomy:DayOfYear # freq=1269961 freq=1118334
+AndHighHighDayTaxoFacets: +i +2006 +facets:taxonomy:DayOfYear # freq=956148 freq=889954
+AndHighHighDayTaxoFacets: +were +publisher +facets:taxonomy:DayOfYear # freq=1524630 freq=1289029
+AndHighHighDayTaxoFacets: +be +when +facets:taxonomy:DayOfYear # freq=2051702 freq=1027487
+AndHighHighDayTaxoFacets: +to +date +facets:taxonomy:DayOfYear # freq=6155577 freq=2020626
+AndHighHighDayTaxoFacets: +for +2006 +facets:taxonomy:DayOfYear # freq=4380011 freq=889954
+AndHighHighDayTaxoFacets: +for +at +facets:taxonomy:DayOfYear # freq=4380011 freq=2857534
+AndHighHighDayTaxoFacets: +his +s +facets:taxonomy:DayOfYear # freq=1777780 freq=1581243
+AndHighHighDayTaxoFacets: +from +or +facets:taxonomy:DayOfYear # freq=3224339 freq=1858841
+AndHighHighDayTaxoFacets: +ref +an +facets:taxonomy:DayOfYear # freq=3793973 freq=2628056
+AndHighHighDayTaxoFacets: +which +had +facets:taxonomy:DayOfYear # freq=1963428 freq=1246743
+AndHighHighDayTaxoFacets: +an +were +facets:taxonomy:DayOfYear # freq=2628056 freq=1524630
+AndHighHighDayTaxoFacets: +web +only +facets:taxonomy:DayOfYear # freq=1118334 freq=875561
+AndHighHighDayTaxoFacets: +ref +one +facets:taxonomy:DayOfYear # freq=3793973 freq=1527689
+AndHighHighDayTaxoFacets: +a +one +facets:taxonomy:DayOfYear # freq=6560531 freq=1527689
+AndHighHighDayTaxoFacets: +they +into +facets:taxonomy:DayOfYear # freq=1021945 freq=888684
+AndHighHighDayTaxoFacets: +of +2008 +facets:taxonomy:DayOfYear # freq=8184358 freq=831253
+AndHighHighDayTaxoFacets: +in +which +facets:taxonomy:DayOfYear # freq=7320987 freq=1963428
+AndHighHighDayTaxoFacets: +united +2010 +facets:taxonomy:DayOfYear # freq=1196944 freq=950573
+AndHighHighDayTaxoFacets: +after +i +facets:taxonomy:DayOfYear # freq=1247398 freq=956148
+AndHighHighDayTaxoFacets: +he +web +facets:taxonomy:DayOfYear # freq=1659434 freq=1118334
+AndHighHighDayTaxoFacets: +are +states +facets:taxonomy:DayOfYear # freq=1877802 freq=1034872
+AndHighHighDayTaxoFacets: +after +time +facets:taxonomy:DayOfYear # freq=1247398 freq=1032071
+AndHighHighDayTaxoFacets: +its +web +facets:taxonomy:DayOfYear # freq=1173450 freq=1118334
+AndHighHighDayTaxoFacets: +for +when +facets:taxonomy:DayOfYear # freq=4380011 freq=1027487
+AndHighHighDayTaxoFacets: +has +states +facets:taxonomy:DayOfYear # freq=1502961 freq=1034872
+AndHighHighDayTaxoFacets: +the +no +facets:taxonomy:DayOfYear # freq=8217362 freq=1045000
+AndHighHighDayTaxoFacets: +title +one +facets:taxonomy:DayOfYear # freq=2397378 freq=1527689
+AndHighHighDayTaxoFacets: +i +2009 +facets:taxonomy:DayOfYear # freq=956148 freq=887702
+AndHighHighDayTaxoFacets: +1 +states +facets:taxonomy:DayOfYear # freq=1641090 freq=1034872
+AndHighHighDayTaxoFacets: +other +only +facets:taxonomy:DayOfYear # freq=1269961 freq=875561
+AndHighHighDayTaxoFacets: +by +they +facets:taxonomy:DayOfYear # freq=3826691 freq=1021945
+AndHighHighDayTaxoFacets: +http +its +facets:taxonomy:DayOfYear # freq=3493581 freq=1173450
+AndHighHighDayTaxoFacets: +for +two +facets:taxonomy:DayOfYear # freq=4380011 freq=1104053
+AndHighHighDayTaxoFacets: +all +may +facets:taxonomy:DayOfYear # freq=1203572 freq=1071932
+AndHighHighDayTaxoFacets: +after +last +facets:taxonomy:DayOfYear # freq=1247398 freq=958437
+AndHighHighDayTaxoFacets: +there +only +facets:taxonomy:DayOfYear # freq=956153 freq=875561
+AndHighHighDayTaxoFacets: +2 +no +facets:taxonomy:DayOfYear # freq=1549245 freq=1045000
+AndHighHighDayTaxoFacets: +an +he +facets:taxonomy:DayOfYear # freq=2628056 freq=1659434
+AndHighHighDayTaxoFacets: +his +i +facets:taxonomy:DayOfYear # freq=1777780 freq=956148
+AndHighHighDayTaxoFacets: +first +not +facets:taxonomy:DayOfYear # freq=1933372 freq=1713264
+AndHighHighDayTaxoFacets: +a +5 +facets:taxonomy:DayOfYear # freq=6560531 freq=891361
+AndHighHighDayTaxoFacets: +from +2005 +facets:taxonomy:DayOfYear # freq=3224339 freq=835460
+AndHighHighDayTaxoFacets: +after +web +facets:taxonomy:DayOfYear # freq=1247398 freq=1118334
+AndHighHighDayTaxoFacets: +to +which +facets:taxonomy:DayOfYear # freq=6155577 freq=1963428
+AndHighHighDayTaxoFacets: +this +into +facets:taxonomy:DayOfYear # freq=2224932 freq=888684
+AndHighHighDayTaxoFacets: +its +last +facets:taxonomy:DayOfYear # freq=1173450 freq=958437
+AndHighHighDayTaxoFacets: +it +there +facets:taxonomy:DayOfYear # freq=2675552 freq=956153
+AndHighHighDayTaxoFacets: +name +are +facets:taxonomy:DayOfYear # freq=2827713 freq=1877802
+AndHighHighDayTaxoFacets: +are +4 +facets:taxonomy:DayOfYear # freq=1877802 freq=986452
+AndHighHighDayTaxoFacets: +name +cite +facets:taxonomy:DayOfYear # freq=2827713 freq=1741194
+AndHighHighDayTaxoFacets: +more +2008 +facets:taxonomy:DayOfYear # freq=963533 freq=831253
+AndHighHighDayTaxoFacets: +of +that +facets:taxonomy:DayOfYear # freq=8184358 freq=2931020
+AndHighHighDayTaxoFacets: +ref +at +facets:taxonomy:DayOfYear # freq=3793973 freq=2857534
+AndHighHighDayTaxoFacets: +new +web +facets:taxonomy:DayOfYear # freq=1657293 freq=1118334
+AndHighHighDayTaxoFacets: +the +2 +facets:taxonomy:DayOfYear # freq=8217362 freq=1549245
+AndHighHighDayTaxoFacets: +for +1 +facets:taxonomy:DayOfYear # freq=4380011 freq=1641090
+AndHighHighDayTaxoFacets: +by +no +facets:taxonomy:DayOfYear # freq=3826691 freq=1045000
+AndHighHighDayTaxoFacets: +all +i +facets:taxonomy:DayOfYear # freq=1203572 freq=956148
+AndHighHighDayTaxoFacets: +5 +2006 +facets:taxonomy:DayOfYear # freq=891361 freq=889954
+AndHighHighDayTaxoFacets: +4 +work +facets:taxonomy:DayOfYear # freq=986452 freq=853422
+AndHighHighDayTaxoFacets: +was +new +facets:taxonomy:DayOfYear # freq=3763623 freq=1657293
+AndHighHighDayTaxoFacets: +year +see +facets:taxonomy:DayOfYear # freq=1235231 freq=1044180
+AndHighHighDayTaxoFacets: +s +had +facets:taxonomy:DayOfYear # freq=1581243 freq=1246743
+AndHighHighDayTaxoFacets: +an +last +facets:taxonomy:DayOfYear # freq=2628056 freq=958437
+AndHighHighDayTaxoFacets: +had +4 +facets:taxonomy:DayOfYear # freq=1246743 freq=986452
+AndHighHighDayTaxoFacets: +from +publisher +facets:taxonomy:DayOfYear # freq=3224339 freq=1289029
+AndHighHighDayTaxoFacets: +new +url +facets:taxonomy:DayOfYear # freq=1657293 freq=1513595
+AndHighHighDayTaxoFacets: +4 +5 +facets:taxonomy:DayOfYear # freq=986452 freq=891361
+AndHighHighDayTaxoFacets: +by +cite +facets:taxonomy:DayOfYear # freq=3826691 freq=1741194
+AndHighHighDayTaxoFacets: +2010 +2009 +facets:taxonomy:DayOfYear # freq=950573 freq=887702
+AndHighHighDayTaxoFacets: +their +4 +facets:taxonomy:DayOfYear # freq=1158682 freq=986452
+AndHighHighDayTaxoFacets: +publisher +who +facets:taxonomy:DayOfYear # freq=1289029 freq=1196171
+AndHighHighDayTaxoFacets: +that +more +facets:taxonomy:DayOfYear # freq=2931020 freq=963533
+AndHighHighDayTaxoFacets: +ref +see +facets:taxonomy:DayOfYear # freq=3793973 freq=1044180
+AndHighHighDayTaxoFacets: +publisher +last +facets:taxonomy:DayOfYear # freq=1289029 freq=958437
+AndHighHighDayTaxoFacets: +but +their +facets:taxonomy:DayOfYear # freq=1456553 freq=1158682
+AndHighHighDayTaxoFacets: +is +1 +facets:taxonomy:DayOfYear # freq=4074455 freq=1641090
+AndHighHighDayTaxoFacets: +new +have +facets:taxonomy:DayOfYear # freq=1657293 freq=1297121
+AndHighHighDayTaxoFacets: +title +also +facets:taxonomy:DayOfYear # freq=2397378 freq=1959419
+AndHighHighDayTaxoFacets: +also +i +facets:taxonomy:DayOfYear # freq=1959419 freq=956148
+AndHighHighDayTaxoFacets: +had +into +facets:taxonomy:DayOfYear # freq=1246743 freq=888684
+AndHighHighDayTaxoFacets: +first +when +facets:taxonomy:DayOfYear # freq=1933372 freq=1027487
+AndHighHighDayTaxoFacets: +in +be +facets:taxonomy:DayOfYear # freq=7320987 freq=2051702
+AndHighHighDayTaxoFacets: +are +2008 +facets:taxonomy:DayOfYear # freq=1877802 freq=831253
+AndHighHighDayTaxoFacets: +two +2006 +facets:taxonomy:DayOfYear # freq=1104053 freq=889954
+AndHighHighDayTaxoFacets: +date +about +facets:taxonomy:DayOfYear # freq=2020626 freq=850283
+AndHighHighDayTaxoFacets: +its +only +facets:taxonomy:DayOfYear # freq=1173450 freq=875561
+AndHighHighDayTaxoFacets: +title +new +facets:taxonomy:DayOfYear # freq=2397378 freq=1657293
+AndHighHighDayTaxoFacets: +2 +10 +facets:taxonomy:DayOfYear # freq=1549245 freq=918339
+AndHighHighDayTaxoFacets: +2 +one +facets:taxonomy:DayOfYear # freq=1549245 freq=1527689
+AndHighHighDayTaxoFacets: +is +an +facets:taxonomy:DayOfYear # freq=4074455 freq=2628056
+AndHighHighDayTaxoFacets: +at +no +facets:taxonomy:DayOfYear # freq=2857534 freq=1045000
+AndHighHighDayTaxoFacets: +has +its +facets:taxonomy:DayOfYear # freq=1502961 freq=1173450
+AndHighHighDayTaxoFacets: +were +there +facets:taxonomy:DayOfYear # freq=1524630 freq=956153
+AndHighHighDayTaxoFacets: +with +were +facets:taxonomy:DayOfYear # freq=3709421 freq=1524630
+AndHighHighDayTaxoFacets: +on +i +facets:taxonomy:DayOfYear # freq=4074624 freq=956148
+AndHighHighDayTaxoFacets: +as +was +facets:taxonomy:DayOfYear # freq=3925535 freq=3763623
+AndHighHighDayTaxoFacets: +date +cite +facets:taxonomy:DayOfYear # freq=2020626 freq=1741194
+AndHighHighDayTaxoFacets: +or +united +facets:taxonomy:DayOfYear # freq=1858841 freq=1196944
+AndHighHighDayTaxoFacets: +to +http +facets:taxonomy:DayOfYear # freq=6155577 freq=3493581
+AndHighHighDayTaxoFacets: +he +have +facets:taxonomy:DayOfYear # freq=1659434 freq=1297121
+AndHighHighDayTaxoFacets: +s +about +facets:taxonomy:DayOfYear # freq=1581243 freq=850283
+AndHighHighDayTaxoFacets: +this +s +facets:taxonomy:DayOfYear # freq=2224932 freq=1581243
+AndHighHighDayTaxoFacets: +is +but +facets:taxonomy:DayOfYear # freq=4074455 freq=1456553
+AndHighHighDayTaxoFacets: +web +2010 +facets:taxonomy:DayOfYear # freq=1118334 freq=950573
+AndHighHighDayTaxoFacets: +first +are +facets:taxonomy:DayOfYear # freq=1933372 freq=1877802
+AndHighHighDayTaxoFacets: +have +2008 +facets:taxonomy:DayOfYear # freq=1297121 freq=831253
+AndHighHighDayTaxoFacets: +to +no +facets:taxonomy:DayOfYear # freq=6155577 freq=1045000
+AndHighHighDayTaxoFacets: +or +2 +facets:taxonomy:DayOfYear # freq=1858841 freq=1549245
+AndHighHighDayTaxoFacets: +was +about +facets:taxonomy:DayOfYear # freq=3763623 freq=850283
+AndHighHighDayTaxoFacets: +cite +more +facets:taxonomy:DayOfYear # freq=1741194 freq=963533
+AndHighHighDayTaxoFacets: +date +their +facets:taxonomy:DayOfYear # freq=2020626 freq=1158682
+AndHighHighDayTaxoFacets: +from +work +facets:taxonomy:DayOfYear # freq=3224339 freq=853422
+AndHighHighDayTaxoFacets: +at +2010 +facets:taxonomy:DayOfYear # freq=2857534 freq=950573
+AndHighHighDayTaxoFacets: +other +last +facets:taxonomy:DayOfYear # freq=1269961 freq=958437
+AndHighHighDayTaxoFacets: +date +into +facets:taxonomy:DayOfYear # freq=2020626 freq=888684
+AndHighHighDayTaxoFacets: +they +more +facets:taxonomy:DayOfYear # freq=1021945 freq=963533
+AndHighHighDayTaxoFacets: +to +ref +facets:taxonomy:DayOfYear # freq=6155577 freq=3793973
+AndHighHighDayTaxoFacets: +be +but +facets:taxonomy:DayOfYear # freq=2051702 freq=1456553
+AndHighHighDayTaxoFacets: +or +into +facets:taxonomy:DayOfYear # freq=1858841 freq=888684
+AndHighHighDayTaxoFacets: +has +last +facets:taxonomy:DayOfYear # freq=1502961 freq=958437
+AndHighHighDayTaxoFacets: +to +time +facets:taxonomy:DayOfYear # freq=6155577 freq=1032071
+AndHighHighDayTaxoFacets: +the +some +facets:taxonomy:DayOfYear # freq=8217362 freq=839919
+AndHighHighDayTaxoFacets: +ref +united +facets:taxonomy:DayOfYear # freq=3793973 freq=1196944
+AndHighHighDayTaxoFacets: +all +last +facets:taxonomy:DayOfYear # freq=1203572 freq=958437
+AndHighHighDayTaxoFacets: +url +all +facets:taxonomy:DayOfYear # freq=1513595 freq=1203572
+AndHighHighDayTaxoFacets: +other +some +facets:taxonomy:DayOfYear # freq=1269961 freq=839919
+AndHighHighDayTaxoFacets: +cite +new +facets:taxonomy:DayOfYear # freq=1741194 freq=1657293
+AndHighHighDayTaxoFacets: +and +by +facets:taxonomy:DayOfYear # freq=7318061 freq=3826691
+AndHighHighDayTaxoFacets: +publisher +i +facets:taxonomy:DayOfYear # freq=1289029 freq=956148
+AndHighHighDayTaxoFacets: +to +publisher +facets:taxonomy:DayOfYear # freq=6155577 freq=1289029
+AndHighHighDayTaxoFacets: +the +about +facets:taxonomy:DayOfYear # freq=8217362 freq=850283
+AndHighHighDayTaxoFacets: +as +are +facets:taxonomy:DayOfYear # freq=3925535 freq=1877802
+AndHighHighDayTaxoFacets: +it +title +facets:taxonomy:DayOfYear # freq=2675552 freq=2397378
+AndHighHighDayTaxoFacets: +by +are +facets:taxonomy:DayOfYear # freq=3826691 freq=1877802
+AndHighHighDayTaxoFacets: +has +have +facets:taxonomy:DayOfYear # freq=1502961 freq=1297121
+AndHighHighDayTaxoFacets: +one +2011 +facets:taxonomy:DayOfYear # freq=1527689 freq=871410
+AndHighHighDayTaxoFacets: +are +2005 +facets:taxonomy:DayOfYear # freq=1877802 freq=835460
+AndHighHighDayTaxoFacets: +had +some +facets:taxonomy:DayOfYear # freq=1246743 freq=839919
+AndHighHighDayTaxoFacets: +by +when +facets:taxonomy:DayOfYear # freq=3826691 freq=1027487
+AndHighHighDayTaxoFacets: +it +2011 +facets:taxonomy:DayOfYear # freq=2675552 freq=871410
+AndHighHighDayTaxoFacets: +1 +they +facets:taxonomy:DayOfYear # freq=1641090 freq=1021945
+AndHighHighDayTaxoFacets: +on +their +facets:taxonomy:DayOfYear # freq=4074624 freq=1158682
+AndHighHighDayTaxoFacets: +been +10 +facets:taxonomy:DayOfYear # freq=1041183 freq=918339
+AndHighHighDayTaxoFacets: +was +only +facets:taxonomy:DayOfYear # freq=3763623 freq=875561
+AndHighHighDayTaxoFacets: +also +other +facets:taxonomy:DayOfYear # freq=1959419 freq=1269961
+AndHighHighDayTaxoFacets: +who +its +facets:taxonomy:DayOfYear # freq=1196171 freq=1173450
+AndHighHighDayTaxoFacets: +3 +may +facets:taxonomy:DayOfYear # freq=1148799 freq=1071932
+AndHighHighDayTaxoFacets: +with +2006 +facets:taxonomy:DayOfYear # freq=3709421 freq=889954
+AndHighHighDayTaxoFacets: +from +but +facets:taxonomy:DayOfYear # freq=3224339 freq=1456553
+AndHighHighDayTaxoFacets: +was +work +facets:taxonomy:DayOfYear # freq=3763623 freq=853422
+AndHighHighDayTaxoFacets: +as +also +facets:taxonomy:DayOfYear # freq=3925535 freq=1959419
+AndHighHighDayTaxoFacets: +which +into +facets:taxonomy:DayOfYear # freq=1963428 freq=888684
+AndHighHighDayTaxoFacets: +see +i +facets:taxonomy:DayOfYear # freq=1044180 freq=956148
+AndHighHighDayTaxoFacets: +have +more +facets:taxonomy:DayOfYear # freq=1297121 freq=963533
+AndHighHighDayTaxoFacets: +were +after +facets:taxonomy:DayOfYear # freq=1524630 freq=1247398
+AndHighHighDayTaxoFacets: +on +2010 +facets:taxonomy:DayOfYear # freq=4074624 freq=950573
+AndHighHighDayTaxoFacets: +is +had +facets:taxonomy:DayOfYear # freq=4074455 freq=1246743
+AndHighHighDayTaxoFacets: +he +5 +facets:taxonomy:DayOfYear # freq=1659434 freq=891361
+AndHighHighDayTaxoFacets: +first +year +facets:taxonomy:DayOfYear # freq=1933372 freq=1235231
+AndHighHighDayTaxoFacets: +not +url +facets:taxonomy:DayOfYear # freq=1713264 freq=1513595
+AndHighHighDayTaxoFacets: +first +his +facets:taxonomy:DayOfYear # freq=1933372 freq=1777780
+AndHighHighDayTaxoFacets: +date +10 +facets:taxonomy:DayOfYear # freq=2020626 freq=918339
+AndHighHighDayTaxoFacets: +was +not +facets:taxonomy:DayOfYear # freq=3763623 freq=1713264
+AndHighHighDayTaxoFacets: +and +may +facets:taxonomy:DayOfYear # freq=7318061 freq=1071932
+AndHighHighDayTaxoFacets: +no +more +facets:taxonomy:DayOfYear # freq=1045000 freq=963533
+AndHighHighDayTaxoFacets: +it +url +facets:taxonomy:DayOfYear # freq=2675552 freq=1513595
+AndHighHighDayTaxoFacets: +as +no +facets:taxonomy:DayOfYear # freq=3925535 freq=1045000
+AndHighHighDayTaxoFacets: +other +all +facets:taxonomy:DayOfYear # freq=1269961 freq=1203572
+AndHighHighDayTaxoFacets: +as +2 +facets:taxonomy:DayOfYear # freq=3925535 freq=1549245
+AndHighHighDayTaxoFacets: +for +as +facets:taxonomy:DayOfYear # freq=4380011 freq=3925535
+AndHighHighDayTaxoFacets: +for +there +facets:taxonomy:DayOfYear # freq=4380011 freq=956153
+AndHighHighDayTaxoFacets: +the +new +facets:taxonomy:DayOfYear # freq=8217362 freq=1657293
+AndHighHighDayTaxoFacets: +is +no +facets:taxonomy:DayOfYear # freq=4074455 freq=1045000
+AndHighHighDayTaxoFacets: +also +their +facets:taxonomy:DayOfYear # freq=1959419 freq=1158682
+AndHighHighDayTaxoFacets: +that +2010 +facets:taxonomy:DayOfYear # freq=2931020 freq=950573
+AndHighHighDayTaxoFacets: +s +2008 +facets:taxonomy:DayOfYear # freq=1581243 freq=831253
+AndHighHighDayTaxoFacets: +were +2009 +facets:taxonomy:DayOfYear # freq=1524630 freq=887702
+AndHighHighDayTaxoFacets: +of +after +facets:taxonomy:DayOfYear # freq=8184358 freq=1247398
+AndHighHighDayTaxoFacets: +of +an +facets:taxonomy:DayOfYear # freq=8184358 freq=2628056
+AndHighHighDayTaxoFacets: +the +10 +facets:taxonomy:DayOfYear # freq=8217362 freq=918339
+AndHighHighDayTaxoFacets: +title +web +facets:taxonomy:DayOfYear # freq=2397378 freq=1118334
+AndHighHighDayTaxoFacets: +on +they +facets:taxonomy:DayOfYear # freq=4074624 freq=1021945
+AndHighHighDayTaxoFacets: +to +have +facets:taxonomy:DayOfYear # freq=6155577 freq=1297121
+AndHighHighDayTaxoFacets: +was +its +facets:taxonomy:DayOfYear # freq=3763623 freq=1173450
+AndHighHighDayTaxoFacets: +at +time +facets:taxonomy:DayOfYear # freq=2857534 freq=1032071
+AndHighHighDayTaxoFacets: +2 +accessdate +facets:taxonomy:DayOfYear # freq=1549245 freq=1228887
+AndHighHighDayTaxoFacets: +with +united +facets:taxonomy:DayOfYear # freq=3709421 freq=1196944
+AndHighHighDayTaxoFacets: +in +about +facets:taxonomy:DayOfYear # freq=7320987 freq=850283
+AndHighHighDayTaxoFacets: +in +2005 +facets:taxonomy:DayOfYear # freq=7320987 freq=835460
+AndHighHighDayTaxoFacets: +for +last +facets:taxonomy:DayOfYear # freq=4380011 freq=958437
+AndHighHighDayTaxoFacets: +and +when +facets:taxonomy:DayOfYear # freq=7318061 freq=1027487
+AndHighHighDayTaxoFacets: +an +their +facets:taxonomy:DayOfYear # freq=2628056 freq=1158682
+AndHighHighDayTaxoFacets: +2010 +into +facets:taxonomy:DayOfYear # freq=950573 freq=888684
+AndHighHighDayTaxoFacets: +web +two +facets:taxonomy:DayOfYear # freq=1118334 freq=1104053
+AndHighHighDayTaxoFacets: +two +4 +facets:taxonomy:DayOfYear # freq=1104053 freq=986452
+AndHighHighDayTaxoFacets: +1 +there +facets:taxonomy:DayOfYear # freq=1641090 freq=956153
+AndHighHighDayTaxoFacets: +name +url +facets:taxonomy:DayOfYear # freq=2827713 freq=1513595
+AndHighHighDayTaxoFacets: +united +who +facets:taxonomy:DayOfYear # freq=1196944 freq=1196171
+AndHighHighDayTaxoFacets: +they +there +facets:taxonomy:DayOfYear # freq=1021945 freq=956153
+AndHighHighDayTaxoFacets: +http +5 +facets:taxonomy:DayOfYear # freq=3493581 freq=891361
+AndHighHighDayTaxoFacets: +not +2008 +facets:taxonomy:DayOfYear # freq=1713264 freq=831253
+AndHighHighDayTaxoFacets: +are +2009 +facets:taxonomy:DayOfYear # freq=1877802 freq=887702
+AndHighHighDayTaxoFacets: +on +may +facets:taxonomy:DayOfYear # freq=4074624 freq=1071932
+AndHighHighDayTaxoFacets: +is +are +facets:taxonomy:DayOfYear # freq=4074455 freq=1877802
+AndHighHighDayTaxoFacets: +been +there +facets:taxonomy:DayOfYear # freq=1041183 freq=956153
+AndHighHighDayTaxoFacets: +other +into +facets:taxonomy:DayOfYear # freq=1269961 freq=888684
+AndHighHighDayTaxoFacets: +be +their +facets:taxonomy:DayOfYear # freq=2051702 freq=1158682
+AndHighHighDayTaxoFacets: +new +other +facets:taxonomy:DayOfYear # freq=1657293 freq=1269961
+AndHighHighDayTaxoFacets: +its +2011 +facets:taxonomy:DayOfYear # freq=1173450 freq=871410
+AndHighHighDayTaxoFacets: +ref +3 +facets:taxonomy:DayOfYear # freq=3793973 freq=1148799
+AndHighHighDayTaxoFacets: +name +be +facets:taxonomy:DayOfYear # freq=2827713 freq=2051702
+AndHighHighDayTaxoFacets: +had +see +facets:taxonomy:DayOfYear # freq=1246743 freq=1044180
+AndHighHighDayTaxoFacets: +also +or +facets:taxonomy:DayOfYear # freq=1959419 freq=1858841
+AndHighHighDayTaxoFacets: +but +4 +facets:taxonomy:DayOfYear # freq=1456553 freq=986452
+AndHighMedDayTaxoFacets: +has +please +facets:taxonomy:DayOfYear # freq=1502961 freq=229602
+AndHighMedDayTaxoFacets: +he +battle +facets:taxonomy:DayOfYear # freq=1659434 freq=192357
+AndHighMedDayTaxoFacets: +be +century +facets:taxonomy:DayOfYear # freq=2051702 freq=385541
+AndHighMedDayTaxoFacets: +may +studio +facets:taxonomy:DayOfYear # freq=1071932 freq=101979
+AndHighMedDayTaxoFacets: +have +level +facets:taxonomy:DayOfYear # freq=1297121 freq=175382
+AndHighMedDayTaxoFacets: +web +place +facets:taxonomy:DayOfYear # freq=1118334 freq=654158
+AndHighMedDayTaxoFacets: +all +close +facets:taxonomy:DayOfYear # freq=1203572 freq=136706
+AndHighMedDayTaxoFacets: +as +chart +facets:taxonomy:DayOfYear # freq=3925535 freq=84194
+AndHighMedDayTaxoFacets: +ref +appropriate +facets:taxonomy:DayOfYear # freq=3793973 freq=135343
+AndHighMedDayTaxoFacets: +be +put +facets:taxonomy:DayOfYear # freq=2051702 freq=139882
+AndHighMedDayTaxoFacets: +and +called +facets:taxonomy:DayOfYear # freq=7318061 freq=454580
+AndHighMedDayTaxoFacets: +been +four +facets:taxonomy:DayOfYear # freq=1041183 freq=389818
+AndHighMedDayTaxoFacets: +url +whether +facets:taxonomy:DayOfYear # freq=1513595 freq=93965
+AndHighMedDayTaxoFacets: +with +day +facets:taxonomy:DayOfYear # freq=3709421 freq=402096
+AndHighMedDayTaxoFacets: +a +famous +facets:taxonomy:DayOfYear # freq=6560531 freq=139092
+AndHighMedDayTaxoFacets: +it +nature +facets:taxonomy:DayOfYear # freq=2675552 freq=107428
+AndHighMedDayTaxoFacets: +his +although +facets:taxonomy:DayOfYear # freq=1777780 freq=341432
+AndHighMedDayTaxoFacets: +1 +artists +facets:taxonomy:DayOfYear # freq=1641090 freq=107145
+AndHighMedDayTaxoFacets: +title +digital +facets:taxonomy:DayOfYear # freq=2397378 freq=82650
+AndHighMedDayTaxoFacets: +that +37 +facets:taxonomy:DayOfYear # freq=2931020 freq=126429
+AndHighMedDayTaxoFacets: +was +free +facets:taxonomy:DayOfYear # freq=3763623 freq=270199
+AndHighMedDayTaxoFacets: +5 +west +facets:taxonomy:DayOfYear # freq=891361 freq=431006
+AndHighMedDayTaxoFacets: +had +reference +facets:taxonomy:DayOfYear # freq=1246743 freq=111493
+AndHighMedDayTaxoFacets: +in +sports +facets:taxonomy:DayOfYear # freq=7320987 freq=178542
+AndHighMedDayTaxoFacets: +its +interview +facets:taxonomy:DayOfYear # freq=1173450 freq=98846
+AndHighMedDayTaxoFacets: +url +took +facets:taxonomy:DayOfYear # freq=1513595 freq=247388
+AndHighMedDayTaxoFacets: +and +los +facets:taxonomy:DayOfYear # freq=7318061 freq=145404
+AndHighMedDayTaxoFacets: +last +english +facets:taxonomy:DayOfYear # freq=958437 freq=412061
+AndHighMedDayTaxoFacets: +not +lee +facets:taxonomy:DayOfYear # freq=1713264 freq=90461
+AndHighMedDayTaxoFacets: +their +few +facets:taxonomy:DayOfYear # freq=1158682 freq=226422
+AndHighMedDayTaxoFacets: +they +round +facets:taxonomy:DayOfYear # freq=1021945 freq=122499
+AndHighMedDayTaxoFacets: +cite +area +facets:taxonomy:DayOfYear # freq=1741194 freq=559023
+AndHighMedDayTaxoFacets: +two +lake +facets:taxonomy:DayOfYear # freq=1104053 freq=131603
+AndHighMedDayTaxoFacets: +time +8 +facets:taxonomy:DayOfYear # freq=1032071 freq=635822
+AndHighMedDayTaxoFacets: +this +winning +facets:taxonomy:DayOfYear # freq=2224932 freq=95704
+AndHighMedDayTaxoFacets: +only +performed +facets:taxonomy:DayOfYear # freq=875561 freq=104044
+AndHighMedDayTaxoFacets: +when +books.google.com +facets:taxonomy:DayOfYear # freq=1027487 freq=119391
+AndHighMedDayTaxoFacets: +who +legal +facets:taxonomy:DayOfYear # freq=1196171 freq=90645
+AndHighMedDayTaxoFacets: +2009 +keep +facets:taxonomy:DayOfYear # freq=887702 freq=177996
+AndHighMedDayTaxoFacets: +http +running +facets:taxonomy:DayOfYear # freq=3493581 freq=101764
+AndHighMedDayTaxoFacets: +5 +grand +facets:taxonomy:DayOfYear # freq=891361 freq=139202
+AndHighMedDayTaxoFacets: +it +man +facets:taxonomy:DayOfYear # freq=2675552 freq=278112
+AndHighMedDayTaxoFacets: +had +entertainment +facets:taxonomy:DayOfYear # freq=1246743 freq=117931
+AndHighMedDayTaxoFacets: +with +200px +facets:taxonomy:DayOfYear # freq=3709421 freq=102661
+AndHighMedDayTaxoFacets: +had +van +facets:taxonomy:DayOfYear # freq=1246743 freq=116920
+AndHighMedDayTaxoFacets: +was +track +facets:taxonomy:DayOfYear # freq=3763623 freq=148840
+AndHighMedDayTaxoFacets: +10 +corporation +facets:taxonomy:DayOfYear # freq=918339 freq=107425
+AndHighMedDayTaxoFacets: +other +make +facets:taxonomy:DayOfYear # freq=1269961 freq=292607
+AndHighMedDayTaxoFacets: +first +results +facets:taxonomy:DayOfYear # freq=1933372 freq=137248
+AndHighMedDayTaxoFacets: +2010 +unreferenced +facets:taxonomy:DayOfYear # freq=950573 freq=107803
+AndHighMedDayTaxoFacets: +first +top +facets:taxonomy:DayOfYear # freq=1933372 freq=364628
+AndHighMedDayTaxoFacets: +his +en +facets:taxonomy:DayOfYear # freq=1777780 freq=277463
+AndHighMedDayTaxoFacets: +other +airport +facets:taxonomy:DayOfYear # freq=1269961 freq=88205
+AndHighMedDayTaxoFacets: +10 +march +facets:taxonomy:DayOfYear # freq=918339 freq=620393
+AndHighMedDayTaxoFacets: +all +recently +facets:taxonomy:DayOfYear # freq=1203572 freq=90249
+AndHighMedDayTaxoFacets: +were +genre +facets:taxonomy:DayOfYear # freq=1524630 freq=121233
+AndHighMedDayTaxoFacets: +and +program +facets:taxonomy:DayOfYear # freq=7318061 freq=173553
+AndHighMedDayTaxoFacets: +i +09 +facets:taxonomy:DayOfYear # freq=956148 freq=296300
+AndHighMedDayTaxoFacets: +to +ended +facets:taxonomy:DayOfYear # freq=6155577 freq=84664
+AndHighMedDayTaxoFacets: +not +playing +facets:taxonomy:DayOfYear # freq=1713264 freq=133330
+AndHighMedDayTaxoFacets: +time +companies +facets:taxonomy:DayOfYear # freq=1032071 freq=98905
+AndHighMedDayTaxoFacets: +to +living +facets:taxonomy:DayOfYear # freq=6155577 freq=181427
+AndHighMedDayTaxoFacets: +of +silver +facets:taxonomy:DayOfYear # freq=8184358 freq=85967
+AndHighMedDayTaxoFacets: +in +images +facets:taxonomy:DayOfYear # freq=7320987 freq=125154
+AndHighMedDayTaxoFacets: +2008 +debate +facets:taxonomy:DayOfYear # freq=831253 freq=177827
+AndHighMedDayTaxoFacets: +some +los +facets:taxonomy:DayOfYear # freq=839919 freq=145404
+AndHighMedDayTaxoFacets: +2008 +simply +facets:taxonomy:DayOfYear # freq=831253 freq=84090
+AndHighMedDayTaxoFacets: +first +producer +facets:taxonomy:DayOfYear # freq=1933372 freq=137098
+AndHighMedDayTaxoFacets: +last +seven +facets:taxonomy:DayOfYear # freq=958437 freq=134402
+AndHighMedDayTaxoFacets: +more +soon +facets:taxonomy:DayOfYear # freq=963533 freq=123657
+AndHighMedDayTaxoFacets: +date +talk +facets:taxonomy:DayOfYear # freq=2020626 freq=364194
+AndHighMedDayTaxoFacets: +its +49 +facets:taxonomy:DayOfYear # freq=1173450 freq=103612
+AndHighMedDayTaxoFacets: +publisher +car +facets:taxonomy:DayOfYear # freq=1289029 freq=121250
+AndHighMedDayTaxoFacets: +were +v +facets:taxonomy:DayOfYear # freq=1524630 freq=284318
+AndHighMedDayTaxoFacets: +more +says +facets:taxonomy:DayOfYear # freq=963533 freq=84589
+AndHighMedDayTaxoFacets: +3 +man +facets:taxonomy:DayOfYear # freq=1148799 freq=278112
+AndHighMedDayTaxoFacets: +but +1974 +facets:taxonomy:DayOfYear # freq=1456553 freq=132835
+AndHighMedDayTaxoFacets: +but +02 +facets:taxonomy:DayOfYear # freq=1456553 freq=319783
+AndHighMedDayTaxoFacets: +see +historic +facets:taxonomy:DayOfYear # freq=1044180 freq=112292
+AndHighMedDayTaxoFacets: +which +wife +facets:taxonomy:DayOfYear # freq=1963428 freq=130807
+AndHighMedDayTaxoFacets: +1 +grand +facets:taxonomy:DayOfYear # freq=1641090 freq=139202
+AndHighMedDayTaxoFacets: +it +real +facets:taxonomy:DayOfYear # freq=2675552 freq=151505
+AndHighMedDayTaxoFacets: +its +development +facets:taxonomy:DayOfYear # freq=1173450 freq=230286
+AndHighMedDayTaxoFacets: +3 +office +facets:taxonomy:DayOfYear # freq=1148799 freq=225338
+AndHighMedDayTaxoFacets: +10 +class +facets:taxonomy:DayOfYear # freq=918339 freq=556838
+AndHighMedDayTaxoFacets: +not +abbr +facets:taxonomy:DayOfYear # freq=1713264 freq=96135
+AndHighMedDayTaxoFacets: +accessdate +hand +facets:taxonomy:DayOfYear # freq=1228887 freq=119947
+AndHighMedDayTaxoFacets: +2011 +trade +facets:taxonomy:DayOfYear # freq=871410 freq=106384
+AndHighMedDayTaxoFacets: +that +love +facets:taxonomy:DayOfYear # freq=2931020 freq=177242
+AndHighMedDayTaxoFacets: +from +took +facets:taxonomy:DayOfYear # freq=3224339 freq=247388
+AndHighMedDayTaxoFacets: +united +id +facets:taxonomy:DayOfYear # freq=1196944 freq=579566
+AndHighMedDayTaxoFacets: +s +mi +facets:taxonomy:DayOfYear # freq=1581243 freq=97131
+AndHighMedDayTaxoFacets: +as +young +facets:taxonomy:DayOfYear # freq=3925535 freq=196428
+AndHighMedDayTaxoFacets: +3 +opening +facets:taxonomy:DayOfYear # freq=1148799 freq=84576
+AndHighMedDayTaxoFacets: +other +european +facets:taxonomy:DayOfYear # freq=1269961 freq=193975
+AndHighMedDayTaxoFacets: +ref +chart +facets:taxonomy:DayOfYear # freq=3793973 freq=84194
+AndHighMedDayTaxoFacets: +about +thought +facets:taxonomy:DayOfYear # freq=850283 freq=108963
+AndHighMedDayTaxoFacets: +for +should +facets:taxonomy:DayOfYear # freq=4380011 freq=401379
+AndHighMedDayTaxoFacets: +united +lead +facets:taxonomy:DayOfYear # freq=1196944 freq=141336
+AndHighMedDayTaxoFacets: +this +movie +facets:taxonomy:DayOfYear # freq=2224932 freq=133291
+AndHighMedDayTaxoFacets: +2011 +winning +facets:taxonomy:DayOfYear # freq=871410 freq=95704
+AndHighMedDayTaxoFacets: +new +shows +facets:taxonomy:DayOfYear # freq=1657293 freq=131923
+AndHighMedDayTaxoFacets: +no +him +facets:taxonomy:DayOfYear # freq=1045000 freq=507350
+AndHighMedDayTaxoFacets: +has +always +facets:taxonomy:DayOfYear # freq=1502961 freq=112388
+AndHighMedDayTaxoFacets: +ref +above +facets:taxonomy:DayOfYear # freq=3793973 freq=246135
+AndHighMedDayTaxoFacets: +have +uses +facets:taxonomy:DayOfYear # freq=1297121 freq=134331
+AndHighMedDayTaxoFacets: +who +80 +facets:taxonomy:DayOfYear # freq=1196171 freq=104865
+AndHighMedDayTaxoFacets: +2008 +series +facets:taxonomy:DayOfYear # freq=831253 freq=521861
+AndHighMedDayTaxoFacets: +ref +40 +facets:taxonomy:DayOfYear # freq=3793973 freq=221687
+AndHighMedDayTaxoFacets: +when +second +facets:taxonomy:DayOfYear # freq=1027487 freq=505575
+AndHighMedDayTaxoFacets: +at +parliament +facets:taxonomy:DayOfYear # freq=2857534 freq=127008
+AndHighMedDayTaxoFacets: +were +pacific +facets:taxonomy:DayOfYear # freq=1524630 freq=107648
+AndHighMedDayTaxoFacets: +2 +recent +facets:taxonomy:DayOfYear # freq=1549245 freq=113385
+AndHighMedDayTaxoFacets: +http +close +facets:taxonomy:DayOfYear # freq=3493581 freq=136706
+AndHighMedDayTaxoFacets: +has +power +facets:taxonomy:DayOfYear # freq=1502961 freq=262586
+AndHighMedDayTaxoFacets: +or +words +facets:taxonomy:DayOfYear # freq=1858841 freq=104783
+AndHighMedDayTaxoFacets: +after +mary +facets:taxonomy:DayOfYear # freq=1247398 freq=96445
+AndHighMedDayTaxoFacets: +3 +state +facets:taxonomy:DayOfYear # freq=1148799 freq=702598
+AndHighMedDayTaxoFacets: +its +directed +facets:taxonomy:DayOfYear # freq=1173450 freq=86592
+AndHighMedDayTaxoFacets: +more +army +facets:taxonomy:DayOfYear # freq=963533 freq=228105
+AndHighMedDayTaxoFacets: +see +genre +facets:taxonomy:DayOfYear # freq=1044180 freq=121233
+AndHighMedDayTaxoFacets: +5 +natural +facets:taxonomy:DayOfYear # freq=891361 freq=125503
+AndHighMedDayTaxoFacets: +into +ship +facets:taxonomy:DayOfYear # freq=888684 freq=113012
+AndHighMedDayTaxoFacets: +2005 +construction +facets:taxonomy:DayOfYear # freq=835460 freq=124179
+AndHighMedDayTaxoFacets: +some +found +facets:taxonomy:DayOfYear # freq=839919 freq=313247
+AndHighMedDayTaxoFacets: +2 +actor +facets:taxonomy:DayOfYear # freq=1549245 freq=144573
+AndHighMedDayTaxoFacets: +and +owned +facets:taxonomy:DayOfYear # freq=7318061 freq=93981
+AndHighMedDayTaxoFacets: +which +authority +facets:taxonomy:DayOfYear # freq=1963428 freq=85540
+AndHighMedDayTaxoFacets: +have +r +facets:taxonomy:DayOfYear # freq=1297121 freq=296283
+AndHighMedDayTaxoFacets: +is +approximately +facets:taxonomy:DayOfYear # freq=4074455 freq=88426
+AndHighMedDayTaxoFacets: +he +deletion +facets:taxonomy:DayOfYear # freq=1659434 freq=166633
+AndHighMedDayTaxoFacets: +and +jean +facets:taxonomy:DayOfYear # freq=7318061 freq=84299
+AndHighMedDayTaxoFacets: +have +43 +facets:taxonomy:DayOfYear # freq=1297121 freq=115496
+AndHighMedDayTaxoFacets: +only +daily +facets:taxonomy:DayOfYear # freq=875561 freq=111717
+AndHighMedDayTaxoFacets: +united +zealand +facets:taxonomy:DayOfYear # freq=1196944 freq=92761
+AndHighMedDayTaxoFacets: +also +read +facets:taxonomy:DayOfYear # freq=1959419 freq=86513
+AndHighMedDayTaxoFacets: +are +division +facets:taxonomy:DayOfYear # freq=1877802 freq=182624
+AndHighMedDayTaxoFacets: +for +seat +facets:taxonomy:DayOfYear # freq=4380011 freq=91288
+AndHighMedDayTaxoFacets: +2005 +hand +facets:taxonomy:DayOfYear # freq=835460 freq=119947
+AndHighMedDayTaxoFacets: +publisher +usually +facets:taxonomy:DayOfYear # freq=1289029 freq=176058
+AndHighMedDayTaxoFacets: +from +teams +facets:taxonomy:DayOfYear # freq=3224339 freq=105245
+AndHighMedDayTaxoFacets: +in +wife +facets:taxonomy:DayOfYear # freq=7320987 freq=130807
+AndHighMedDayTaxoFacets: +2006 +james +facets:taxonomy:DayOfYear # freq=889954 freq=281597
+AndHighMedDayTaxoFacets: +2005 +found +facets:taxonomy:DayOfYear # freq=835460 freq=313247
+AndHighMedDayTaxoFacets: +after +replaced +facets:taxonomy:DayOfYear # freq=1247398 freq=112506
+AndHighMedDayTaxoFacets: +5 +played +facets:taxonomy:DayOfYear # freq=891361 freq=248191
+AndHighMedDayTaxoFacets: +last +1945 +facets:taxonomy:DayOfYear # freq=958437 freq=106881
+AndHighMedDayTaxoFacets: +not +william +facets:taxonomy:DayOfYear # freq=1713264 freq=284592
+AndHighMedDayTaxoFacets: +may +changed +facets:taxonomy:DayOfYear # freq=1071932 freq=112032
+AndHighMedDayTaxoFacets: +one +might +facets:taxonomy:DayOfYear # freq=1527689 freq=114290
+AndHighMedDayTaxoFacets: +one +1966 +facets:taxonomy:DayOfYear # freq=1527689 freq=106672
+AndHighMedDayTaxoFacets: +2006 +mother +facets:taxonomy:DayOfYear # freq=889954 freq=122930
+AndHighMedDayTaxoFacets: +no +hi +facets:taxonomy:DayOfYear # freq=1045000 freq=91593
+AndHighMedDayTaxoFacets: +they +my +facets:taxonomy:DayOfYear # freq=1021945 freq=274256
+AndHighMedDayTaxoFacets: +it +london +facets:taxonomy:DayOfYear # freq=2675552 freq=348918
+AndHighMedDayTaxoFacets: +but +according +facets:taxonomy:DayOfYear # freq=1456553 freq=256949
+AndHighMedDayTaxoFacets: +an +results +facets:taxonomy:DayOfYear # freq=2628056 freq=137248
+AndHighMedDayTaxoFacets: +from +you +facets:taxonomy:DayOfYear # freq=3224339 freq=461587
+AndHighMedDayTaxoFacets: +web +single +facets:taxonomy:DayOfYear # freq=1118334 freq=283824
+AndHighMedDayTaxoFacets: +two +old +facets:taxonomy:DayOfYear # freq=1104053 freq=381809
+AndHighMedDayTaxoFacets: +some +daughter +facets:taxonomy:DayOfYear # freq=839919 freq=103883
+AndHighMedDayTaxoFacets: +url +various +facets:taxonomy:DayOfYear # freq=1513595 freq=224593
+AndHighMedDayTaxoFacets: +have +would +facets:taxonomy:DayOfYear # freq=1297121 freq=690480
+AndHighMedDayTaxoFacets: +to +released +facets:taxonomy:DayOfYear # freq=6155577 freq=322473
+AndHighMedDayTaxoFacets: +had +refer +facets:taxonomy:DayOfYear # freq=1246743 freq=110259
+AndHighMedDayTaxoFacets: +url +article +facets:taxonomy:DayOfYear # freq=1513595 freq=610650
+AndHighMedDayTaxoFacets: +when +designed +facets:taxonomy:DayOfYear # freq=1027487 freq=118748
+AndHighMedDayTaxoFacets: +which +party +facets:taxonomy:DayOfYear # freq=1963428 freq=394410
+AndHighMedDayTaxoFacets: +a +florida +facets:taxonomy:DayOfYear # freq=6560531 freq=92166
+AndHighMedDayTaxoFacets: +the +image_caption +facets:taxonomy:DayOfYear # freq=8217362 freq=87977
+AndHighMedDayTaxoFacets: +last +width +facets:taxonomy:DayOfYear # freq=958437 freq=172609
+AndHighMedDayTaxoFacets: +may +r +facets:taxonomy:DayOfYear # freq=1071932 freq=296283
+AndHighMedDayTaxoFacets: +at +inside +facets:taxonomy:DayOfYear # freq=2857534 freq=84712
+AndHighMedDayTaxoFacets: +3 +p +facets:taxonomy:DayOfYear # freq=1148799 freq=616159
+AndHighMedDayTaxoFacets: +2009 +imperial +facets:taxonomy:DayOfYear # freq=887702 freq=86508
+AndHighMedDayTaxoFacets: +for +access +facets:taxonomy:DayOfYear # freq=4380011 freq=100041
+AndHighMedDayTaxoFacets: +some +former +facets:taxonomy:DayOfYear # freq=839919 freq=332750
+AndHighMedDayTaxoFacets: +url +important +facets:taxonomy:DayOfYear # freq=1513595 freq=195851
+AndHighMedDayTaxoFacets: +which +recorded +facets:taxonomy:DayOfYear # freq=1963428 freq=160249
+AndHighMedDayTaxoFacets: +of +family +facets:taxonomy:DayOfYear # freq=8184358 freq=387175
+AndHighMedDayTaxoFacets: +2 +family +facets:taxonomy:DayOfYear # freq=1549245 freq=387175
+AndHighMedDayTaxoFacets: +was +old +facets:taxonomy:DayOfYear # freq=3763623 freq=381809
+AndHighMedDayTaxoFacets: +more +jpg +facets:taxonomy:DayOfYear # freq=963533 freq=322278
+AndHighMedDayTaxoFacets: +2005 +1979 +facets:taxonomy:DayOfYear # freq=835460 freq=145407
+AndHighMedDayTaxoFacets: +are +became +facets:taxonomy:DayOfYear # freq=1877802 freq=465594
+AndHighMedDayTaxoFacets: +new +products +facets:taxonomy:DayOfYear # freq=1657293 freq=88448
+AndHighMedDayTaxoFacets: +first +mexico +facets:taxonomy:DayOfYear # freq=1933372 freq=88689
+AndHighMedDayTaxoFacets: +10 +nbsp +facets:taxonomy:DayOfYear # freq=918339 freq=506054
+AndHighMedDayTaxoFacets: +by +25 +facets:taxonomy:DayOfYear # freq=3826691 freq=491957
+AndHighMedDayTaxoFacets: +was +language +facets:taxonomy:DayOfYear # freq=3763623 freq=416771
+AndHighMedDayTaxoFacets: +and +future +facets:taxonomy:DayOfYear # freq=7318061 freq=136421
+AndHighMedDayTaxoFacets: +their +flight +facets:taxonomy:DayOfYear # freq=1158682 freq=84316
+AndHighMedDayTaxoFacets: +2011 +hold +facets:taxonomy:DayOfYear # freq=871410 freq=82579
+AndHighMedDayTaxoFacets: +there +programs +facets:taxonomy:DayOfYear # freq=956153 freq=83974
+AndHighMedDayTaxoFacets: +after +original +facets:taxonomy:DayOfYear # freq=1247398 freq=323521
+AndHighMedDayTaxoFacets: +only +ten +facets:taxonomy:DayOfYear # freq=875561 freq=114388
+AndHighMedDayTaxoFacets: +to +traditional +facets:taxonomy:DayOfYear # freq=6155577 freq=110425
+AndHighMedDayTaxoFacets: +also +centre +facets:taxonomy:DayOfYear # freq=1959419 freq=159597
+AndHighMedDayTaxoFacets: +all +isbn +facets:taxonomy:DayOfYear # freq=1203572 freq=467574
+AndHighMedDayTaxoFacets: +this +direct +facets:taxonomy:DayOfYear # freq=2224932 freq=82292
+AndHighMedDayTaxoFacets: +http +earlier +facets:taxonomy:DayOfYear # freq=3493581 freq=100372
+AndHighMedDayTaxoFacets: +cite +system +facets:taxonomy:DayOfYear # freq=1741194 freq=412862
+AndHighMedDayTaxoFacets: +were +library +facets:taxonomy:DayOfYear # freq=1524630 freq=138468
+AndHighMedDayTaxoFacets: +first +alone +facets:taxonomy:DayOfYear # freq=1933372 freq=93166
+AndHighMedDayTaxoFacets: +new +century +facets:taxonomy:DayOfYear # freq=1657293 freq=385541
+AndHighMedDayTaxoFacets: +s +reached +facets:taxonomy:DayOfYear # freq=1581243 freq=89854
+AndHighMedDayTaxoFacets: +united +le +facets:taxonomy:DayOfYear # freq=1196944 freq=84979
+AndHighMedDayTaxoFacets: +url +auto +facets:taxonomy:DayOfYear # freq=1513595 freq=103107
+AndHighMedDayTaxoFacets: +3 +practice +facets:taxonomy:DayOfYear # freq=1148799 freq=93287
+AndHighMedDayTaxoFacets: +http +working +facets:taxonomy:DayOfYear # freq=3493581 freq=144617
+AndHighMedDayTaxoFacets: +in +fire +facets:taxonomy:DayOfYear # freq=7320987 freq=133712
+AndHighMedDayTaxoFacets: +10 +52 +facets:taxonomy:DayOfYear # freq=918339 freq=108395
+AndHighMedDayTaxoFacets: +more +singer +facets:taxonomy:DayOfYear # freq=963533 freq=114006
+AndHighMedDayTaxoFacets: +new +low +facets:taxonomy:DayOfYear # freq=1657293 freq=157852
+AndHighMedDayTaxoFacets: +with +previously +facets:taxonomy:DayOfYear # freq=3709421 freq=96083
+AndHighMedDayTaxoFacets: +first +original +facets:taxonomy:DayOfYear # freq=1933372 freq=323521
+AndHighMedDayTaxoFacets: +2008 +wikitable +facets:taxonomy:DayOfYear # freq=831253 freq=210990
+AndHighMedDayTaxoFacets: +http +can +facets:taxonomy:DayOfYear # freq=3493581 freq=765163
+AndHighMedDayTaxoFacets: +year +1965 +facets:taxonomy:DayOfYear # freq=1235231 freq=104539
+AndHighMedDayTaxoFacets: +have +mother +facets:taxonomy:DayOfYear # freq=1297121 freq=122930
+AndHighMedDayTaxoFacets: +states +lived +facets:taxonomy:DayOfYear # freq=1034872 freq=91327
+AndHighMedDayTaxoFacets: +to +me +facets:taxonomy:DayOfYear # freq=6155577 freq=229204
+AndHighMedDayTaxoFacets: +4 +race +facets:taxonomy:DayOfYear # freq=986452 freq=148763
+AndHighMedDayTaxoFacets: +of +54 +facets:taxonomy:DayOfYear # freq=8184358 freq=101462
+AndHighMedDayTaxoFacets: +some +series +facets:taxonomy:DayOfYear # freq=839919 freq=521861
+AndHighMedDayTaxoFacets: +2 +big +facets:taxonomy:DayOfYear # freq=1549245 freq=163394
+AndHighMedDayTaxoFacets: +some +without +facets:taxonomy:DayOfYear # freq=839919 freq=249926
+AndHighMedDayTaxoFacets: +2011 +font +facets:taxonomy:DayOfYear # freq=871410 freq=269439
+AndHighMedDayTaxoFacets: +http +votes +facets:taxonomy:DayOfYear # freq=3493581 freq=93844
+AndHighMedDayTaxoFacets: +2009 +19th +facets:taxonomy:DayOfYear # freq=887702 freq=93290
+AndHighMedDayTaxoFacets: +an +central +facets:taxonomy:DayOfYear # freq=2628056 freq=272531
+AndHighMedDayTaxoFacets: +some +1959 +facets:taxonomy:DayOfYear # freq=839919 freq=87097
+AndHighMedDayTaxoFacets: +cite +out +facets:taxonomy:DayOfYear # freq=1741194 freq=733775
+AndHighMedDayTaxoFacets: +was +cross +facets:taxonomy:DayOfYear # freq=3763623 freq=127216
+AndHighMedDayTaxoFacets: +3 +1950 +facets:taxonomy:DayOfYear # freq=1148799 freq=89746
+AndHighMedDayTaxoFacets: +there +market +facets:taxonomy:DayOfYear # freq=956153 freq=118467
+AndHighMedDayTaxoFacets: +new +mid +facets:taxonomy:DayOfYear # freq=1657293 freq=126355
+AndHighMedDayTaxoFacets: +or +sent +facets:taxonomy:DayOfYear # freq=1858841 freq=103620
+AndHighMedDayTaxoFacets: +may +pp +facets:taxonomy:DayOfYear # freq=1071932 freq=204742
+AndHighMedDayTaxoFacets: +the +flagicon +facets:taxonomy:DayOfYear # freq=8217362 freq=107428
+AndHighMedDayTaxoFacets: +who +genre +facets:taxonomy:DayOfYear # freq=1196171 freq=121233
+AndHighMedDayTaxoFacets: +last +library +facets:taxonomy:DayOfYear # freq=958437 freq=138468
+AndHighMedDayTaxoFacets: +and +none +facets:taxonomy:DayOfYear # freq=7318061 freq=100192
+AndHighMedDayTaxoFacets: +an +majority +facets:taxonomy:DayOfYear # freq=2628056 freq=105058
+AndHighMedDayTaxoFacets: +it +religion +facets:taxonomy:DayOfYear # freq=2675552 freq=96655
+AndHighMedDayTaxoFacets: +first +brown +facets:taxonomy:DayOfYear # freq=1933372 freq=116178
+AndHighMedDayTaxoFacets: +more +standard +facets:taxonomy:DayOfYear # freq=963533 freq=185039
+AndHighMedDayTaxoFacets: +into +process +facets:taxonomy:DayOfYear # freq=888684 freq=152588
+AndHighMedDayTaxoFacets: +for +website +facets:taxonomy:DayOfYear # freq=4380011 freq=435941
+AndHighMedDayTaxoFacets: +name +parts +facets:taxonomy:DayOfYear # freq=2827713 freq=123891
+AndHighMedDayTaxoFacets: +for +few +facets:taxonomy:DayOfYear # freq=4380011 freq=226422
+AndHighMedDayTaxoFacets: +web +available +facets:taxonomy:DayOfYear # freq=1118334 freq=175514
+AndHighMedDayTaxoFacets: +other +christian +facets:taxonomy:DayOfYear # freq=1269961 freq=140312
+AndHighMedDayTaxoFacets: +2 +imperial +facets:taxonomy:DayOfYear # freq=1549245 freq=86508
+AndHighMedDayTaxoFacets: +at +space +facets:taxonomy:DayOfYear # freq=2857534 freq=163436
+AndHighMedDayTaxoFacets: +but +paul +facets:taxonomy:DayOfYear # freq=1456553 freq=207229
+AndHighMedDayTaxoFacets: +into +70 +facets:taxonomy:DayOfYear # freq=888684 freq=90305
+AndHighMedDayTaxoFacets: +s +mdash +facets:taxonomy:DayOfYear # freq=1581243 freq=111708
+AndHighMedDayTaxoFacets: +5 +brown +facets:taxonomy:DayOfYear # freq=891361 freq=116178
+AndHighMedDayTaxoFacets: +2005 +hill +facets:taxonomy:DayOfYear # freq=835460 freq=133714
+AndHighMedDayTaxoFacets: +2006 +eight +facets:taxonomy:DayOfYear # freq=889954 freq=106268
+AndHighMedDayTaxoFacets: +two +era +facets:taxonomy:DayOfYear # freq=1104053 freq=95989
+AndHighMedDayTaxoFacets: +time +100 +facets:taxonomy:DayOfYear # freq=1032071 freq=268978
+AndHighMedDayTaxoFacets: +title +70 +facets:taxonomy:DayOfYear # freq=2397378 freq=90305
+AndHighMedDayTaxoFacets: +3 +empire +facets:taxonomy:DayOfYear # freq=1148799 freq=143207
+AndHighMedDayTaxoFacets: +in +di +facets:taxonomy:DayOfYear # freq=7320987 freq=83139
+AndHighMedDayTaxoFacets: +and +included +facets:taxonomy:DayOfYear # freq=7318061 freq=216978
+AndHighMedDayTaxoFacets: +that +play +facets:taxonomy:DayOfYear # freq=2931020 freq=210199
+AndHighMedDayTaxoFacets: +an +might +facets:taxonomy:DayOfYear # freq=2628056 freq=114290
+AndHighMedDayTaxoFacets: +other +country +facets:taxonomy:DayOfYear # freq=1269961 freq=420052
+AndHighMedDayTaxoFacets: +also +success +facets:taxonomy:DayOfYear # freq=1959419 freq=112195
+AndHighMedDayTaxoFacets: +also +27 +facets:taxonomy:DayOfYear # freq=1959419 freq=383042
+AndHighMedDayTaxoFacets: +more +stations +facets:taxonomy:DayOfYear # freq=963533 freq=92011
+AndHighMedDayTaxoFacets: +they +system +facets:taxonomy:DayOfYear # freq=1021945 freq=412862
+AndHighMedDayTaxoFacets: +in +31 +facets:taxonomy:DayOfYear # freq=7320987 freq=298349
+AndHighMedDayTaxoFacets: +all +provided +facets:taxonomy:DayOfYear # freq=1203572 freq=110088
+AndHighMedDayTaxoFacets: +i +u.s +facets:taxonomy:DayOfYear # freq=956148 freq=428534
+AndHighMedDayTaxoFacets: +a +certain +facets:taxonomy:DayOfYear # freq=6560531 freq=105714
+AndHighMedDayTaxoFacets: +his +summary +facets:taxonomy:DayOfYear # freq=1777780 freq=106702
+AndHighMedDayTaxoFacets: +2009 +america +facets:taxonomy:DayOfYear # freq=887702 freq=240374
+AndHighMedDayTaxoFacets: +1 +chicago +facets:taxonomy:DayOfYear # freq=1641090 freq=117756
+AndHighMedDayTaxoFacets: +other +2000 +facets:taxonomy:DayOfYear # freq=1269961 freq=499639
+AndHighMedDayTaxoFacets: +year +men +facets:taxonomy:DayOfYear # freq=1235231 freq=182445
+AndHighMedDayTaxoFacets: +4 +upon +facets:taxonomy:DayOfYear # freq=986452 freq=169174
+AndHighMedDayTaxoFacets: +in +seems +facets:taxonomy:DayOfYear # freq=7320987 freq=83963
+AndHighMedDayTaxoFacets: +he +bank +facets:taxonomy:DayOfYear # freq=1659434 freq=88080
+AndHighMedDayTaxoFacets: +name +both +facets:taxonomy:DayOfYear # freq=2827713 freq=534900
+AndHighMedDayTaxoFacets: +publisher +e +facets:taxonomy:DayOfYear # freq=1289029 freq=408741
+AndHighMedDayTaxoFacets: +who +computer +facets:taxonomy:DayOfYear # freq=1196171 freq=126524
+AndHighMedDayTaxoFacets: +about +type +facets:taxonomy:DayOfYear # freq=850283 freq=318210
+AndHighMedDayTaxoFacets: +this +people +facets:taxonomy:DayOfYear # freq=2224932 freq=790960
+AndHighMedDayTaxoFacets: +their +1978 +facets:taxonomy:DayOfYear # freq=1158682 freq=135223
+AndHighMedDayTaxoFacets: +url +museum +facets:taxonomy:DayOfYear # freq=1513595 freq=135250
+AndHighMedDayTaxoFacets: +4 +least +facets:taxonomy:DayOfYear # freq=986452 freq=146209
+AndHighMedDayTaxoFacets: +2011 +money +facets:taxonomy:DayOfYear # freq=871410 freq=100440
+AndHighMedDayTaxoFacets: +first +referred +facets:taxonomy:DayOfYear # freq=1933372 freq=94811
+AndHighMedDayTaxoFacets: +he +20 +facets:taxonomy:DayOfYear # freq=1659434 freq=624967
+AndHighMedDayTaxoFacets: +were +events +facets:taxonomy:DayOfYear # freq=1524630 freq=158248
+AndHighMedDayTaxoFacets: +it +because +facets:taxonomy:DayOfYear # freq=2675552 freq=413003
+AndHighMedDayTaxoFacets: +accessdate +large +facets:taxonomy:DayOfYear # freq=1228887 freq=308888
+AndHighMedDayTaxoFacets: +there +usa +facets:taxonomy:DayOfYear # freq=956153 freq=191220
+AndHighMedDayTaxoFacets: +he +association +facets:taxonomy:DayOfYear # freq=1659434 freq=247156
+AndHighMedDayTaxoFacets: +2010 +rest +facets:taxonomy:DayOfYear # freq=950573 freq=95113
+AndHighMedDayTaxoFacets: +he +face +facets:taxonomy:DayOfYear # freq=1659434 freq=95144
+AndHighMedDayTaxoFacets: +title +out +facets:taxonomy:DayOfYear # freq=2397378 freq=733775
+AndHighMedDayTaxoFacets: +first +christian +facets:taxonomy:DayOfYear # freq=1933372 freq=140312
+AndHighMedDayTaxoFacets: +has +april +facets:taxonomy:DayOfYear # freq=1502961 freq=587542
+AndHighMedDayTaxoFacets: +in +very +facets:taxonomy:DayOfYear # freq=7320987 freq=354898
+AndHighMedDayTaxoFacets: +no +century +facets:taxonomy:DayOfYear # freq=1045000 freq=385541
+AndHighMedDayTaxoFacets: +accessdate +recording +facets:taxonomy:DayOfYear # freq=1228887 freq=90757
+AndHighMedDayTaxoFacets: +by +55 +facets:taxonomy:DayOfYear # freq=3826691 freq=110526
+AndHighMedDayTaxoFacets: +2005 +54 +facets:taxonomy:DayOfYear # freq=835460 freq=101462
+AndHighMedDayTaxoFacets: +this +x +facets:taxonomy:DayOfYear # freq=2224932 freq=272695
+AndHighMedDayTaxoFacets: +url +following +facets:taxonomy:DayOfYear # freq=1513595 freq=416515
+AndHighMedDayTaxoFacets: +s +per +facets:taxonomy:DayOfYear # freq=1581243 freq=283568
+AndHighMedDayTaxoFacets: +2005 +bureau +facets:taxonomy:DayOfYear # freq=835460 freq=83671
+AndHighMedDayTaxoFacets: +1 +09 +facets:taxonomy:DayOfYear # freq=1641090 freq=296300
+AndHighMedDayTaxoFacets: +title +buildings +facets:taxonomy:DayOfYear # freq=2397378 freq=89046
+AndHighMedDayTaxoFacets: +by +appears +facets:taxonomy:DayOfYear # freq=3826691 freq=104511
+AndHighMedDayTaxoFacets: +year +taken +facets:taxonomy:DayOfYear # freq=1235231 freq=166217
+AndHighMedDayTaxoFacets: +on +size +facets:taxonomy:DayOfYear # freq=4074624 freq=237662
+AndHighMedDayTaxoFacets: +2005 +thomas +facets:taxonomy:DayOfYear # freq=835460 freq=191625
+AndHighMedDayTaxoFacets: +2008 +chicago +facets:taxonomy:DayOfYear # freq=831253 freq=117756
+AndHighMedDayTaxoFacets: +2 +1991 +facets:taxonomy:DayOfYear # freq=1549245 freq=207589
+AndHighMedDayTaxoFacets: +only +2003 +facets:taxonomy:DayOfYear # freq=875561 freq=456990
+AndHighMedDayTaxoFacets: +their +found +facets:taxonomy:DayOfYear # freq=1158682 freq=313247
+AndHighMedDayTaxoFacets: +for +long +facets:taxonomy:DayOfYear # freq=4380011 freq=385787
+AndHighMedDayTaxoFacets: +2011 +low +facets:taxonomy:DayOfYear # freq=871410 freq=157852
+AndHighMedDayTaxoFacets: +for +iii +facets:taxonomy:DayOfYear # freq=4380011 freq=123618
+AndHighMedDayTaxoFacets: +is +1990s +facets:taxonomy:DayOfYear # freq=4074455 freq=83166
+AndHighMedDayTaxoFacets: +some +instead +facets:taxonomy:DayOfYear # freq=839919 freq=149345
+AndHighMedDayTaxoFacets: +publisher +historical +facets:taxonomy:DayOfYear # freq=1289029 freq=159636
+AndHighMedDayTaxoFacets: +are +please +facets:taxonomy:DayOfYear # freq=1877802 freq=229602
+AndHighMedDayTaxoFacets: +who +brown +facets:taxonomy:DayOfYear # freq=1196171 freq=116178
+AndHighMedDayTaxoFacets: +an +professional +facets:taxonomy:DayOfYear # freq=2628056 freq=138520
+AndHighMedDayTaxoFacets: +name +security +facets:taxonomy:DayOfYear # freq=2827713 freq=89382
+AndHighMedDayTaxoFacets: +name +8 +facets:taxonomy:DayOfYear # freq=2827713 freq=635822
+AndHighMedDayTaxoFacets: +from +china +facets:taxonomy:DayOfYear # freq=3224339 freq=130849
+AndHighMedDayTaxoFacets: +a +early +facets:taxonomy:DayOfYear # freq=6560531 freq=482793
+AndHighMedDayTaxoFacets: +cite +changes +facets:taxonomy:DayOfYear # freq=1741194 freq=105677
+AndHighMedDayTaxoFacets: +it +debate +facets:taxonomy:DayOfYear # freq=2675552 freq=177827
+AndHighMedDayTaxoFacets: +by +total +facets:taxonomy:DayOfYear # freq=3826691 freq=230013
+AndHighMedDayTaxoFacets: +it +event +facets:taxonomy:DayOfYear # freq=2675552 freq=114340
+AndHighMedDayTaxoFacets: +2005 +cup +facets:taxonomy:DayOfYear # freq=835460 freq=141942
+AndHighMedDayTaxoFacets: +publisher +1950 +facets:taxonomy:DayOfYear # freq=1289029 freq=89746
+AndHighMedDayTaxoFacets: +no +christian +facets:taxonomy:DayOfYear # freq=1045000 freq=140312
+AndHighMedDayTaxoFacets: +from +forces +facets:taxonomy:DayOfYear # freq=3224339 freq=152939
+AndHighMedDayTaxoFacets: +when +between +facets:taxonomy:DayOfYear # freq=1027487 freq=630650
+AndHighMedDayTaxoFacets: +its +words +facets:taxonomy:DayOfYear # freq=1173450 freq=104783
+AndHighMedDayTaxoFacets: +a +she +facets:taxonomy:DayOfYear # freq=6560531 freq=426267
+AndHighMedDayTaxoFacets: +s +align +facets:taxonomy:DayOfYear # freq=1581243 freq=300455
+AndHighMedDayTaxoFacets: +http +served +facets:taxonomy:DayOfYear # freq=3493581 freq=188351
+AndHighMedDayTaxoFacets: +of +finally +facets:taxonomy:DayOfYear # freq=8184358 freq=99185
+AndHighMedDayTaxoFacets: +some +pre +facets:taxonomy:DayOfYear # freq=839919 freq=90549
+AndHighMedDayTaxoFacets: +which +am +facets:taxonomy:DayOfYear # freq=1963428 freq=127152
+AndHighMedDayTaxoFacets: +with +governor +facets:taxonomy:DayOfYear # freq=3709421 freq=102274
+AndHighMedDayTaxoFacets: +publisher +f.c +facets:taxonomy:DayOfYear # freq=1289029 freq=83548
+AndHighMedDayTaxoFacets: +on +player +facets:taxonomy:DayOfYear # freq=4074624 freq=241451
+AndHighMedDayTaxoFacets: +time +including +facets:taxonomy:DayOfYear # freq=1032071 freq=521324
+AndHighMedDayTaxoFacets: +work +1950 +facets:taxonomy:DayOfYear # freq=853422 freq=89746
+AndHighMedDayTaxoFacets: +http +now +facets:taxonomy:DayOfYear # freq=3493581 freq=484114
+AndHighMedDayTaxoFacets: +is +separate +facets:taxonomy:DayOfYear # freq=4074455 freq=88604
+AndHighMedDayTaxoFacets: +be +having +facets:taxonomy:DayOfYear # freq=2051702 freq=213416
+AndHighMedDayTaxoFacets: +its +practice +facets:taxonomy:DayOfYear # freq=1173450 freq=93287
+AndHighMedDayTaxoFacets: +new +30 +facets:taxonomy:DayOfYear # freq=1657293 freq=488930
+AndHighMedDayTaxoFacets: +date +most +facets:taxonomy:DayOfYear # freq=2020626 freq=819634
+AndHighMedDayTaxoFacets: +by +railway +facets:taxonomy:DayOfYear # freq=3826691 freq=125543
+AndHighMedDayTaxoFacets: +that +related +facets:taxonomy:DayOfYear # freq=2931020 freq=174856
+AndHighMedDayTaxoFacets: +other +data +facets:taxonomy:DayOfYear # freq=1269961 freq=159657
+AndHighMedDayTaxoFacets: +an +daily +facets:taxonomy:DayOfYear # freq=2628056 freq=111717
+AndHighMedDayTaxoFacets: +web +performance +facets:taxonomy:DayOfYear # freq=1118334 freq=130862
+AndHighMedDayTaxoFacets: +their +engine +facets:taxonomy:DayOfYear # freq=1158682 freq=100930
+AndHighMedDayTaxoFacets: +states +found +facets:taxonomy:DayOfYear # freq=1034872 freq=313247
+AndHighMedDayTaxoFacets: +name +takes +facets:taxonomy:DayOfYear # freq=2827713 freq=95889
+AndHighMedDayTaxoFacets: +cite +editor +facets:taxonomy:DayOfYear # freq=1741194 freq=119419
+AndHighMedDayTaxoFacets: +last +canadian +facets:taxonomy:DayOfYear # freq=958437 freq=181906
+AndHighMedDayTaxoFacets: +2 +jersey +facets:taxonomy:DayOfYear # freq=1549245 freq=88847
+AndHighMedDayTaxoFacets: +5 +far +facets:taxonomy:DayOfYear # freq=891361 freq=143873
+AndHighMedDayTaxoFacets: +it +3rd +facets:taxonomy:DayOfYear # freq=2675552 freq=90723
+AndHighMedDayTaxoFacets: +ref +say +facets:taxonomy:DayOfYear # freq=3793973 freq=110895
+AndHighMedDayTaxoFacets: +be +forces +facets:taxonomy:DayOfYear # freq=2051702 freq=152939
+AndHighMedDayTaxoFacets: +2010 +where +facets:taxonomy:DayOfYear # freq=950573 freq=630647
+AndHighMedDayTaxoFacets: +states +earlier +facets:taxonomy:DayOfYear # freq=1034872 freq=100372
+AndHighMedDayTaxoFacets: +has +organization +facets:taxonomy:DayOfYear # freq=1502961 freq=119614
+AndHighMedDayTaxoFacets: +its +fiction +facets:taxonomy:DayOfYear # freq=1173450 freq=87227
+AndHighMedDayTaxoFacets: +it +star +facets:taxonomy:DayOfYear # freq=2675552 freq=195768
+AndHighMedDayTaxoFacets: +have +speed +facets:taxonomy:DayOfYear # freq=1297121 freq=99899
+AndHighMedDayTaxoFacets: +into +2nd +facets:taxonomy:DayOfYear # freq=888684 freq=167463
+AndHighMedDayTaxoFacets: +name +having +facets:taxonomy:DayOfYear # freq=2827713 freq=213416
+AndHighMedDayTaxoFacets: +his +head +facets:taxonomy:DayOfYear # freq=1777780 freq=194682
+AndHighMedDayTaxoFacets: +when +change +facets:taxonomy:DayOfYear # freq=1027487 freq=182336
+AndHighMedDayTaxoFacets: +2005 +edit +facets:taxonomy:DayOfYear # freq=835460 freq=129064
+AndHighMedDayTaxoFacets: +about +mass +facets:taxonomy:DayOfYear # freq=850283 freq=82794
+AndHighMedDayTaxoFacets: +not +profile +facets:taxonomy:DayOfYear # freq=1713264 freq=86788
+AndHighMedDayTaxoFacets: +of +mayor +facets:taxonomy:DayOfYear # freq=8184358 freq=88578
+AndHighMedDayTaxoFacets: +no +woman +facets:taxonomy:DayOfYear # freq=1045000 freq=92071
+AndHighMedDayTaxoFacets: +from +these +facets:taxonomy:DayOfYear # freq=3224339 freq=623267
+AndHighMedDayTaxoFacets: +2005 +literature +facets:taxonomy:DayOfYear # freq=835460 freq=96743
+AndHighMedDayTaxoFacets: +an +07 +facets:taxonomy:DayOfYear # freq=2628056 freq=299351
+AndHighMedDayTaxoFacets: +that +age +facets:taxonomy:DayOfYear # freq=2931020 freq=395368
+AndHighMedDayTaxoFacets: +2008 +august +facets:taxonomy:DayOfYear # freq=831253 freq=527806
+AndHighMedDayTaxoFacets: +date +type +facets:taxonomy:DayOfYear # freq=2020626 freq=318210
+AndHighMedDayTaxoFacets: +other +most +facets:taxonomy:DayOfYear # freq=1269961 freq=819634
+AndHighMedDayTaxoFacets: +his +mark +facets:taxonomy:DayOfYear # freq=1777780 freq=160033
+AndHighMedDayTaxoFacets: +was +elected +facets:taxonomy:DayOfYear # freq=3763623 freq=119941
+AndHighMedDayTaxoFacets: +title +parliament +facets:taxonomy:DayOfYear # freq=2397378 freq=127008
+AndHighMedDayTaxoFacets: +been +27 +facets:taxonomy:DayOfYear # freq=1041183 freq=383042
+AndHighMedDayTaxoFacets: +publisher +western +facets:taxonomy:DayOfYear # freq=1289029 freq=232781
+AndHighMedDayTaxoFacets: +its +done +facets:taxonomy:DayOfYear # freq=1173450 freq=102033
+AndHighMedDayTaxoFacets: +more +web.archive.org +facets:taxonomy:DayOfYear # freq=963533 freq=95902
+AndHighMedDayTaxoFacets: +date +half +facets:taxonomy:DayOfYear # freq=2020626 freq=155387
+AndHighMedDayTaxoFacets: +that +lower +facets:taxonomy:DayOfYear # freq=2931020 freq=127260
+AndHighMedDayTaxoFacets: +more +already +facets:taxonomy:DayOfYear # freq=963533 freq=126694
+AndHighMedDayTaxoFacets: +for +report +facets:taxonomy:DayOfYear # freq=4380011 freq=153204
+AndHighMedDayTaxoFacets: +5 +ed +facets:taxonomy:DayOfYear # freq=891361 freq=134224
+AndHighMedDayTaxoFacets: +http +1965 +facets:taxonomy:DayOfYear # freq=3493581 freq=104539
+AndHighMedDayTaxoFacets: +s +debate +facets:taxonomy:DayOfYear # freq=1581243 freq=177827
+AndHighMedDayTaxoFacets: +only +official +facets:taxonomy:DayOfYear # freq=875561 freq=326177
+AndHighMedDayTaxoFacets: +2006 +seat +facets:taxonomy:DayOfYear # freq=889954 freq=91288
+AndHighMedDayTaxoFacets: +in +27 +facets:taxonomy:DayOfYear # freq=7320987 freq=383042
+AndHighMedDayTaxoFacets: +cite +fields +facets:taxonomy:DayOfYear # freq=1741194 freq=86938
+AndHighMedDayTaxoFacets: +states +remained +facets:taxonomy:DayOfYear # freq=1034872 freq=107736
+AndHighMedDayTaxoFacets: +for +hold +facets:taxonomy:DayOfYear # freq=4380011 freq=82579
+AndHighMedDayTaxoFacets: +2011 +joseph +facets:taxonomy:DayOfYear # freq=871410 freq=121533
+AndHighMedDayTaxoFacets: +2009 +met +facets:taxonomy:DayOfYear # freq=887702 freq=84001
+AndHighMedDayTaxoFacets: +an +31 +facets:taxonomy:DayOfYear # freq=2628056 freq=298349
+AndHighMedDayTaxoFacets: +there +hill +facets:taxonomy:DayOfYear # freq=956153 freq=133714
+AndHighMedDayTaxoFacets: +3 +allowed +facets:taxonomy:DayOfYear # freq=1148799 freq=98720
+AndHighMedDayTaxoFacets: +4 +table +facets:taxonomy:DayOfYear # freq=986452 freq=99163
+AndHighMedDayTaxoFacets: +accessdate +later +facets:taxonomy:DayOfYear # freq=1228887 freq=604921
+AndHighMedDayTaxoFacets: +2008 +rather +facets:taxonomy:DayOfYear # freq=831253 freq=174136
+AndHighMedDayTaxoFacets: +also +late +facets:taxonomy:DayOfYear # freq=1959419 freq=243636
+AndHighMedDayTaxoFacets: +2008 +60 +facets:taxonomy:DayOfYear # freq=831253 freq=118403
+AndHighMedDayTaxoFacets: +1 +why +facets:taxonomy:DayOfYear # freq=1641090 freq=108161
+AndHighMedDayTaxoFacets: +new +winning +facets:taxonomy:DayOfYear # freq=1657293 freq=95704
+AndHighMedDayTaxoFacets: +accessdate +towards +facets:taxonomy:DayOfYear # freq=1228887 freq=95574
+AndHighMedDayTaxoFacets: +date +t +facets:taxonomy:DayOfYear # freq=2020626 freq=262832
+AndHighMedDayTaxoFacets: +2 +nbsp +facets:taxonomy:DayOfYear # freq=1549245 freq=506054
+AndHighMedDayTaxoFacets: +time +website +facets:taxonomy:DayOfYear # freq=1032071 freq=435941
+AndHighMedDayTaxoFacets: +5 +republic +facets:taxonomy:DayOfYear # freq=891361 freq=166154
+AndHighMedDayTaxoFacets: +were +hold +facets:taxonomy:DayOfYear # freq=1524630 freq=82579
+AndHighMedDayTaxoFacets: +the +whom +facets:taxonomy:DayOfYear # freq=8217362 freq=95520
+AndHighMedDayTaxoFacets: +http +free +facets:taxonomy:DayOfYear # freq=3493581 freq=270199
+AndHighMedDayTaxoFacets: +his +self +facets:taxonomy:DayOfYear # freq=1777780 freq=135012
+AndHighMedDayTaxoFacets: +with +music +facets:taxonomy:DayOfYear # freq=3709421 freq=473240
+AndHighMedDayTaxoFacets: +is +academy +facets:taxonomy:DayOfYear # freq=4074455 freq=119055
+AndHighMedDayTaxoFacets: +year +appearance +facets:taxonomy:DayOfYear # freq=1235231 freq=89229
+AndHighMedDayTaxoFacets: +year +square +facets:taxonomy:DayOfYear # freq=1235231 freq=123538
+AndHighMedDayTaxoFacets: +i +h +facets:taxonomy:DayOfYear # freq=956148 freq=241946
+AndHighMedDayTaxoFacets: +by +35 +facets:taxonomy:DayOfYear # freq=3826691 freq=155506
+AndHighMedDayTaxoFacets: +2005 +sports +facets:taxonomy:DayOfYear # freq=835460 freq=178542
+AndHighMedDayTaxoFacets: +united +series +facets:taxonomy:DayOfYear # freq=1196944 freq=521861
+AndHighMedDayTaxoFacets: +may +congress +facets:taxonomy:DayOfYear # freq=1071932 freq=92382
+AndHighMedDayTaxoFacets: +title +la +facets:taxonomy:DayOfYear # freq=2397378 freq=232610
+AndHighMedDayTaxoFacets: +its +category:american +facets:taxonomy:DayOfYear # freq=1173450 freq=107823
+AndHighMedDayTaxoFacets: +the +lake +facets:taxonomy:DayOfYear # freq=8217362 freq=131603
+AndHighMedDayTaxoFacets: +who +foundation +facets:taxonomy:DayOfYear # freq=1196171 freq=107123
+AndHighMedDayTaxoFacets: +3 +57 +facets:taxonomy:DayOfYear # freq=1148799 freq=93708
+AndHighMedDayTaxoFacets: +date +flag +facets:taxonomy:DayOfYear # freq=2020626 freq=104210
+AndHighMedDayTaxoFacets: +10 +dq +facets:taxonomy:DayOfYear # freq=918339 freq=88557
+AndHighMedDayTaxoFacets: +that +study +facets:taxonomy:DayOfYear # freq=2931020 freq=137170
+AndHighMedDayTaxoFacets: +first +france +facets:taxonomy:DayOfYear # freq=1933372 freq=220058
+AndHighMedDayTaxoFacets: +on +culture +facets:taxonomy:DayOfYear # freq=4074624 freq=157773
+AndHighMedDayTaxoFacets: +to +1984 +facets:taxonomy:DayOfYear # freq=6155577 freq=161404
+AndHighMedDayTaxoFacets: +all +u.s +facets:taxonomy:DayOfYear # freq=1203572 freq=428534
+AndHighMedDayTaxoFacets: +name +era +facets:taxonomy:DayOfYear # freq=2827713 freq=95989
+AndHighMedDayTaxoFacets: +url +02 +facets:taxonomy:DayOfYear # freq=1513595 freq=319783
+AndHighMedDayTaxoFacets: +a +teams +facets:taxonomy:DayOfYear # freq=6560531 freq=105245
+AndHighMedDayTaxoFacets: +name +paul +facets:taxonomy:DayOfYear # freq=2827713 freq=207229
+AndHighMedDayTaxoFacets: +2008 +command +facets:taxonomy:DayOfYear # freq=831253 freq=87496
+AndHighMedDayTaxoFacets: +after +today +facets:taxonomy:DayOfYear # freq=1247398 freq=168864
+AndHighMedDayTaxoFacets: +no +native +facets:taxonomy:DayOfYear # freq=1045000 freq=129103
+AndHighMedDayTaxoFacets: +into +st +facets:taxonomy:DayOfYear # freq=888684 freq=309092
+AndHighMedDayTaxoFacets: +accessdate +m +facets:taxonomy:DayOfYear # freq=1228887 freq=441232
+AndHighMedDayTaxoFacets: +a +heart +facets:taxonomy:DayOfYear # freq=6560531 freq=95365
+AndHighMedDayTaxoFacets: +2010 +1986 +facets:taxonomy:DayOfYear # freq=950573 freq=167724
+AndHighMedDayTaxoFacets: +2008 +remained +facets:taxonomy:DayOfYear # freq=831253 freq=107736
+AndHighMedDayTaxoFacets: +this +college +facets:taxonomy:DayOfYear # freq=2224932 freq=278094
+AndHighMedDayTaxoFacets: +date +note +facets:taxonomy:DayOfYear # freq=2020626 freq=194472
+AndHighMedDayTaxoFacets: +5 +coast +facets:taxonomy:DayOfYear # freq=891361 freq=119047
+AndHighMedDayTaxoFacets: +time +sometimes +facets:taxonomy:DayOfYear # freq=1032071 freq=144078
+AndHighMedDayTaxoFacets: +3 +look +facets:taxonomy:DayOfYear # freq=1148799 freq=91122
+AndHighMedDayTaxoFacets: +states +people +facets:taxonomy:DayOfYear # freq=1034872 freq=790960
+AndHighMedDayTaxoFacets: +to +specific +facets:taxonomy:DayOfYear # freq=6155577 freq=93622
+AndHighMedDayTaxoFacets: +year +between +facets:taxonomy:DayOfYear # freq=1235231 freq=630650
+AndHighMedDayTaxoFacets: +publisher +led +facets:taxonomy:DayOfYear # freq=1289029 freq=210033
+AndHighMedDayTaxoFacets: +a +given +facets:taxonomy:DayOfYear # freq=6560531 freq=235719
+AndHighMedDayTaxoFacets: +2008 +stations +facets:taxonomy:DayOfYear # freq=831253 freq=92011
+AndHighMedDayTaxoFacets: +his +england +facets:taxonomy:DayOfYear # freq=1777780 freq=317884
+AndHighMedDayTaxoFacets: +states +geo +facets:taxonomy:DayOfYear # freq=1034872 freq=83404
+AndHighMedDayTaxoFacets: +at +1960 +facets:taxonomy:DayOfYear # freq=2857534 freq=109083
+AndHighMedDayTaxoFacets: +be +60 +facets:taxonomy:DayOfYear # freq=2051702 freq=118403
+AndHighMedDayTaxoFacets: +there +schools +facets:taxonomy:DayOfYear # freq=956153 freq=141308
+AndHighMedDayTaxoFacets: +that +value +facets:taxonomy:DayOfYear # freq=2931020 freq=86806
+AndHighMedDayTaxoFacets: +no +needed +facets:taxonomy:DayOfYear # freq=1045000 freq=281051
+AndHighMedDayTaxoFacets: +2011 +31 +facets:taxonomy:DayOfYear # freq=871410 freq=298349
+AndHighMedDayTaxoFacets: +year +16 +facets:taxonomy:DayOfYear # freq=1235231 freq=540539
+AndHighMedDayTaxoFacets: +title +set +facets:taxonomy:DayOfYear # freq=2397378 freq=294255
+AndHighMedDayTaxoFacets: +work +sport +facets:taxonomy:DayOfYear # freq=853422 freq=106696
+AndHighMedDayTaxoFacets: +all +42 +facets:taxonomy:DayOfYear # freq=1203572 freq=124253
+OrHighMedDayTaxoFacets: there background +facets:taxonomy:DayOfYear # freq=956153 freq=314229
+OrHighMedDayTaxoFacets: be important +facets:taxonomy:DayOfYear # freq=2051702 freq=195851
+OrHighMedDayTaxoFacets: name cd +facets:taxonomy:DayOfYear # freq=2827713 freq=87105
+OrHighMedDayTaxoFacets: when regular +facets:taxonomy:DayOfYear # freq=1027487 freq=93809
+OrHighMedDayTaxoFacets: 1 called +facets:taxonomy:DayOfYear # freq=1641090 freq=454580
+OrHighMedDayTaxoFacets: may force +facets:taxonomy:DayOfYear # freq=1071932 freq=198556
+OrHighMedDayTaxoFacets: 1 regular +facets:taxonomy:DayOfYear # freq=1641090 freq=93809
+OrHighMedDayTaxoFacets: s 1986 +facets:taxonomy:DayOfYear # freq=1581243 freq=167724
+OrHighMedDayTaxoFacets: 2011 co +facets:taxonomy:DayOfYear # freq=871410 freq=209086
+OrHighMedDayTaxoFacets: he artist +facets:taxonomy:DayOfYear # freq=1659434 freq=210591
+OrHighMedDayTaxoFacets: 2009 him +facets:taxonomy:DayOfYear # freq=887702 freq=507350
+OrHighMedDayTaxoFacets: at interest +facets:taxonomy:DayOfYear # freq=2857534 freq=108551
+OrHighMedDayTaxoFacets: and 1959 +facets:taxonomy:DayOfYear # freq=7318061 freq=87097
+OrHighMedDayTaxoFacets: had few +facets:taxonomy:DayOfYear # freq=1246743 freq=226422
+OrHighMedDayTaxoFacets: this era +facets:taxonomy:DayOfYear # freq=2224932 freq=95989
+OrHighMedDayTaxoFacets: also video +facets:taxonomy:DayOfYear # freq=1959419 freq=202380
+OrHighMedDayTaxoFacets: into capital +facets:taxonomy:DayOfYear # freq=888684 freq=120421
+OrHighMedDayTaxoFacets: who los +facets:taxonomy:DayOfYear # freq=1196171 freq=145404
+OrHighMedDayTaxoFacets: that ii +facets:taxonomy:DayOfYear # freq=2931020 freq=340800
+OrHighMedDayTaxoFacets: as working +facets:taxonomy:DayOfYear # freq=3925535 freq=144617
+OrHighMedDayTaxoFacets: accessdate status +facets:taxonomy:DayOfYear # freq=1228887 freq=133818
+OrHighMedDayTaxoFacets: not put +facets:taxonomy:DayOfYear # freq=1713264 freq=139882
+OrHighMedDayTaxoFacets: cite soviet +facets:taxonomy:DayOfYear # freq=1741194 freq=89070
+OrHighMedDayTaxoFacets: see reading +facets:taxonomy:DayOfYear # freq=1044180 freq=101214
+OrHighMedDayTaxoFacets: all area +facets:taxonomy:DayOfYear # freq=1203572 freq=559023
+OrHighMedDayTaxoFacets: his influence +facets:taxonomy:DayOfYear # freq=1777780 freq=83101
+OrHighMedDayTaxoFacets: new less +facets:taxonomy:DayOfYear # freq=1657293 freq=170266
+OrHighMedDayTaxoFacets: states 14 +facets:taxonomy:DayOfYear # freq=1034872 freq=534005
+OrHighMedDayTaxoFacets: no april +facets:taxonomy:DayOfYear # freq=1045000 freq=587542
+OrHighMedDayTaxoFacets: http wife +facets:taxonomy:DayOfYear # freq=3493581 freq=130807
+OrHighMedDayTaxoFacets: had stories +facets:taxonomy:DayOfYear # freq=1246743 freq=110223
+OrHighMedDayTaxoFacets: this established +facets:taxonomy:DayOfYear # freq=2224932 freq=282471
+OrHighMedDayTaxoFacets: other source +facets:taxonomy:DayOfYear # freq=1269961 freq=231838
+OrHighMedDayTaxoFacets: 1 alone +facets:taxonomy:DayOfYear # freq=1641090 freq=93166
+OrHighMedDayTaxoFacets: and per +facets:taxonomy:DayOfYear # freq=7318061 freq=283568
+OrHighMedDayTaxoFacets: into larger +facets:taxonomy:DayOfYear # freq=888684 freq=87424
+OrHighMedDayTaxoFacets: to book +facets:taxonomy:DayOfYear # freq=6155577 freq=617297
+OrHighMedDayTaxoFacets: at london +facets:taxonomy:DayOfYear # freq=2857534 freq=348918
+OrHighMedDayTaxoFacets: at km +facets:taxonomy:DayOfYear # freq=2857534 freq=233831
+OrHighMedDayTaxoFacets: in convert +facets:taxonomy:DayOfYear # freq=7320987 freq=267974
+OrHighMedDayTaxoFacets: s yet +facets:taxonomy:DayOfYear # freq=1581243 freq=100857
+OrHighMedDayTaxoFacets: 1 1973 +facets:taxonomy:DayOfYear # freq=1641090 freq=125985
+OrHighMedDayTaxoFacets: 1 yet +facets:taxonomy:DayOfYear # freq=1641090 freq=100857
+OrHighMedDayTaxoFacets: 3 preserved +facets:taxonomy:DayOfYear # freq=1148799 freq=111088
+OrHighMedDayTaxoFacets: when various +facets:taxonomy:DayOfYear # freq=1027487 freq=224593
+OrHighMedDayTaxoFacets: his result +facets:taxonomy:DayOfYear # freq=1777780 freq=276803
+OrHighMedDayTaxoFacets: into film +facets:taxonomy:DayOfYear # freq=888684 freq=432758
+OrHighMedDayTaxoFacets: was leader +facets:taxonomy:DayOfYear # freq=3763623 freq=127591
+OrHighMedDayTaxoFacets: see list +facets:taxonomy:DayOfYear # freq=1044180 freq=585922
+OrHighMedDayTaxoFacets: first institute +facets:taxonomy:DayOfYear # freq=1933372 freq=136311
+OrHighMedDayTaxoFacets: work got +facets:taxonomy:DayOfYear # freq=853422 freq=92640
+OrHighMedDayTaxoFacets: had rule +facets:taxonomy:DayOfYear # freq=1246743 freq=86729
+OrHighMedDayTaxoFacets: 1 thought +facets:taxonomy:DayOfYear # freq=1641090 freq=108963
+OrHighMedDayTaxoFacets: an hard +facets:taxonomy:DayOfYear # freq=2628056 freq=90149
+OrHighMedDayTaxoFacets: only 1972 +facets:taxonomy:DayOfYear # freq=875561 freq=130791
+OrHighMedDayTaxoFacets: was american +facets:taxonomy:DayOfYear # freq=3763623 freq=758337
+OrHighMedDayTaxoFacets: 2009 lines +facets:taxonomy:DayOfYear # freq=887702 freq=96969
+OrHighMedDayTaxoFacets: no followed +facets:taxonomy:DayOfYear # freq=1045000 freq=121848
+OrHighMedDayTaxoFacets: had five +facets:taxonomy:DayOfYear # freq=1246743 freq=262923
+OrHighMedDayTaxoFacets: was q +facets:taxonomy:DayOfYear # freq=3763623 freq=149271
+OrHighMedDayTaxoFacets: cite wikipedia +facets:taxonomy:DayOfYear # freq=1741194 freq=149673
+OrHighMedDayTaxoFacets: other already +facets:taxonomy:DayOfYear # freq=1269961 freq=126694
+OrHighMedDayTaxoFacets: it keep +facets:taxonomy:DayOfYear # freq=2675552 freq=177996
+OrHighMedDayTaxoFacets: states t +facets:taxonomy:DayOfYear # freq=1034872 freq=262832
+OrHighMedDayTaxoFacets: 1 listed +facets:taxonomy:DayOfYear # freq=1641090 freq=94990
+OrHighMedDayTaxoFacets: there modify +facets:taxonomy:DayOfYear # freq=956153 freq=109819
+OrHighMedDayTaxoFacets: url win +facets:taxonomy:DayOfYear # freq=1513595 freq=121070
+OrHighMedDayTaxoFacets: may 39 +facets:taxonomy:DayOfYear # freq=1071932 freq=132689
+OrHighMedDayTaxoFacets: two charles +facets:taxonomy:DayOfYear # freq=1104053 freq=204987
+OrHighMedDayTaxoFacets: also appears +facets:taxonomy:DayOfYear # freq=1959419 freq=104511
+OrHighMedDayTaxoFacets: more rowspan +facets:taxonomy:DayOfYear # freq=963533 freq=124637
+OrHighMedDayTaxoFacets: web north +facets:taxonomy:DayOfYear # freq=1118334 freq=564195
+OrHighMedDayTaxoFacets: 1 smith +facets:taxonomy:DayOfYear # freq=1641090 freq=126344
+OrHighMedDayTaxoFacets: 2010 2000 +facets:taxonomy:DayOfYear # freq=950573 freq=499639
+OrHighMedDayTaxoFacets: they features +facets:taxonomy:DayOfYear # freq=1021945 freq=156867
+OrHighMedDayTaxoFacets: 2 project +facets:taxonomy:DayOfYear # freq=1549245 freq=180139
+OrHighMedDayTaxoFacets: http instead +facets:taxonomy:DayOfYear # freq=3493581 freq=149345
+OrHighMedDayTaxoFacets: by am +facets:taxonomy:DayOfYear # freq=3826691 freq=127152
+OrHighMedDayTaxoFacets: it pacific +facets:taxonomy:DayOfYear # freq=2675552 freq=107648
+OrHighMedDayTaxoFacets: states times +facets:taxonomy:DayOfYear # freq=1034872 freq=407155
+OrHighMedDayTaxoFacets: name middle +facets:taxonomy:DayOfYear # freq=2827713 freq=156728
+OrHighMedDayTaxoFacets: is 1988 +facets:taxonomy:DayOfYear # freq=4074455 freq=181327
+OrHighMedDayTaxoFacets: 5 c +facets:taxonomy:DayOfYear # freq=891361 freq=444247
+OrHighMedDayTaxoFacets: their court +facets:taxonomy:DayOfYear # freq=1158682 freq=169309
+OrHighMedDayTaxoFacets: they double +facets:taxonomy:DayOfYear # freq=1021945 freq=87304
+OrHighMedDayTaxoFacets: in george +facets:taxonomy:DayOfYear # freq=7320987 freq=256196
+OrHighMedDayTaxoFacets: after appears +facets:taxonomy:DayOfYear # freq=1247398 freq=104511
+OrHighMedDayTaxoFacets: is thomas +facets:taxonomy:DayOfYear # freq=4074455 freq=191625
+OrHighMedDayTaxoFacets: about specific +facets:taxonomy:DayOfYear # freq=850283 freq=93622
+OrHighMedDayTaxoFacets: be captain +facets:taxonomy:DayOfYear # freq=2051702 freq=91635
+OrHighMedDayTaxoFacets: be journal +facets:taxonomy:DayOfYear # freq=2051702 freq=348162
+OrHighMedDayTaxoFacets: this month +facets:taxonomy:DayOfYear # freq=2224932 freq=162128
+OrHighMedDayTaxoFacets: last given +facets:taxonomy:DayOfYear # freq=958437 freq=235719
+OrHighMedDayTaxoFacets: from running +facets:taxonomy:DayOfYear # freq=3224339 freq=101764
+OrHighMedDayTaxoFacets: 2008 liberal +facets:taxonomy:DayOfYear # freq=831253 freq=93070
+OrHighMedDayTaxoFacets: i island +facets:taxonomy:DayOfYear # freq=956148 freq=203023
+OrHighMedDayTaxoFacets: or pp +facets:taxonomy:DayOfYear # freq=1858841 freq=204742
+OrHighMedDayTaxoFacets: which earth +facets:taxonomy:DayOfYear # freq=1963428 freq=110512
+OrHighMedDayTaxoFacets: united school +facets:taxonomy:DayOfYear # freq=1196944 freq=462166
+OrHighMedDayTaxoFacets: at fall +facets:taxonomy:DayOfYear # freq=2857534 freq=103379
+OrHighMedDayTaxoFacets: by talk +facets:taxonomy:DayOfYear # freq=3826691 freq=364194
+OrHighMedDayTaxoFacets: title appropriate +facets:taxonomy:DayOfYear # freq=2397378 freq=135343
+OrHighMedDayTaxoFacets: first data +facets:taxonomy:DayOfYear # freq=1933372 freq=159657
+OrHighMedDayTaxoFacets: by community +facets:taxonomy:DayOfYear # freq=3826691 freq=225571
+OrHighMedDayTaxoFacets: it anti +facets:taxonomy:DayOfYear # freq=2675552 freq=99993
+OrHighMedDayTaxoFacets: 2005 would +facets:taxonomy:DayOfYear # freq=835460 freq=690480
+OrHighMedDayTaxoFacets: no archive +facets:taxonomy:DayOfYear # freq=1045000 freq=215381
+OrHighMedDayTaxoFacets: had 11 +facets:taxonomy:DayOfYear # freq=1246743 freq=730505
+OrHighMedDayTaxoFacets: which 978 +facets:taxonomy:DayOfYear # freq=1963428 freq=101276
+OrHighMedDayTaxoFacets: accessdate seems +facets:taxonomy:DayOfYear # freq=1228887 freq=83963
+OrHighMedDayTaxoFacets: 2011 commission +facets:taxonomy:DayOfYear # freq=871410 freq=91476
+OrHighMedDayTaxoFacets: that county +facets:taxonomy:DayOfYear # freq=2931020 freq=521126
+OrHighMedDayTaxoFacets: they hard +facets:taxonomy:DayOfYear # freq=1021945 freq=90149
+OrHighMedDayTaxoFacets: first historic +facets:taxonomy:DayOfYear # freq=1933372 freq=112292
+OrHighMedDayTaxoFacets: this category +facets:taxonomy:DayOfYear # freq=2224932 freq=595446
+OrHighMedDayTaxoFacets: its counties +facets:taxonomy:DayOfYear # freq=1173450 freq=87574
+OrHighMedDayTaxoFacets: year 1963 +facets:taxonomy:DayOfYear # freq=1235231 freq=96439
+OrHighMedDayTaxoFacets: this include +facets:taxonomy:DayOfYear # freq=2224932 freq=276466
+OrHighMedDayTaxoFacets: one british +facets:taxonomy:DayOfYear # freq=1527689 freq=417307
+OrHighMedDayTaxoFacets: was world +facets:taxonomy:DayOfYear # freq=3763623 freq=808563
+OrHighMedDayTaxoFacets: the references +facets:taxonomy:DayOfYear # freq=8217362 freq=760306
+OrHighMedDayTaxoFacets: its 56 +facets:taxonomy:DayOfYear # freq=1173450 freq=96215
+OrHighMedDayTaxoFacets: their son +facets:taxonomy:DayOfYear # freq=1158682 freq=202340
+OrHighMedDayTaxoFacets: the federal +facets:taxonomy:DayOfYear # freq=8217362 freq=166274
+OrHighMedDayTaxoFacets: with jpg +facets:taxonomy:DayOfYear # freq=3709421 freq=322278
+OrHighMedDayTaxoFacets: on training +facets:taxonomy:DayOfYear # freq=4074624 freq=107271
+OrHighMedDayTaxoFacets: for famous +facets:taxonomy:DayOfYear # freq=4380011 freq=139092
+OrHighMedDayTaxoFacets: work run +facets:taxonomy:DayOfYear # freq=853422 freq=183609
+OrHighMedDayTaxoFacets: which start +facets:taxonomy:DayOfYear # freq=1963428 freq=233925
+OrHighMedDayTaxoFacets: and author +facets:taxonomy:DayOfYear # freq=7318061 freq=567768
+OrHighMedDayTaxoFacets: name mother +facets:taxonomy:DayOfYear # freq=2827713 freq=122930
+OrHighMedDayTaxoFacets: who current +facets:taxonomy:DayOfYear # freq=1196171 freq=217174
+OrHighMedDayTaxoFacets: s vote +facets:taxonomy:DayOfYear # freq=1581243 freq=96871
+OrHighMedDayTaxoFacets: 4 51 +facets:taxonomy:DayOfYear # freq=986452 freq=108800
+OrHighMedDayTaxoFacets: 2011 special +facets:taxonomy:DayOfYear # freq=871410 freq=198917
+OrHighMedDayTaxoFacets: accessdate st +facets:taxonomy:DayOfYear # freq=1228887 freq=309092
+OrHighMedDayTaxoFacets: about must +facets:taxonomy:DayOfYear # freq=850283 freq=228491
+OrHighMedDayTaxoFacets: had census +facets:taxonomy:DayOfYear # freq=1246743 freq=205166
+OrHighMedDayTaxoFacets: publisher 56 +facets:taxonomy:DayOfYear # freq=1289029 freq=96215
+OrHighMedDayTaxoFacets: other 12 +facets:taxonomy:DayOfYear # freq=1269961 freq=774572
+OrHighMedDayTaxoFacets: or 22 +facets:taxonomy:DayOfYear # freq=1858841 freq=502778
+OrHighMedDayTaxoFacets: of deletion +facets:taxonomy:DayOfYear # freq=8184358 freq=166633
+OrHighMedDayTaxoFacets: as married +facets:taxonomy:DayOfYear # freq=3925535 freq=156752
+OrHighMedDayTaxoFacets: also do +facets:taxonomy:DayOfYear # freq=1959419 freq=511178
+OrHighMedDayTaxoFacets: of larger +facets:taxonomy:DayOfYear # freq=8184358 freq=87424
+OrHighMedDayTaxoFacets: the wikipedia:persondata +facets:taxonomy:DayOfYear # freq=8217362 freq=222385
+OrHighMedDayTaxoFacets: be books +facets:taxonomy:DayOfYear # freq=2051702 freq=341376
+OrHighMedDayTaxoFacets: url george +facets:taxonomy:DayOfYear # freq=1513595 freq=256196
+OrHighMedDayTaxoFacets: accessdate del +facets:taxonomy:DayOfYear # freq=1228887 freq=82614
+OrHighMedDayTaxoFacets: about command +facets:taxonomy:DayOfYear # freq=850283 freq=87496
+OrHighMedDayTaxoFacets: there soon +facets:taxonomy:DayOfYear # freq=956153 freq=123657
+OrHighMedDayTaxoFacets: url special +facets:taxonomy:DayOfYear # freq=1513595 freq=198917
+OrHighMedDayTaxoFacets: may authority +facets:taxonomy:DayOfYear # freq=1071932 freq=85540
+OrHighMedDayTaxoFacets: url ever +facets:taxonomy:DayOfYear # freq=1513595 freq=128732
+OrHighMedDayTaxoFacets: see 1987 +facets:taxonomy:DayOfYear # freq=1044180 freq=172453
+OrHighMedDayTaxoFacets: his ended +facets:taxonomy:DayOfYear # freq=1777780 freq=84664
+OrHighMedDayTaxoFacets: who prime +facets:taxonomy:DayOfYear # freq=1196171 freq=96945
+OrHighMedDayTaxoFacets: a success +facets:taxonomy:DayOfYear # freq=6560531 freq=112195
+OrHighMedDayTaxoFacets: cite elected +facets:taxonomy:DayOfYear # freq=1741194 freq=119941
+OrHighMedDayTaxoFacets: 2008 without +facets:taxonomy:DayOfYear # freq=831253 freq=249926
+OrHighMedDayTaxoFacets: after km +facets:taxonomy:DayOfYear # freq=1247398 freq=233831
+OrHighMedDayTaxoFacets: no fields +facets:taxonomy:DayOfYear # freq=1045000 freq=86938
+OrHighMedDayTaxoFacets: the financial +facets:taxonomy:DayOfYear # freq=8217362 freq=82536
+OrHighMedDayTaxoFacets: had features +facets:taxonomy:DayOfYear # freq=1246743 freq=156867
+OrHighMedDayTaxoFacets: into dead +facets:taxonomy:DayOfYear # freq=888684 freq=171386
+OrHighMedDayTaxoFacets: of caused +facets:taxonomy:DayOfYear # freq=8184358 freq=86397
+OrHighMedDayTaxoFacets: as changes +facets:taxonomy:DayOfYear # freq=3925535 freq=105677
+OrHighMedDayTaxoFacets: no president +facets:taxonomy:DayOfYear # freq=1045000 freq=263341
+OrHighMedDayTaxoFacets: one within +facets:taxonomy:DayOfYear # freq=1527689 freq=291049
+OrHighMedDayTaxoFacets: at mark +facets:taxonomy:DayOfYear # freq=2857534 freq=160033
+OrHighMedDayTaxoFacets: first down +facets:taxonomy:DayOfYear # freq=1933372 freq=280662
+OrHighMedDayTaxoFacets: be leader +facets:taxonomy:DayOfYear # freq=2051702 freq=127591
+OrHighMedDayTaxoFacets: were know +facets:taxonomy:DayOfYear # freq=1524630 freq=129655
+OrHighMedDayTaxoFacets: s england +facets:taxonomy:DayOfYear # freq=1581243 freq=317884
+OrHighMedDayTaxoFacets: one set +facets:taxonomy:DayOfYear # freq=1527689 freq=294255
+OrHighMedDayTaxoFacets: 5 flight +facets:taxonomy:DayOfYear # freq=891361 freq=84316
+OrHighMedDayTaxoFacets: i works +facets:taxonomy:DayOfYear # freq=956148 freq=199177
+OrHighMedDayTaxoFacets: was 1982 +facets:taxonomy:DayOfYear # freq=3763623 freq=153269
+OrHighMedDayTaxoFacets: but 57 +facets:taxonomy:DayOfYear # freq=1456553 freq=93708
+OrHighMedDayTaxoFacets: date coord +facets:taxonomy:DayOfYear # freq=2020626 freq=180590
+OrHighMedDayTaxoFacets: cite science +facets:taxonomy:DayOfYear # freq=1741194 freq=219988
+OrHighMedDayTaxoFacets: two past +facets:taxonomy:DayOfYear # freq=1104053 freq=126130
+OrHighMedDayTaxoFacets: first albums +facets:taxonomy:DayOfYear # freq=1933372 freq=118322
+OrHighMedDayTaxoFacets: its 14 +facets:taxonomy:DayOfYear # freq=1173450 freq=534005
+OrHighMedDayTaxoFacets: when rowspan +facets:taxonomy:DayOfYear # freq=1027487 freq=124637
+OrHighMedDayTaxoFacets: for league +facets:taxonomy:DayOfYear # freq=4380011 freq=270223
+OrHighMedDayTaxoFacets: to keep +facets:taxonomy:DayOfYear # freq=6155577 freq=177996
+OrHighMedDayTaxoFacets: a baseball +facets:taxonomy:DayOfYear # freq=6560531 freq=93326
+OrHighMedDayTaxoFacets: publisher colspan +facets:taxonomy:DayOfYear # freq=1289029 freq=134521
+OrHighMedDayTaxoFacets: when release +facets:taxonomy:DayOfYear # freq=1027487 freq=189375
+OrHighMedDayTaxoFacets: see down +facets:taxonomy:DayOfYear # freq=1044180 freq=280662
+OrHighMedDayTaxoFacets: date does +facets:taxonomy:DayOfYear # freq=2020626 freq=232202
+OrHighMedDayTaxoFacets: s boston +facets:taxonomy:DayOfYear # freq=1581243 freq=85235
+OrHighMedDayTaxoFacets: but center +facets:taxonomy:DayOfYear # freq=1456553 freq=489673
+OrHighMedDayTaxoFacets: some originally +facets:taxonomy:DayOfYear # freq=839919 freq=168282
+OrHighMedDayTaxoFacets: all movement +facets:taxonomy:DayOfYear # freq=1203572 freq=131692
+OrHighMedDayTaxoFacets: an human +facets:taxonomy:DayOfYear # freq=2628056 freq=182617
+OrHighMedDayTaxoFacets: time life +facets:taxonomy:DayOfYear # freq=1032071 freq=477007
+OrHighMedDayTaxoFacets: first bridge +facets:taxonomy:DayOfYear # freq=1933372 freq=92398
+OrHighMedDayTaxoFacets: one comments +facets:taxonomy:DayOfYear # freq=1527689 freq=185637
+OrHighMedDayTaxoFacets: he background +facets:taxonomy:DayOfYear # freq=1659434 freq=314229
+OrHighMedDayTaxoFacets: 2006 1988 +facets:taxonomy:DayOfYear # freq=889954 freq=181327
+OrHighMedDayTaxoFacets: http fiction +facets:taxonomy:DayOfYear # freq=3493581 freq=87227
+OrHighMedDayTaxoFacets: 4 case +facets:taxonomy:DayOfYear # freq=986452 freq=207307
+OrHighMedDayTaxoFacets: there mike +facets:taxonomy:DayOfYear # freq=956153 freq=91795
+OrHighMedDayTaxoFacets: there 29 +facets:taxonomy:DayOfYear # freq=956153 freq=372091
+OrHighMedDayTaxoFacets: 2010 near +facets:taxonomy:DayOfYear # freq=950573 freq=254492
+OrHighMedDayTaxoFacets: url channel +facets:taxonomy:DayOfYear # freq=1513595 freq=101401
+OrHighMedDayTaxoFacets: two robert +facets:taxonomy:DayOfYear # freq=1104053 freq=246405
+OrHighMedDayTaxoFacets: or public +facets:taxonomy:DayOfYear # freq=1858841 freq=368868
+OrHighMedDayTaxoFacets: other robert +facets:taxonomy:DayOfYear # freq=1269961 freq=246405
+OrHighMedDayTaxoFacets: ref germany +facets:taxonomy:DayOfYear # freq=3793973 freq=190478
+OrHighMedDayTaxoFacets: one english +facets:taxonomy:DayOfYear # freq=1527689 freq=412061
+OrHighMedDayTaxoFacets: no cd +facets:taxonomy:DayOfYear # freq=1045000 freq=87105
+OrHighMedDayTaxoFacets: publisher what +facets:taxonomy:DayOfYear # freq=1289029 freq=394675
+OrHighMedDayTaxoFacets: their win +facets:taxonomy:DayOfYear # freq=1158682 freq=121070
+OrHighMedDayTaxoFacets: an 1959 +facets:taxonomy:DayOfYear # freq=2628056 freq=87097
+OrHighMedDayTaxoFacets: but digital +facets:taxonomy:DayOfYear # freq=1456553 freq=82650
+OrHighMedDayTaxoFacets: but 30 +facets:taxonomy:DayOfYear # freq=1456553 freq=488930
+OrHighMedDayTaxoFacets: work information +facets:taxonomy:DayOfYear # freq=853422 freq=353153
+OrHighMedDayTaxoFacets: by population +facets:taxonomy:DayOfYear # freq=3826691 freq=374481
+OrHighMedDayTaxoFacets: in post +facets:taxonomy:DayOfYear # freq=7320987 freq=218570
+OrHighMedDayTaxoFacets: who birth +facets:taxonomy:DayOfYear # freq=1196171 freq=425138
+OrHighMedDayTaxoFacets: who multiple +facets:taxonomy:DayOfYear # freq=1196171 freq=89684
+OrHighMedDayTaxoFacets: ref trade +facets:taxonomy:DayOfYear # freq=3793973 freq=106384
+OrHighMedDayTaxoFacets: after lord +facets:taxonomy:DayOfYear # freq=1247398 freq=106633
+OrHighMedDayTaxoFacets: to significant +facets:taxonomy:DayOfYear # freq=6155577 freq=111574
+OrHighMedDayTaxoFacets: also 1976 +facets:taxonomy:DayOfYear # freq=1959419 freq=134555
+OrHighMedDayTaxoFacets: which awards +facets:taxonomy:DayOfYear # freq=1963428 freq=159679
+OrHighMedDayTaxoFacets: by blue +facets:taxonomy:DayOfYear # freq=3826691 freq=156658
+OrHighMedDayTaxoFacets: that cause +facets:taxonomy:DayOfYear # freq=2931020 freq=83898
+OrHighMedDayTaxoFacets: about began +facets:taxonomy:DayOfYear # freq=850283 freq=276036
+OrHighMedDayTaxoFacets: other entire +facets:taxonomy:DayOfYear # freq=1269961 freq=97485
+OrHighMedDayTaxoFacets: has internet +facets:taxonomy:DayOfYear # freq=1502961 freq=85510
+OrHighMedDayTaxoFacets: url highest +facets:taxonomy:DayOfYear # freq=1513595 freq=91072
+OrHighMedDayTaxoFacets: an stage +facets:taxonomy:DayOfYear # freq=2628056 freq=113041
+OrHighMedDayTaxoFacets: title imagesize +facets:taxonomy:DayOfYear # freq=2397378 freq=82746
+OrHighMedDayTaxoFacets: see span +facets:taxonomy:DayOfYear # freq=1044180 freq=146676
+OrHighMedDayTaxoFacets: states 2007 +facets:taxonomy:DayOfYear # freq=1034872 freq=801586
+OrHighMedDayTaxoFacets: in clear +facets:taxonomy:DayOfYear # freq=7320987 freq=109812
+OrHighMedDayTaxoFacets: with jean +facets:taxonomy:DayOfYear # freq=3709421 freq=84299
+OrHighMedDayTaxoFacets: other dq +facets:taxonomy:DayOfYear # freq=1269961 freq=88557
+OrHighMedDayTaxoFacets: from chris +facets:taxonomy:DayOfYear # freq=3224339 freq=85523
+OrHighMedDayTaxoFacets: no next +facets:taxonomy:DayOfYear # freq=1045000 freq=259039
+OrHighMedDayTaxoFacets: for musical +facets:taxonomy:DayOfYear # freq=4380011 freq=132600
+OrHighMedDayTaxoFacets: see came +facets:taxonomy:DayOfYear # freq=1044180 freq=197126
+OrHighMedDayTaxoFacets: two wales +facets:taxonomy:DayOfYear # freq=1104053 freq=103595
+OrHighMedDayTaxoFacets: new eastern +facets:taxonomy:DayOfYear # freq=1657293 freq=176853
+OrHighMedDayTaxoFacets: 2 marriage +facets:taxonomy:DayOfYear # freq=1549245 freq=97658
+OrHighMedDayTaxoFacets: 2009 forces +facets:taxonomy:DayOfYear # freq=887702 freq=152939
+OrHighMedDayTaxoFacets: at any +facets:taxonomy:DayOfYear # freq=2857534 freq=483514
+OrHighMedDayTaxoFacets: as live +facets:taxonomy:DayOfYear # freq=3925535 freq=242147
+OrHighMedDayTaxoFacets: see academy +facets:taxonomy:DayOfYear # freq=1044180 freq=119055
+OrHighMedDayTaxoFacets: their get +facets:taxonomy:DayOfYear # freq=1158682 freq=187847
+OrHighMedDayTaxoFacets: about via +facets:taxonomy:DayOfYear # freq=850283 freq=109090
+OrHighMedDayTaxoFacets: only fields +facets:taxonomy:DayOfYear # freq=875561 freq=86938
+OrHighMedDayTaxoFacets: time central +facets:taxonomy:DayOfYear # freq=1032071 freq=272531
+OrHighMedDayTaxoFacets: two my +facets:taxonomy:DayOfYear # freq=1104053 freq=274256
+OrHighMedDayTaxoFacets: with land +facets:taxonomy:DayOfYear # freq=3709421 freq=230284
+OrHighMedDayTaxoFacets: two financial +facets:taxonomy:DayOfYear # freq=1104053 freq=82536
+OrHighMedDayTaxoFacets: was convert +facets:taxonomy:DayOfYear # freq=3763623 freq=267974
+OrHighMedDayTaxoFacets: not course +facets:taxonomy:DayOfYear # freq=1713264 freq=106126
+OrHighMedDayTaxoFacets: 10 producer +facets:taxonomy:DayOfYear # freq=918339 freq=137098
+OrHighMedDayTaxoFacets: 3 52 +facets:taxonomy:DayOfYear # freq=1148799 freq=108395
+OrHighMedDayTaxoFacets: 2008 final +facets:taxonomy:DayOfYear # freq=831253 freq=230006
+OrHighMedDayTaxoFacets: from sir +facets:taxonomy:DayOfYear # freq=3224339 freq=107709
+OrHighMedDayTaxoFacets: to majority +facets:taxonomy:DayOfYear # freq=6155577 freq=105058
+OrHighMedDayTaxoFacets: work published +facets:taxonomy:DayOfYear # freq=853422 freq=243548
+OrHighMedDayTaxoFacets: but might +facets:taxonomy:DayOfYear # freq=1456553 freq=114290
+OrHighMedDayTaxoFacets: has radio +facets:taxonomy:DayOfYear # freq=1502961 freq=183866
+OrHighMedDayTaxoFacets: of 45 +facets:taxonomy:DayOfYear # freq=8184358 freq=180879
+OrHighMedDayTaxoFacets: some africa +facets:taxonomy:DayOfYear # freq=839919 freq=124511
+OrHighMedDayTaxoFacets: title club +facets:taxonomy:DayOfYear # freq=2397378 freq=232173
+OrHighMedDayTaxoFacets: his bgcolor +facets:taxonomy:DayOfYear # freq=1777780 freq=124305
+OrHighMedDayTaxoFacets: that opened +facets:taxonomy:DayOfYear # freq=2931020 freq=140033
+OrHighMedDayTaxoFacets: new station +facets:taxonomy:DayOfYear # freq=1657293 freq=239572
+OrHighMedDayTaxoFacets: were value +facets:taxonomy:DayOfYear # freq=1524630 freq=86806
+OrHighMedDayTaxoFacets: time end +facets:taxonomy:DayOfYear # freq=1032071 freq=526636
+OrHighMedDayTaxoFacets: date start +facets:taxonomy:DayOfYear # freq=2020626 freq=233925
+OrHighMedDayTaxoFacets: 3 across +facets:taxonomy:DayOfYear # freq=1148799 freq=134478
+OrHighMedDayTaxoFacets: 1 j +facets:taxonomy:DayOfYear # freq=1641090 freq=327713
+OrHighMedDayTaxoFacets: the ever +facets:taxonomy:DayOfYear # freq=8217362 freq=128732
+OrHighMedDayTaxoFacets: s archive +facets:taxonomy:DayOfYear # freq=1581243 freq=215381
+OrHighMedDayTaxoFacets: date style +facets:taxonomy:DayOfYear # freq=2020626 freq=606000
+OrHighMedDayTaxoFacets: 2010 caused +facets:taxonomy:DayOfYear # freq=950573 freq=86397
+OrHighMedDayTaxoFacets: or past +facets:taxonomy:DayOfYear # freq=1858841 freq=126130
+OrHighMedDayTaxoFacets: also edits +facets:taxonomy:DayOfYear # freq=1959419 freq=134321
+OrHighMedDayTaxoFacets: http stated +facets:taxonomy:DayOfYear # freq=3493581 freq=89795
+OrHighMedDayTaxoFacets: publisher association +facets:taxonomy:DayOfYear # freq=1289029 freq=247156
+OrHighMedDayTaxoFacets: other europe +facets:taxonomy:DayOfYear # freq=1269961 freq=188671
+OrHighMedDayTaxoFacets: work japan +facets:taxonomy:DayOfYear # freq=853422 freq=163103
+OrHighMedDayTaxoFacets: been committee +facets:taxonomy:DayOfYear # freq=1041183 freq=108636
+OrHighMedDayTaxoFacets: about five +facets:taxonomy:DayOfYear # freq=850283 freq=262923
+OrHighMedDayTaxoFacets: the throughout +facets:taxonomy:DayOfYear # freq=8217362 freq=143603
+OrHighMedDayTaxoFacets: first studies +facets:taxonomy:DayOfYear # freq=1933372 freq=128020
+OrHighMedDayTaxoFacets: his university +facets:taxonomy:DayOfYear # freq=1777780 freq=636959
+OrHighMedDayTaxoFacets: there legal +facets:taxonomy:DayOfYear # freq=956153 freq=90645
+OrHighMedDayTaxoFacets: all italian +facets:taxonomy:DayOfYear # freq=1203572 freq=107082
+OrHighMedDayTaxoFacets: may buildings +facets:taxonomy:DayOfYear # freq=1071932 freq=89046
+OrHighMedDayTaxoFacets: with day +facets:taxonomy:DayOfYear # freq=3709421 freq=402096
+OrHighMedDayTaxoFacets: is code +facets:taxonomy:DayOfYear # freq=4074455 freq=170156
+OrHighMedDayTaxoFacets: date asia +facets:taxonomy:DayOfYear # freq=2020626 freq=90307
+OrHighMedDayTaxoFacets: and thumb +facets:taxonomy:DayOfYear # freq=7318061 freq=672667
+OrHighMedDayTaxoFacets: 10 1970 +facets:taxonomy:DayOfYear # freq=918339 freq=139043
+OrHighMedDayTaxoFacets: from generated +facets:taxonomy:DayOfYear # freq=3224339 freq=97908
+OrHighMedDayTaxoFacets: for light +facets:taxonomy:DayOfYear # freq=4380011 freq=161671
+OrHighMedDayTaxoFacets: about 1970 +facets:taxonomy:DayOfYear # freq=850283 freq=139043
+OrHighMedDayTaxoFacets: states start +facets:taxonomy:DayOfYear # freq=1034872 freq=233925
+OrHighMedDayTaxoFacets: 2 sir +facets:taxonomy:DayOfYear # freq=1549245 freq=107709
+OrHighMedDayTaxoFacets: from information +facets:taxonomy:DayOfYear # freq=3224339 freq=353153
+OrHighMedDayTaxoFacets: 3 reflist +facets:taxonomy:DayOfYear # freq=1148799 freq=561253
+OrHighMedDayTaxoFacets: year modern +facets:taxonomy:DayOfYear # freq=1235231 freq=218831
+OrHighMedDayTaxoFacets: states successful +facets:taxonomy:DayOfYear # freq=1034872 freq=106021
+OrHighMedDayTaxoFacets: on local +facets:taxonomy:DayOfYear # freq=4074624 freq=299012
+OrHighMedDayTaxoFacets: also production +facets:taxonomy:DayOfYear # freq=1959419 freq=191554
+OrHighMedDayTaxoFacets: ref white +facets:taxonomy:DayOfYear # freq=3793973 freq=299411
+OrHighMedDayTaxoFacets: that too +facets:taxonomy:DayOfYear # freq=2931020 freq=161626
+OrHighMedDayTaxoFacets: 2 20 +facets:taxonomy:DayOfYear # freq=1549245 freq=624967
+OrHighMedDayTaxoFacets: 2008 strong +facets:taxonomy:DayOfYear # freq=831253 freq=125611
+OrHighMedDayTaxoFacets: no list +facets:taxonomy:DayOfYear # freq=1045000 freq=585922
+OrHighMedDayTaxoFacets: first label +facets:taxonomy:DayOfYear # freq=1933372 freq=159161
+OrHighMedDayTaxoFacets: see metadata +facets:taxonomy:DayOfYear # freq=1044180 freq=298533
+OrHighMedDayTaxoFacets: they before +facets:taxonomy:DayOfYear # freq=1021945 freq=580481
+OrHighMedDayTaxoFacets: been volume +facets:taxonomy:DayOfYear # freq=1041183 freq=312846
+OrHighMedDayTaxoFacets: last division +facets:taxonomy:DayOfYear # freq=958437 freq=182624
+OrHighMedDayTaxoFacets: new 1988 +facets:taxonomy:DayOfYear # freq=1657293 freq=181327
+OrHighMedDayTaxoFacets: its single +facets:taxonomy:DayOfYear # freq=1173450 freq=283824
+OrHighMedDayTaxoFacets: accessdate awards +facets:taxonomy:DayOfYear # freq=1228887 freq=159679
+OrHighMedDayTaxoFacets: of 1974 +facets:taxonomy:DayOfYear # freq=8184358 freq=132835
+OrHighMedDayTaxoFacets: and st +facets:taxonomy:DayOfYear # freq=7318061 freq=309092
+OrHighMedDayTaxoFacets: which 2002 +facets:taxonomy:DayOfYear # freq=1963428 freq=406953
+OrHighMedDayTaxoFacets: 10 role +facets:taxonomy:DayOfYear # freq=918339 freq=208579
+OrHighMedDayTaxoFacets: 2008 infobox +facets:taxonomy:DayOfYear # freq=831253 freq=524810
+OrHighMedDayTaxoFacets: by units +facets:taxonomy:DayOfYear # freq=3826691 freq=118189
+OrHighMedDayTaxoFacets: see reported +facets:taxonomy:DayOfYear # freq=1044180 freq=91533
+OrHighMedDayTaxoFacets: were love +facets:taxonomy:DayOfYear # freq=1524630 freq=177242
+OrHighMedDayTaxoFacets: their london +facets:taxonomy:DayOfYear # freq=1158682 freq=348918
+OrHighMedDayTaxoFacets: who persondata +facets:taxonomy:DayOfYear # freq=1196171 freq=246119
+OrHighMedDayTaxoFacets: be uk +facets:taxonomy:DayOfYear # freq=2051702 freq=319211
+OrHighMedDayTaxoFacets: for f +facets:taxonomy:DayOfYear # freq=4380011 freq=278015
+OrHighMedDayTaxoFacets: only hold +facets:taxonomy:DayOfYear # freq=875561 freq=82579
+OrHighMedDayTaxoFacets: new way +facets:taxonomy:DayOfYear # freq=1657293 freq=318344
+OrHighMedDayTaxoFacets: which lines +facets:taxonomy:DayOfYear # freq=1963428 freq=96969
+OrHighMedDayTaxoFacets: has div +facets:taxonomy:DayOfYear # freq=1502961 freq=206057
+OrHighMedDayTaxoFacets: all francisco +facets:taxonomy:DayOfYear # freq=1203572 freq=83200
+OrHighMedDayTaxoFacets: from per +facets:taxonomy:DayOfYear # freq=3224339 freq=283568
+OrHighMedDayTaxoFacets: it marriage +facets:taxonomy:DayOfYear # freq=2675552 freq=97658
+OrHighMedDayTaxoFacets: states small +facets:taxonomy:DayOfYear # freq=1034872 freq=581643
+OrHighMedDayTaxoFacets: 2011 july +facets:taxonomy:DayOfYear # freq=871410 freq=529655
+OrHighMedDayTaxoFacets: and mid +facets:taxonomy:DayOfYear # freq=7318061 freq=126355
+OrHighMedDayTaxoFacets: year copy +facets:taxonomy:DayOfYear # freq=1235231 freq=95252
+OrHighMedDayTaxoFacets: not ft +facets:taxonomy:DayOfYear # freq=1713264 freq=88505
+OrHighMedDayTaxoFacets: this 1988 +facets:taxonomy:DayOfYear # freq=2224932 freq=181327
+OrHighMedDayTaxoFacets: accessdate father +facets:taxonomy:DayOfYear # freq=1228887 freq=175393
+OrHighMedDayTaxoFacets: this continued +facets:taxonomy:DayOfYear # freq=2224932 freq=151209
+OrHighMedDayTaxoFacets: with union +facets:taxonomy:DayOfYear # freq=3709421 freq=214164
+OrHighMedDayTaxoFacets: 2011 festival +facets:taxonomy:DayOfYear # freq=871410 freq=85717
+OrHighMedDayTaxoFacets: states hall +facets:taxonomy:DayOfYear # freq=1034872 freq=177247
+OrHighMedDayTaxoFacets: after thomas +facets:taxonomy:DayOfYear # freq=1247398 freq=191625
+OrHighMedDayTaxoFacets: 2 god +facets:taxonomy:DayOfYear # freq=1549245 freq=97443
+OrHighMedDayTaxoFacets: states owned +facets:taxonomy:DayOfYear # freq=1034872 freq=93981
+OrHighMedDayTaxoFacets: were european +facets:taxonomy:DayOfYear # freq=1524630 freq=193975
+OrHighMedDayTaxoFacets: have jack +facets:taxonomy:DayOfYear # freq=1297121 freq=91552
+OrHighMedDayTaxoFacets: time majority +facets:taxonomy:DayOfYear # freq=1032071 freq=105058
+OrHighMedDayTaxoFacets: were went +facets:taxonomy:DayOfYear # freq=1524630 freq=172677
+OrHighMedDayTaxoFacets: only game +facets:taxonomy:DayOfYear # freq=875561 freq=315157
+OrHighMedDayTaxoFacets: a review +facets:taxonomy:DayOfYear # freq=6560531 freq=240157
+OrHighMedDayTaxoFacets: united thomas +facets:taxonomy:DayOfYear # freq=1196944 freq=191625
+OrHighMedDayTaxoFacets: may off +facets:taxonomy:DayOfYear # freq=1071932 freq=315473
+OrHighMedDayTaxoFacets: url persondata +facets:taxonomy:DayOfYear # freq=1513595 freq=246119
+OrHighMedDayTaxoFacets: new hill +facets:taxonomy:DayOfYear # freq=1657293 freq=133714
+OrHighMedDayTaxoFacets: at ice +facets:taxonomy:DayOfYear # freq=2857534 freq=87086
+OrHighMedDayTaxoFacets: 2008 fourth +facets:taxonomy:DayOfYear # freq=831253 freq=102351
+OrHighMedDayTaxoFacets: for 3rd +facets:taxonomy:DayOfYear # freq=4380011 freq=90723
+OrHighMedDayTaxoFacets: more cross +facets:taxonomy:DayOfYear # freq=963533 freq=127216
+OrHighMedDayTaxoFacets: not index.php +facets:taxonomy:DayOfYear # freq=1713264 freq=126813
+OrHighMedDayTaxoFacets: but census +facets:taxonomy:DayOfYear # freq=1456553 freq=205166
+OrHighMedDayTaxoFacets: work replaced +facets:taxonomy:DayOfYear # freq=853422 freq=112506
+OrHighMedDayTaxoFacets: some groups +facets:taxonomy:DayOfYear # freq=839919 freq=146670
+OrHighMedDayTaxoFacets: 10 collection +facets:taxonomy:DayOfYear # freq=918339 freq=110483
+OrHighMedDayTaxoFacets: not opening +facets:taxonomy:DayOfYear # freq=1713264 freq=84576
+OrHighMedDayTaxoFacets: see september +facets:taxonomy:DayOfYear # freq=1044180 freq=553409
+OrHighMedDayTaxoFacets: 4 steve +facets:taxonomy:DayOfYear # freq=986452 freq=84364
+OrHighMedDayTaxoFacets: ref appears +facets:taxonomy:DayOfYear # freq=3793973 freq=104511
+OrHighMedDayTaxoFacets: a named +facets:taxonomy:DayOfYear # freq=6560531 freq=310150
+OrHighMedDayTaxoFacets: which pre +facets:taxonomy:DayOfYear # freq=1963428 freq=90549
+OrHighMedDayTaxoFacets: has stone +facets:taxonomy:DayOfYear # freq=1502961 freq=92132
+OrHighMedDayTaxoFacets: to energy +facets:taxonomy:DayOfYear # freq=6155577 freq=91150
+OrHighMedDayTaxoFacets: not should +facets:taxonomy:DayOfYear # freq=1713264 freq=401379
+OrHighMedDayTaxoFacets: 2010 media +facets:taxonomy:DayOfYear # freq=950573 freq=206574
+OrHighMedDayTaxoFacets: was behind +facets:taxonomy:DayOfYear # freq=3763623 freq=112070
+OrHighMedDayTaxoFacets: that black +facets:taxonomy:DayOfYear # freq=2931020 freq=256526
+OrHighMedDayTaxoFacets: are itself +facets:taxonomy:DayOfYear # freq=1877802 freq=138231
+OrHighMedDayTaxoFacets: only 90 +facets:taxonomy:DayOfYear # freq=875561 freq=116206
+OrHighMedDayTaxoFacets: 4 main +facets:taxonomy:DayOfYear # freq=986452 freq=470429
+OrHighMedDayTaxoFacets: with august +facets:taxonomy:DayOfYear # freq=3709421 freq=527806
+OrHighMedDayTaxoFacets: have age +facets:taxonomy:DayOfYear # freq=1297121 freq=395368
+OrHighMedDayTaxoFacets: time citation +facets:taxonomy:DayOfYear # freq=1032071 freq=291478
+OrHighMedDayTaxoFacets: his notes +facets:taxonomy:DayOfYear # freq=1777780 freq=210029
+OrHighMedDayTaxoFacets: year 17 +facets:taxonomy:DayOfYear # freq=1235231 freq=507396
+OrHighMedDayTaxoFacets: i bbc +facets:taxonomy:DayOfYear # freq=956148 freq=138548
+OrHighMedDayTaxoFacets: name 1984 +facets:taxonomy:DayOfYear # freq=2827713 freq=161404
+OrHighMedDayTaxoFacets: his greek +facets:taxonomy:DayOfYear # freq=1777780 freq=94348
+OrHighMedDayTaxoFacets: cite votes +facets:taxonomy:DayOfYear # freq=1741194 freq=93844
+OrHighMedDayTaxoFacets: be fire +facets:taxonomy:DayOfYear # freq=2051702 freq=133712
+OrHighMedDayTaxoFacets: in sometimes +facets:taxonomy:DayOfYear # freq=7320987 freq=144078
+OrHighMedDayTaxoFacets: last better +facets:taxonomy:DayOfYear # freq=958437 freq=125889
+OrHighMedDayTaxoFacets: by considered +facets:taxonomy:DayOfYear # freq=3826691 freq=186840
+OrHighMedDayTaxoFacets: no leading +facets:taxonomy:DayOfYear # freq=1045000 freq=120945
+OrHighMedDayTaxoFacets: name influence +facets:taxonomy:DayOfYear # freq=2827713 freq=83101
+OrHighMedDayTaxoFacets: 2009 power +facets:taxonomy:DayOfYear # freq=887702 freq=262586
+OrHighMedDayTaxoFacets: is institute +facets:taxonomy:DayOfYear # freq=4074455 freq=136311
+OrHighMedDayTaxoFacets: into doi +facets:taxonomy:DayOfYear # freq=888684 freq=170085
+OrHighMedDayTaxoFacets: into short +facets:taxonomy:DayOfYear # freq=888684 freq=465205
+OrHighMedDayTaxoFacets: were gr +facets:taxonomy:DayOfYear # freq=1524630 freq=83712
+OrHighMedDayTaxoFacets: has 16 +facets:taxonomy:DayOfYear # freq=1502961 freq=540539
+OrHighMedDayTaxoFacets: this towards +facets:taxonomy:DayOfYear # freq=2224932 freq=95574
+OrHighMedDayTaxoFacets: the div +facets:taxonomy:DayOfYear # freq=8217362 freq=206057
+OrHighMedDayTaxoFacets: its jean +facets:taxonomy:DayOfYear # freq=1173450 freq=84299
+OrHighMedDayTaxoFacets: their continued +facets:taxonomy:DayOfYear # freq=1158682 freq=151209
+OrHighMedDayTaxoFacets: publisher come +facets:taxonomy:DayOfYear # freq=1289029 freq=139047
+OrHighMedDayTaxoFacets: name yet +facets:taxonomy:DayOfYear # freq=2827713 freq=100857
+OrHighMedDayTaxoFacets: be before +facets:taxonomy:DayOfYear # freq=2051702 freq=580481
+OrHighMedDayTaxoFacets: ref britain +facets:taxonomy:DayOfYear # freq=3793973 freq=101080
+OrHighMedDayTaxoFacets: 10 returned +facets:taxonomy:DayOfYear # freq=918339 freq=141639
+OrHighMedDayTaxoFacets: 2006 02 +facets:taxonomy:DayOfYear # freq=889954 freq=319783
+OrHighMedDayTaxoFacets: 2011 daughter +facets:taxonomy:DayOfYear # freq=871410 freq=103883
+OrHighMedDayTaxoFacets: be independent +facets:taxonomy:DayOfYear # freq=2051702 freq=164766
+OrHighMedDayTaxoFacets: more self +facets:taxonomy:DayOfYear # freq=963533 freq=135012
+OrHighMedDayTaxoFacets: in particular +facets:taxonomy:DayOfYear # freq=7320987 freq=103643
+OrHighMedDayTaxoFacets: which non +facets:taxonomy:DayOfYear # freq=1963428 freq=348142
+OrHighMedDayTaxoFacets: his birth +facets:taxonomy:DayOfYear # freq=1777780 freq=425138
+OrHighMedDayTaxoFacets: ref stations +facets:taxonomy:DayOfYear # freq=3793973 freq=92011
+OrHighMedDayTaxoFacets: united include +facets:taxonomy:DayOfYear # freq=1196944 freq=276466
+OrHighMedDayTaxoFacets: http flight +facets:taxonomy:DayOfYear # freq=3493581 freq=84316
+OrHighMedDayTaxoFacets: http singles +facets:taxonomy:DayOfYear # freq=3493581 freq=89221
+OrHighMedDayTaxoFacets: year northern +facets:taxonomy:DayOfYear # freq=1235231 freq=194363
+OrHighMedDayTaxoFacets: been htm +facets:taxonomy:DayOfYear # freq=1041183 freq=191479
+OrHighMedDayTaxoFacets: one alone +facets:taxonomy:DayOfYear # freq=1527689 freq=93166
+OrHighMedDayTaxoFacets: their systems +facets:taxonomy:DayOfYear # freq=1158682 freq=134476
+OrHighMedDayTaxoFacets: to yet +facets:taxonomy:DayOfYear # freq=6155577 freq=100857
+OrHighMedDayTaxoFacets: see leader +facets:taxonomy:DayOfYear # freq=1044180 freq=127591
+OrHighMedDayTaxoFacets: on seen +facets:taxonomy:DayOfYear # freq=4074624 freq=173530
+OrHighMedDayTaxoFacets: has 200px +facets:taxonomy:DayOfYear # freq=1502961 freq=102661
+OrHighMedDayTaxoFacets: that 56 +facets:taxonomy:DayOfYear # freq=2931020 freq=96215
+OrHighMedDayTaxoFacets: about women +facets:taxonomy:DayOfYear # freq=850283 freq=128847
+OrHighMedDayTaxoFacets: only michael +facets:taxonomy:DayOfYear # freq=875561 freq=217311
+OrHighMedDayTaxoFacets: 2009 provided +facets:taxonomy:DayOfYear # freq=887702 freq=110088
+OrHighMedDayTaxoFacets: with show +facets:taxonomy:DayOfYear # freq=3709421 freq=293934
+OrHighMedDayTaxoFacets: 2011 utc +facets:taxonomy:DayOfYear # freq=871410 freq=450225
+OrHighMedDayTaxoFacets: which give +facets:taxonomy:DayOfYear # freq=1963428 freq=116375
+OrHighMedDayTaxoFacets: 2010 support +facets:taxonomy:DayOfYear # freq=950573 freq=236989
+OrHighMedDayTaxoFacets: 4 very +facets:taxonomy:DayOfYear # freq=986452 freq=354898
+OrHighMedDayTaxoFacets: 2 foreign +facets:taxonomy:DayOfYear # freq=1549245 freq=109174
+OrHighMedDayTaxoFacets: were 59 +facets:taxonomy:DayOfYear # freq=1524630 freq=93856
+OrHighMedDayTaxoFacets: 2010 take +facets:taxonomy:DayOfYear # freq=950573 freq=224260
+OrHighMedDayTaxoFacets: by york +facets:taxonomy:DayOfYear # freq=3826691 freq=521383
+OrHighMedDayTaxoFacets: http kingdom +facets:taxonomy:DayOfYear # freq=3493581 freq=299825
+OrHighMedDayTaxoFacets: only brother +facets:taxonomy:DayOfYear # freq=875561 freq=110146
+OrHighMedDayTaxoFacets: no died +facets:taxonomy:DayOfYear # freq=1045000 freq=202125
+OrHighMedDayTaxoFacets: other november +facets:taxonomy:DayOfYear # freq=1269961 freq=527131
+OrHighMedDayTaxoFacets: 2008 system +facets:taxonomy:DayOfYear # freq=831253 freq=412862
+OrHighMedDayTaxoFacets: 5 still +facets:taxonomy:DayOfYear # freq=891361 freq=332543
+OrHighMedDayTaxoFacets: by required +facets:taxonomy:DayOfYear # freq=3826691 freq=100578
+OrHighMedDayTaxoFacets: title era +facets:taxonomy:DayOfYear # freq=2397378 freq=95989
+OrHighMedDayTaxoFacets: 3 larger +facets:taxonomy:DayOfYear # freq=1148799 freq=87424
+OrHighMedDayTaxoFacets: into within +facets:taxonomy:DayOfYear # freq=888684 freq=291049
+OrHighMedDayTaxoFacets: http where +facets:taxonomy:DayOfYear # freq=3493581 freq=630647
+OrHighMedDayTaxoFacets: united say +facets:taxonomy:DayOfYear # freq=1196944 freq=110895
+OrHighMedDayTaxoFacets: no second +facets:taxonomy:DayOfYear # freq=1045000 freq=505575
+OrHighMedDayTaxoFacets: work 1998 +facets:taxonomy:DayOfYear # freq=853422 freq=300506
+OrHighMedDayTaxoFacets: 1 think +facets:taxonomy:DayOfYear # freq=1641090 freq=129332
+OrHighMedDayTaxoFacets: by b +facets:taxonomy:DayOfYear # freq=3826691 freq=369454
+OrHighMedDayTaxoFacets: 4 thumb +facets:taxonomy:DayOfYear # freq=986452 freq=672667
+OrHighMedDayTaxoFacets: be usa +facets:taxonomy:DayOfYear # freq=2051702 freq=191220
+OrHighMedDayTaxoFacets: not african +facets:taxonomy:DayOfYear # freq=1713264 freq=128682
+OrHighMedDayTaxoFacets: 1 president +facets:taxonomy:DayOfYear # freq=1641090 freq=263341
+OrHighMedDayTaxoFacets: 4 worked +facets:taxonomy:DayOfYear # freq=986452 freq=119896
+OrHighMedDayTaxoFacets: http added +facets:taxonomy:DayOfYear # freq=3493581 freq=138409
+OrHighMedDayTaxoFacets: s deletion +facets:taxonomy:DayOfYear # freq=1581243 freq=166633
+OrHighMedDayTaxoFacets: time nbsp +facets:taxonomy:DayOfYear # freq=1032071 freq=506054
+OrHighMedDayTaxoFacets: when 02 +facets:taxonomy:DayOfYear # freq=1027487 freq=319783
+OrHighMedDayTaxoFacets: may la +facets:taxonomy:DayOfYear # freq=1071932 freq=232610
+OrHighMedDayTaxoFacets: 2 royal +facets:taxonomy:DayOfYear # freq=1549245 freq=211710
+OrHighMedDayTaxoFacets: from office +facets:taxonomy:DayOfYear # freq=3224339 freq=225338
+OrHighMedDayTaxoFacets: and 22 +facets:taxonomy:DayOfYear # freq=7318061 freq=502778
+OrHighMedDayTaxoFacets: cite order +facets:taxonomy:DayOfYear # freq=1741194 freq=360915
+OrHighMedDayTaxoFacets: of upper +facets:taxonomy:DayOfYear # freq=8184358 freq=86379
+OrHighMedDayTaxoFacets: all htm +facets:taxonomy:DayOfYear # freq=1203572 freq=191479
+OrHighMedDayTaxoFacets: he towards +facets:taxonomy:DayOfYear # freq=1659434 freq=95574
+OrHighMedDayTaxoFacets: are traditional +facets:taxonomy:DayOfYear # freq=1877802 freq=110425
+OrHighMedDayTaxoFacets: a team +facets:taxonomy:DayOfYear # freq=6560531 freq=379028
+OrHighMedDayTaxoFacets: or imagesize +facets:taxonomy:DayOfYear # freq=1858841 freq=82746
+OrHighMedDayTaxoFacets: date regular +facets:taxonomy:DayOfYear # freq=2020626 freq=93809
+OrHighMedDayTaxoFacets: or birth_date +facets:taxonomy:DayOfYear # freq=1858841 freq=122665
+OrHighMedDayTaxoFacets: name each +facets:taxonomy:DayOfYear # freq=2827713 freq=354583
+OrHighMedDayTaxoFacets: but begin +facets:taxonomy:DayOfYear # freq=1456553 freq=104303
+OrHighMedDayTaxoFacets: 2 developed +facets:taxonomy:DayOfYear # freq=1549245 freq=151220
+OrHighMedDayTaxoFacets: ref note +facets:taxonomy:DayOfYear # freq=3793973 freq=194472
+OrHighMedDayTaxoFacets: united programs +facets:taxonomy:DayOfYear # freq=1196944 freq=83974

--- a/tasks/wikimedium.1M.nostopwords.tasks
+++ b/tasks/wikimedium.1M.nostopwords.tasks
@@ -11263,14 +11263,14 @@ Respell: 25000
 Fuzzy1: marne~1
 Fuzzy2: marne~2
 Respell: marne
-BrowseDateTaxoFacets: *:* +facets:Date.taxonomy
-BrowseMonthTaxoFacets: *:* +facets:Month.taxonomy
-BrowseDayOfYearTaxoFacets: *:* +facets:DayOfYear.taxonomy
-BrowseDateSSDVFacets: *:* +facets:Date.sortedset
-BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
-BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
-BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
-BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
+BrowseDateTaxoFacets: *:* +facets:taxonomy:Date
+BrowseMonthTaxoFacets: *:* +facets:taxonomy:Month
+BrowseDayOfYearTaxoFacets: *:* +facets:taxonomy:DayOfYear
+BrowseDateSSDVFacets: *:* +facets:sortedset:Date
+BrowseMonthSSDVFacets: *:* +facets:sortedset:Month
+BrowseDayOfYearSSDVFacets: *:* +facets:sortedset:DayOfYear
+BrowseRandomLabelSSDVFacets: *:* +facets:sortedset:RandomLabel
+BrowseRandomLabelTaxoFacets: *:* +facets:taxonomy:RandomLabel
 range:dayOfYear:0-50,50-100,100-150,150-200,200-250,250-300,300-350,350-400
 range:dayOfYear:0-100,50-150,100-200,150-250,200-300,250-350,300-400
 range:dayOfYear:0-10,10-20,20-30,30-40,40-50,50-60,60-70,70-80,80-90,90-100,100-110,110-120,120-130,130-140,140-150,150-160,160-170,170-180,180-190,190-200,200-210,210-220,220-230,230-240,240-250,250-260,260-270,270-280,280-290,290-300,300-310,310-320,320-330,330-340,340-350,350-360,360-370,370-380,380-390

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -86,27 +86,27 @@ Term: nbsp # freq=492778
 Term: part # freq=588644
 Term: st # freq=306811
 
-BrowseDateTaxoFacets: *:* +facets:Date.taxonomy
+BrowseDateTaxoFacets: *:* +facets:taxonomy:Date
 
-BrowseMonthTaxoFacets: *:* +facets:Month.taxonomy
+BrowseMonthTaxoFacets: *:* +facets:taxonomy:Month
 
-BrowseDayOfYearTaxoFacets: *:* +facets:DayOfYear.taxonomy
+BrowseDayOfYearTaxoFacets: *:* +facets:taxonomy:DayOfYear
 
-BrowseDateSSDVFacets: *:* +facets:Date.sortedset
+BrowseDateSSDVFacets: *:* +facets:sortedset:Date
 
-BrowseMonthSSDVFacets: *:* +facets:Month.sortedset
+BrowseMonthSSDVFacets: *:* +facets:sortedset:Month
 
-BrowseDayOfYearSSDVFacets: *:* +facets:DayOfYear.sortedset
+BrowseDayOfYearSSDVFacets: *:* +facets:sortedset:DayOfYear
 
-BrowseRandomLabelTaxoFacets: *:* +facets:RandomLabel.taxonomy
+BrowseRandomLabelTaxoFacets: *:* +facets:taxonomy:RandomLabel
 
-BrowseRandomLabelSSDVFacets: *:* +facets:RandomLabel.sortedset
+BrowseRandomLabelSSDVFacets: *:* +facets:sortedset:RandomLabel
 
-TermDateFacets: 0 +facets:Date.taxonomy # freq=708472
-TermDateFacets: names +facets:Date.taxonomy # freq=402762
-TermDateFacets: nbsp +facets:Date.taxonomy # freq=492778
-TermDateFacets: part +facets:Date.taxonomy # freq=588644
-TermDateFacets: st +facets:Date.taxonomy # freq=306811
+TermDateFacets: 0 +facets:taxonomy:Date # freq=708472
+TermDateFacets: names +facets:taxonomy:Date # freq=402762
+TermDateFacets: nbsp +facets:taxonomy:Date # freq=492778
+TermDateFacets: part +facets:taxonomy:Date # freq=588644
+TermDateFacets: st +facets:taxonomy:Date # freq=306811
 
 TermDateTimeSort: lastmodndvsort//0 # freq=708472
 TermDateTimeSort: lastmodndvsort//names # freq=402762
@@ -222,29 +222,29 @@ PostFilteredVectorSearch: vector//many foundation +filter=5%
 PostFilteredVectorSearch: vector//this school +filter=5%
 PostFilteredVectorSearch: vector//such 2007 +filter=5%
 
-OrHighMedDayTaxoFacets: 4 steve +facets:DayOfYear.taxonomy # freq=986452 freq=84364
-OrHighMedDayTaxoFacets: some groups +facets:DayOfYear.taxonomy # freq=839919 freq=146670
-OrHighMedDayTaxoFacets: a named +facets:DayOfYear.taxonomy # freq=6560531 freq=310150
-OrHighMedDayTaxoFacets: not opening +facets:DayOfYear.taxonomy # freq=1713264 freq=84576
-OrHighMedDayTaxoFacets: which pre +facets:DayOfYear.taxonomy # freq=1963428 freq=90549
+OrHighMedDayTaxoFacets: 4 steve +facets:taxonomy:DayOfYear # freq=986452 freq=84364
+OrHighMedDayTaxoFacets: some groups +facets:taxonomy:DayOfYear # freq=839919 freq=146670
+OrHighMedDayTaxoFacets: a named +facets:taxonomy:DayOfYear # freq=6560531 freq=310150
+OrHighMedDayTaxoFacets: not opening +facets:taxonomy:DayOfYear # freq=1713264 freq=84576
+OrHighMedDayTaxoFacets: which pre +facets:taxonomy:DayOfYear # freq=1963428 freq=90549
 
-AndHighMedDayTaxoFacets: +web +available +facets:DayOfYear.taxonomy # freq=1118334 freq=175514
-AndHighMedDayTaxoFacets: +other +christian +facets:DayOfYear.taxonomy # freq=1269961 freq=140312
-AndHighMedDayTaxoFacets: +into +70 +facets:DayOfYear.taxonomy # freq=888684 freq=90305
-AndHighMedDayTaxoFacets: +at +space +facets:DayOfYear.taxonomy # freq=2857534 freq=163436
-AndHighMedDayTaxoFacets: +for +few +facets:DayOfYear.taxonomy # freq=4380011 freq=226422
+AndHighMedDayTaxoFacets: +web +available +facets:taxonomy:DayOfYear # freq=1118334 freq=175514
+AndHighMedDayTaxoFacets: +other +christian +facets:taxonomy:DayOfYear # freq=1269961 freq=140312
+AndHighMedDayTaxoFacets: +into +70 +facets:taxonomy:DayOfYear # freq=888684 freq=90305
+AndHighMedDayTaxoFacets: +at +space +facets:taxonomy:DayOfYear # freq=2857534 freq=163436
+AndHighMedDayTaxoFacets: +for +few +facets:taxonomy:DayOfYear # freq=4380011 freq=226422
 
-AndHighHighDayTaxoFacets: +a +work +facets:DayOfYear.taxonomy # freq=6560531 freq=853422
-AndHighHighDayTaxoFacets: +and +2 +facets:DayOfYear.taxonomy # freq=7318061 freq=1549245
-AndHighHighDayTaxoFacets: +in +2011 +facets:DayOfYear.taxonomy # freq=7320987 freq=871410
-AndHighHighDayTaxoFacets: +was +also +facets:DayOfYear.taxonomy # freq=3763623 freq=1959419
-AndHighHighDayTaxoFacets: +to +an +facets:DayOfYear.taxonomy # freq=6155577 freq=2628056
+AndHighHighDayTaxoFacets: +a +work +facets:taxonomy:DayOfYear # freq=6560531 freq=853422
+AndHighHighDayTaxoFacets: +and +2 +facets:taxonomy:DayOfYear # freq=7318061 freq=1549245
+AndHighHighDayTaxoFacets: +in +2011 +facets:taxonomy:DayOfYear # freq=7320987 freq=871410
+AndHighHighDayTaxoFacets: +was +also +facets:taxonomy:DayOfYear # freq=3763623 freq=1959419
+AndHighHighDayTaxoFacets: +to +an +facets:taxonomy:DayOfYear # freq=6155577 freq=2628056
 
-MedTermDayTaxoFacets: result +facets:DayOfYear.taxonomy # freq=276803
-MedTermDayTaxoFacets: college +facets:DayOfYear.taxonomy # freq=278094
-MedTermDayTaxoFacets: site +facets:DayOfYear.taxonomy # freq=277788
-MedTermDayTaxoFacets: man +facets:DayOfYear.taxonomy # freq=278112
-MedTermDayTaxoFacets: football +facets:DayOfYear.taxonomy # freq=277738
+MedTermDayTaxoFacets: result +facets:taxonomy:DayOfYear # freq=276803
+MedTermDayTaxoFacets: college +facets:taxonomy:DayOfYear # freq=278094
+MedTermDayTaxoFacets: site +facets:taxonomy:DayOfYear # freq=277788
+MedTermDayTaxoFacets: man +facets:taxonomy:DayOfYear # freq=278112
+MedTermDayTaxoFacets: football +facets:taxonomy:DayOfYear # freq=277738
 
 # CombinedFieldQuery: does BM25F across the title and body fields, with a boost
 # of 8 on the title field


### PR DESCRIPTION
TaskParser now uses a single `+facets:TYPE:SPEC[:mode]` prefix for all facet types (taxonomy, sortedset, range), replacing the old `+facets:DIM.TYPE` format. TYPE and SPEC are colon-delimited; the optional mode suffix (:during or :post) overrides testContext.

SearchTask handles the new range type in both DURING_COLLECTION (via RangeFacetBuilderFactory.forLongRanges/forDoubleRanges) and POST_COLLECTION (via LongRangeFacetCounts/DoubleRangeFacetCounts) paths. Range spec format: long|field|min-max,... or double|field|...

All existing task files are migrated to the new syntax. New range task categories added to wikimedium.10M.facets.tasks:

  BrowseLastModRangeFacets
  BrowseLastModOvlpRangeFacets
  BrowseIDRangeFacets
  BrowseIDOvlpRangeFacets
  MedTermLastModRangeFacets
  MedTermLastModOvlpRangeFacets
  MedTermIDRangeFacets
  MedTermIDOvlpRangeFacets

These cover all four range leaf cutter paths in the sandbox facet framework: single/multi-value x overlapping/non-overlapping.