### PR TITLE
knnPerfTest: Record merge time in addition to indexing and force merge times

### DIFF
--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -186,6 +186,7 @@ public class KnnGraphTester implements FormatterLogger {
   private boolean reindex;
   private boolean forceMerge;
   private int reindexTimeMsec;
+  private int mergeTimeMsec;
   private double forceMergeTimeSec;
   private int indexNumSegments;
   private double indexSizeOnDiskMB;
@@ -670,7 +671,7 @@ public class KnnGraphTester implements FormatterLogger {
         indexTimeFilter = null;
       }
 
-      reindexTimeMsec = new KnnIndexer(
+      KnnIndexer.IndexResult indexResult = new KnnIndexer(
         docVectorsPath,
         indexPath,
         getCodec(maxConn, beamWidth, exec, numMergeWorker, quantize, quantizeBits, indexType, rerank, rerankQuantizeBits),
@@ -687,10 +688,14 @@ public class KnnGraphTester implements FormatterLogger {
         indexTimeFilter,
         rerank
       ).createIndex();
+      reindexTimeMsec = indexResult.indexTimeMsec();
+      mergeTimeMsec = indexResult.mergeTimeMsec();
       Files.writeString(indexKeyPath, indexKey);
-      log("reindex takes %.2f sec\n", msToSec(reindexTimeMsec));
+      log("reindex takes %.2f sec (plus %.2f sec waiting for merges)\n", msToSec(reindexTimeMsec), msToSec(mergeTimeMsec));
       // save indexing time so future runs that re-use this index remember:
       Files.writeString(indexTimePath(indexPath), String.valueOf(reindexTimeMsec));
+      // save merge time so future runs that re-use this index remember:
+      Files.writeString(mergeTimePath(indexPath), String.valueOf(mergeTimeMsec));
       segmentCount = -1;
     } else {
       // paranoia: let's sanity check:
@@ -718,8 +723,25 @@ public class KnnGraphTester implements FormatterLogger {
       } else {
         reindexTimeMsec = -1;
       }
+
+      String ms;
+      Path mergePath = mergeTimePath(indexPath);
+      try {
+        ms = Files.readString(mergePath);
+      } catch (NoSuchFileException nsfe) {
+        // ok -- back compat: old index that didn't write merge time
+        log("WARNING: index did not record merge time msec in %s\n", mergePath);
+        ms = null;
+      }
+      if (ms != null) {
+        log("retrieving previously saved merge time in %s\n", mergePath);
+        mergeTimeMsec = Integer.parseInt(ms);
+        log("read previously saved merge time: %d msec\n", mergeTimeMsec);
+      } else {
+        mergeTimeMsec = -1;
+      }
     }
-    
+
     if (forceMerge) {
       if (segmentCount == 1) {
         log("skip force-merge: index already has 1 segment\n");
@@ -798,6 +820,11 @@ public class KnnGraphTester implements FormatterLogger {
   // we save indexing elapsed time sec to this file inside the index
   private static Path indexTimePath(Path indexPath) {
     return indexPath.resolve("index-time-msec.txt");
+  }
+
+  // we save merge elapsed time msec (time spent waiting for merges during indexing) to this file inside the index
+  private static Path mergeTimePath(Path indexPath) {
+    return indexPath.resolve("merge-time-msec.txt");
   }
 
   private void printIndexStatistics(Path indexPath, String field) throws IOException {
@@ -1334,9 +1361,10 @@ public class KnnGraphTester implements FormatterLogger {
       }
       String rerankDesc = rerank ? Integer.toString(rerankQuantizeBits) + " bits" : "no";
       double reindexSec = reindexTimeMsec / 1000.0;
+      double mergeSec = mergeTimeMsec / 1000.0;
       System.out.printf(
           Locale.ROOT,
-          "SUMMARY: %5.3f\t%5.3f\t%5.3f\t%5.3f\t%d\t%s\t%s\t%s\t%s\t%s\t%.3f\t%d\t%d\t%s\t%d\t%.2f\t%.2f\t%.2f\t%d\t%.2f\t%s\t%s\t%5.3f\t%5.3f\t%5.3f\t%s\t%s\t%s\n",
+          "SUMMARY: %5.3f\t%5.3f\t%5.3f\t%5.3f\t%d\t%s\t%s\t%s\t%s\t%s\t%.3f\t%d\t%d\t%s\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%d\t%.2f\t%s\t%s\t%5.3f\t%5.3f\t%5.3f\t%s\t%s\t%s\n",
           recall,
           elapsedMS / (float) numQueryVectors,
           totalCpuTimeMS / (float) numQueryVectors,
@@ -1354,6 +1382,7 @@ public class KnnGraphTester implements FormatterLogger {
           totalVisited / numQueryVectors,
           reindexSec,
           numDocs / reindexSec,
+          mergeSec,
           forceMergeTimeSec,
           indexNumSegments,
           indexSizeOnDiskMB,

--- a/src/main/knn/KnnIndexer.java
+++ b/src/main/knn/KnnIndexer.java
@@ -108,7 +108,11 @@ public class KnnIndexer implements FormatterLogger {
     this.ttmp = new TrackingTieredMergePolicy();
   }
 
-  public int createIndex() throws IOException, InterruptedException {
+  // result of indexing: time spent indexing (excluding merges) and time spent waiting for merges,
+  // both in milliseconds
+  public record IndexResult(int indexTimeMsec, int mergeTimeMsec) {}
+
+  public IndexResult createIndex() throws IOException, InterruptedException {
     IndexWriterConfig iwc = new IndexWriterConfig().setOpenMode(IndexWriterConfig.OpenMode.CREATE);
     iwc.setCodec(codec);
     iwc.setMergeScheduler(tcms);
@@ -152,7 +156,7 @@ public class KnnIndexer implements FormatterLogger {
       indexPath.toFile().mkdirs();
     }
 
-    long startNS = System.nanoTime(), elapsedNS;
+    long startNS = System.nanoTime(), elapsedNS, mergeNS;
     try (FSDirectory dir = FSDirectory.open(indexPath);
          IndexWriter iw = new IndexWriter(dir, iwc);
          FileChannel in = FileChannel.open(docsPath)) {
@@ -266,10 +270,17 @@ public class KnnIndexer implements FormatterLogger {
 
       elapsedNS = System.nanoTime() - startNS;
 
+      // merge time is intentionally excluded from the indexing time reported above, but we still
+      // track it explicitly here so it is not silently dropped (otherwise both index(s) and the
+      // later force_merge(s) become noisy depending on how much merge work happened in this phase)
+      long mergeStartNS = System.nanoTime();
       waitForMergesWithStatus(ttmp, tcms, this);
+      mergeNS = System.nanoTime() - mergeStartNS;
     }
-    log("Indexed %d docs in %d seconds\n", numDocs, TimeUnit.NANOSECONDS.toSeconds(elapsedNS));
-    return (int) TimeUnit.NANOSECONDS.toMillis(elapsedNS);
+    log("Indexed %d docs in %d seconds (plus %d seconds waiting for merges)\n",
+        numDocs, TimeUnit.NANOSECONDS.toSeconds(elapsedNS), TimeUnit.NANOSECONDS.toSeconds(mergeNS));
+    return new IndexResult((int) TimeUnit.NANOSECONDS.toMillis(elapsedNS),
+                           (int) TimeUnit.NANOSECONDS.toMillis(mergeNS));
   }
 
   public static void waitForMergesWithStatus(TrackingTieredMergePolicy ttmp, TrackingConcurrentMergeScheduler tcms, FormatterLogger log) throws InterruptedException {

--- a/src/python/knnPerfTest.py
+++ b/src/python/knnPerfTest.py
@@ -269,6 +269,7 @@ OUTPUT_HEADERS = [
   "visited",
   "index(s)",
   "index_docs/s",
+  "merge(s)",
   "force_merge(s)",
   "num_segments",
   "index_size(MB)",

--- a/src/python/knnVarianceTest.py
+++ b/src/python/knnVarianceTest.py
@@ -303,6 +303,7 @@ _HISTOGRAM_FIELDS = [
   "avgCpuCount",
   "visited",
   "index(s)",
+  "merge(s)",
   "force_merge(s)",
   "index_size(MB)",
 ]

--- a/src/python/runNightlyKnn.py
+++ b/src/python/runNightlyKnn.py
@@ -142,6 +142,41 @@ KNNResultV1 = namedtuple(
   ],
 )
 
+KNNResultV2 = namedtuple(
+  "KNNResultV2",
+  [
+    "lucene_git_rev",
+    "luceneutil_git_rev",
+    "index_vectors_file",
+    "search_vectors_file",
+    "vector_dims",
+    "do_force_merge",
+    "recall",
+    "cpu_time_ms",
+    "net_cpu_ms",
+    "avg_cpu_core_count",
+    "num_docs",
+    "top_k",
+    "fanout",
+    "max_conn",
+    "beam_width",
+    "quantize_desc",
+    "total_visited",
+    "index_time_sec",
+    "index_docs_per_sec",
+    "merge_time_sec",
+    "force_merge_time_sec",
+    "index_num_segments",
+    "index_size_on_disk_mb",
+    "selectivity",
+    "pre_post_filter",
+    "vec_disk_mb",
+    "vec_ram_mb",
+    "graph_level_conn_p_values",
+    "combined_run_time",
+  ],
+)
+
 
 CHANGES = [
   ("2016-07-04 07:13:41", "LUCENE-7351: Doc id compression for dimensional points"),
@@ -223,6 +258,20 @@ def convert_v0_to_v1(v0_result):
   return KNNResultV1(*fields)
 
 
+def convert_v1_to_v2(v1_result):
+  """Convert a KNNResultV1 result to KNNResultV2 format."""
+  # Extract all fields from v1
+  fields = list(v1_result)
+
+  assert len(fields) == 28, f"got {len(fields)}"
+
+  # merge_time_sec added just before force_merge_time_sec
+  force_merge_index = 19  # index of force_merge_time_sec in KNNResultV1
+  fields.insert(force_merge_index, -1.0)  # merge_time_sec placeholder for old results
+
+  return KNNResultV2(*fields)
+
+
 def main():
   if "-write_graph" in sys.argv:
     write_graph()
@@ -253,6 +302,8 @@ def write_graph():
       # Unpickle does something weird... type(run) is runNightlyKnn.KNNResultV0 but KNNResultV0 is __main_)_.KNResultV0
       if str(type(run)).endswith(".KNNResultV0'>"):
         run = convert_v0_to_v1(run)
+      if str(type(run)).endswith(".KNNResultV1'>"):
+        run = convert_v1_to_v2(run)
 
       if lucene_git_rev is None:
         lucene_git_rev = run.lucene_git_rev
@@ -274,6 +325,7 @@ def write_graph():
       add(series, f"{desc} RAM", run.vec_ram_mb)
       add(series, f"{desc} disk", run.vec_disk_mb)
       add(series, f"{desc} index-time-sec", run.index_time_sec)
+      add(series, f"{desc} merge-time-sec", run.merge_time_sec)
       add(series, f"{desc} force-merge-time-sec", run.force_merge_time_sec)
       add(series, f"{desc} index K docs/sec", run.index_docs_per_sec / 1000.0)
       add(series, f"{desc} vec_ram_gb", run.vec_ram_mb / 1024.0)
@@ -445,6 +497,16 @@ This benchmark indexes 8.0M and searches Cohere 768 dimension vectors from https
       (series["no.force_merge force-merge-time-sec"], series["7 bits.force_merge force-merge-time-sec"], series["4 bits.force_merge force-merge-time-sec"]),
       "force_merge_time_sec",
       "Force Merge time (sec)",
+      headers=("Date", "float32", "7 bits", "4 bits"),
+      ylabel="sec",
+    )
+
+    write_one_graph(
+      f,
+      timestamps,
+      (series["no merge-time-sec"], series["7 bits merge-time-sec"], series["4 bits merge-time-sec"]),
+      "merge_time_sec",
+      "Merge time during indexing (sec)",
       headers=("Date", "float32", "7 bits", "4 bits"),
       ylabel="sec",
     )
@@ -806,14 +868,14 @@ def _run(results_dir):
 
       cols = summary.split("\t")
 
-      assert len(cols) >= 27
+      assert len(cols) >= 28
 
-      if cols[21] == "N/A":
+      if cols[22] == "N/A":
         selectivity = None
       else:
-        selectivity = float(cols[21])
+        selectivity = float(cols[22])
 
-      result = KNNResultV1(
+      result = KNNResultV2(
         lucene_git_rev,
         luceneutil_git_rev,
         INDEX_VECTORS_FILE,
@@ -833,13 +895,14 @@ def _run(results_dir):
         int(cols[14]),  # total_visited
         float(cols[15]),  # index_time_sec
         float(cols[16]),  # index_docs_per_sec
-        float(cols[17]),  # force_merge_time_sec
-        int(cols[18]),  # index_num_segments
-        float(cols[19]),  # index_size_on_disk_mb
-        selectivity,  # selectivity (cols[21])
-        cols[20],  # filter-strategy
-        float(cols[23]),  # vec_disk_mb
-        float(cols[24]),  # vec_ram_mb
+        float(cols[17]),  # merge_time_sec
+        float(cols[18]),  # force_merge_time_sec
+        int(cols[19]),  # index_num_segments
+        float(cols[20]),  # index_size_on_disk_mb
+        selectivity,  # selectivity (cols[22])
+        cols[21],  # filter-strategy
+        float(cols[24]),  # vec_disk_mb
+        float(cols[25]),  # vec_ram_mb
         graph_level_conn_p_values,  # graph_level_conn_p_values
         combined_run_time,  # time to run KnnGraphTester
       )


### PR DESCRIPTION
### Description

Follow-up to #445 

`knnPerfTest.py` records indexing (1) and force merge (2) times, but not the time spent waiting for merges after indexing (between 1 and 2).

While merges are noisy in general -- it becomes tricky to compare force merge times across runs, depending on how much untracked work is done during normal merge.

This PR simply records `merge(s)` as a separate column in addition to `index(s)` and `force_merge(s)`.

This change was mostly AI, but looks pretty reasonable.