### PR TITLE
Fix KNN warmup allocating numDocs-sized collector per query

### DIFF
--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -1237,6 +1237,13 @@ public class KnnGraphTester implements FormatterLogger {
 
           // TODO: Replace with more sophisticated result collection in https://github.com/mikemccand/luceneutil/issues/545
           int[] resultSizes = new int[numQueryVectors];
+          
+          // For KNN, narrow results to topK (oversample/fanout only widen the graph search).
+          // For RADIUS, the result count is unbounded so we need the full index capacity.
+          int maxResultSize = switch (searchType) {
+            case KNN -> this.topK;
+            case RADIUS -> indexNumDocs;
+          };
 
           // warm up (and optionally collect HNSW traversal scores)
           if (hnswScoreHistogram && vectorEncoding.equals(VectorEncoding.FLOAT32)) {
@@ -1247,10 +1254,10 @@ public class KnnGraphTester implements FormatterLogger {
               final Result result;
               if (vectorEncoding.equals(VectorEncoding.BYTE)) {
                 byte[] target = targetReaderByte.nextBytes();
-                result = doByteVectorQuery(searcher, target, searchType, oversampledTopK, oversampledFanout, resultSimilarity, decay, filterStrategy, filterQuery, oversampledTopK);
+                result = doByteVectorQuery(searcher, target, searchType, oversampledTopK, oversampledFanout, resultSimilarity, decay, filterStrategy, filterQuery, maxResultSize);
               } else {
                 float[] target = targetReader.next();
-                result = doFloatVectorQuery(searcher, target, searchType, oversampledTopK, oversampledFanout, resultSimilarity, decay, filterStrategy, filterQuery, parentJoin, searcher.getIndexReader().numDocs(), rerank, rerankQuantizeBits, this.topK);
+                result = doFloatVectorQuery(searcher, target, searchType, oversampledTopK, oversampledFanout, resultSimilarity, decay, filterStrategy, filterQuery, parentJoin, maxResultSize, rerank, rerankQuantizeBits, this.topK);
               }
               resultSizes[i] = Math.max(1, result.topDocs.scoreDocs.length);
             }


### PR DESCRIPTION
The KNN warmup loop passes `resultSize` to `searcher.search(query, resultSize)`, which sizes the internal `TopScoreDocCollector` (backed by a `HitQueue` priority queue). The float path passed `searcher.getIndexReader().numDocs()` and the byte path passed `oversampledTopK`.

For KNN search the query itself only ever returns `k + fanout` candidates (bounded by the HNSW graph search), so the collector capacity doesn't affect what's returned — but it does allocate the priority queue up front. With `numDocs = 7,845,343`, that's a ~156 MB `HitQueue` instantiated per query, adding ~36 ms/query of allocation + GC overhead.

The measured pass already uses `resultSizes[i]` (the actual count observed during warmup), which equals `k + fanout` ≈ 32–72 — so the measured pass never had this problem.

**Fix:** Set warmup `resultSize = topK` for KNN (RADIUS retains `indexNumDocs` since its result count is genuinely unbounded). The collector now keeps only the top `topK` by score from the `k + fanout` candidates returned by the graph search.

**Impact:**
- Warmup time at niter=100,000 with numDocs=7.8M: **~60 min → ~80 sec** (48× improvement)
- Measured search latency: unchanged (was never affected)
- Recall: unchanged (result IDs were already trimmed to `topK` before recall computation at line 1291)

**Before/after (niter=100k, d=4096, topK=32, numDocs=7,845,343):**

| | warmup ms/q | measured ms/q | total wall-clock |
|---|---|---|---|
| Before | 36 | 0.65 | ~78 min |
| After | 1.2 | 0.65 | ~15 min |

**Note:** The byte warmup path previously used `oversampledTopK` as its collector size. While not as extreme as `numDocs`, this was still an unnecessary over-allocation (e.g., 64 vs 32 entries). Now unified with the float path at `topK`.