### PR TITLE
Add doc values range filtering benchmark tasks

### DIFF
--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -38,6 +38,8 @@ import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.KeywordField;
 import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.facet.DrillDownQuery;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.intervals.IntervalQuery;
@@ -162,6 +164,7 @@ class TaskParser implements Closeable {
   // pattern: taskName term1 term2 term3 term4 +combinedFields=field1^1.0,field2,field3^2.0
   // this pattern doesn't handle all variations of floating numbers, such as .9 , but should be good enough for perf test query parsing purpose
   private final static Pattern combinedFieldsPattern = Pattern.compile(" \\+combinedFields=((\\p{Alnum}+(\\^\\d+.\\d)?,)+\\p{Alnum}+(\\^\\d+.\\d)?)");
+  private final static Pattern dvRangeFilterPattern = Pattern.compile(" \\+dvRangeFilter=([\\w]+),(-?[0-9]+),(-?[0-9]+)");
 
   /**
    * First pass, parsing from String to some task, may/may not be an UnparsedTask
@@ -265,6 +268,15 @@ class TaskParser implements Closeable {
     SearchTask buildSearchTask(String input) throws ParseException, IOException {
       text = input;
       Query filter = parseFilter();
+      Query dvRangeFilter = parseDVRangeFilter();
+      if (filter != null && dvRangeFilter != null) {
+        filter = new BooleanQuery.Builder()
+          .add(filter, Occur.FILTER)
+          .add(dvRangeFilter, Occur.FILTER)
+          .build();
+      } else if (dvRangeFilter != null) {
+        filter = dvRangeFilter;
+      }
       boolean isCountOnly = parseIsCountOnly();
       facets = parseFacets();
       List<String> drillDowns = parseDrillDowns();
@@ -340,6 +352,19 @@ class TaskParser implements Closeable {
         // Splice out the filter string:
         text = (text.substring(0, m.start(0)) + text.substring(m.end(0), text.length())).trim();
         return new RandomQuery(filterPct);
+      }
+      return null;
+    }
+
+    Query parseDVRangeFilter() {
+      // Check for doc values range filter (eg: " +dvRangeFilter=lastMod_skipper,1200000000000,1400000000000")
+      final Matcher m = dvRangeFilterPattern.matcher(text);
+      if (m.find()) {
+        final String fieldName = m.group(1);
+        final long min = Long.parseLong(m.group(2));
+        final long max = Long.parseLong(m.group(3));
+        text = (text.substring(0, m.start(0)) + text.substring(m.end(0), text.length())).trim();
+        return NumericDocValuesField.newSlowRangeQuery(fieldName, min, max);
       }
       return null;
     }
@@ -579,6 +604,10 @@ class TaskParser implements Closeable {
           return parseDisjunctionMax();
         case "nrq":
           return parseNRQ();
+        case "dvrange":
+          return parseDVRange();
+        case "dvrangeint":
+          return parseDVRangeInt();
         case "intSet":
           return parseIntSet();
         case "datetimesort":
@@ -729,6 +758,38 @@ class TaskParser implements Closeable {
       final int start = Integer.parseInt(text.substring(1+spot3, spot4));
       final int end = Integer.parseInt(text.substring(1+spot4));
       return IntPoint.newRangeQuery(nrqFieldName, start, end);
+    }
+
+    Query parseDVRange() {
+      // field min max (long values, uses NumericDocValuesField skip index)
+      final int spot3 = text.indexOf(' ');
+      if (spot3 == -1) {
+        throw new RuntimeException("failed to parse dvrange query=" + text);
+      }
+      final int spot4 = text.indexOf(' ', spot3+1);
+      if (spot4 == -1) {
+        throw new RuntimeException("failed to parse dvrange query=" + text);
+      }
+      final String dvFieldName = text.substring(0, spot3);
+      final long min = Long.parseLong(text.substring(1+spot3, spot4));
+      final long max = Long.parseLong(text.substring(1+spot4));
+      return NumericDocValuesField.newSlowRangeQuery(dvFieldName, min, max);
+    }
+
+    Query parseDVRangeInt() {
+      // field min max (int values, uses SortedNumericDocValuesField)
+      final int spot3 = text.indexOf(' ');
+      if (spot3 == -1) {
+        throw new RuntimeException("failed to parse dvrangeint query=" + text);
+      }
+      final int spot4 = text.indexOf(' ', spot3+1);
+      if (spot4 == -1) {
+        throw new RuntimeException("failed to parse dvrangeint query=" + text);
+      }
+      final String dvFieldName = text.substring(0, spot3);
+      final long min = Long.parseLong(text.substring(1+spot3, spot4));
+      final long max = Long.parseLong(text.substring(1+spot4));
+      return SortedNumericDocValuesField.newSlowRangeQuery(dvFieldName, min, max);
     }
 
     Query parseIntSet() {

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -38,7 +38,6 @@ import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.KeywordField;
 import org.apache.lucene.document.LongField;
-import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.facet.DrillDownQuery;
 import org.apache.lucene.index.Term;
@@ -357,14 +356,13 @@ class TaskParser implements Closeable {
     }
 
     Query parseDVRangeFilter() {
-      // Check for doc values range filter (eg: " +dvRangeFilter=lastMod_skipper,1200000000000,1400000000000")
-      final Matcher m = dvRangeFilterPattern.matcher(text);
+      Matcher m = dvRangeFilterPattern.matcher(text);
       if (m.find()) {
-        final String fieldName = m.group(1);
-        final long min = Long.parseLong(m.group(2));
-        final long max = Long.parseLong(m.group(3));
+        String fieldName = m.group(1);
+        long min = Long.parseLong(m.group(2));
+        long max = Long.parseLong(m.group(3));
         text = (text.substring(0, m.start(0)) + text.substring(m.end(0), text.length())).trim();
-        return NumericDocValuesField.newSlowRangeQuery(fieldName, min, max);
+        return SortedNumericDocValuesField.newSlowRangeQuery(fieldName, min, max);
       }
       return null;
     }
@@ -606,8 +604,6 @@ class TaskParser implements Closeable {
           return parseNRQ();
         case "dvrange":
           return parseDVRange();
-        case "dvrangeint":
-          return parseDVRangeInt();
         case "intSet":
           return parseIntSet();
         case "datetimesort":
@@ -761,34 +757,17 @@ class TaskParser implements Closeable {
     }
 
     Query parseDVRange() {
-      // field min max (long values, uses NumericDocValuesField skip index)
-      final int spot3 = text.indexOf(' ');
+      int spot3 = text.indexOf(' ');
       if (spot3 == -1) {
         throw new RuntimeException("failed to parse dvrange query=" + text);
       }
-      final int spot4 = text.indexOf(' ', spot3+1);
+      int spot4 = text.indexOf(' ', spot3+1);
       if (spot4 == -1) {
         throw new RuntimeException("failed to parse dvrange query=" + text);
       }
-      final String dvFieldName = text.substring(0, spot3);
-      final long min = Long.parseLong(text.substring(1+spot3, spot4));
-      final long max = Long.parseLong(text.substring(1+spot4));
-      return NumericDocValuesField.newSlowRangeQuery(dvFieldName, min, max);
-    }
-
-    Query parseDVRangeInt() {
-      // field min max (int values, uses SortedNumericDocValuesField)
-      final int spot3 = text.indexOf(' ');
-      if (spot3 == -1) {
-        throw new RuntimeException("failed to parse dvrangeint query=" + text);
-      }
-      final int spot4 = text.indexOf(' ', spot3+1);
-      if (spot4 == -1) {
-        throw new RuntimeException("failed to parse dvrangeint query=" + text);
-      }
-      final String dvFieldName = text.substring(0, spot3);
-      final long min = Long.parseLong(text.substring(1+spot3, spot4));
-      final long max = Long.parseLong(text.substring(1+spot4));
+      String dvFieldName = text.substring(0, spot3);
+      long min = Long.parseLong(text.substring(1+spot3, spot4));
+      long max = Long.parseLong(text.substring(1+spot4));
       return SortedNumericDocValuesField.newSlowRangeQuery(dvFieldName, min, max);
     }
 

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -1808,6 +1808,16 @@ def writeIndexHTML(searchChartData, days, timeStampString):
   writeOneLine(w, done, "TermMonthSortSkipper", "Month (string, low cardinality, skipper)")
   writeOneLine(w, done, "TermDayOfYearSortSkipper", "Day of year (int, medium cardinality, skipper)")
 
+  w("<br><br><b>Doc values range filtering with skip index (count-only):</b>")
+  writeOneLine(w, done, "DVRangeLastModNarrow", "lastMod range narrow (~1 month, high cardinality)")
+  writeOneLine(w, done, "DVRangeLastModWide", "lastMod range wide (~4 years, high cardinality)")
+  writeOneLine(w, done, "DVRangeDayOfYearNarrow", "dayOfYear range narrow (~30 days, medium cardinality)")
+  writeOneLine(w, done, "DVRangeDayOfYearWide", "dayOfYear range wide (~6 months, medium cardinality)")
+
+  w("<br><br><b>Doc values range filter on TermQuery (skip index):</b>")
+  writeOneLine(w, done, "TermWithDVRangeLastMod", "TermQuery + lastMod DV range filter (~1 year)")
+  writeOneLine(w, done, "TermWithDVRangeDayOfYear", "TermQuery + dayOfYear DV range filter (~4 months)")
+
   w("<br><br><b>Grouping (on TermQuery):</b>")
   writeOneLine(w, done, "TermGroup100", "100 groups")
   writeOneLine(w, done, "TermGroup10K", "10K groups")

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -156,8 +156,8 @@ TermDayOfYearSortSkipper: dayofyearskippersort//nbsp # freq=492778
 TermDayOfYearSortSkipper: dayofyearskippersort//part # freq=588644
 TermDayOfYearSortSkipper: dayofyearskippersort//st # freq=306811
 
-# Doc values range queries using skip index (count-only, measuring pure DV filtering speed)
-# lastMod_skipper: epoch millis, high cardinality — narrow 1-month range
+# DV range queries with skip index (count-only)
+# lastMod_skipper: narrow 1-month range
 DVRangeLastModNarrow: count(dvrange//lastMod_skipper 1330588800000 1333263600000)
 DVRangeLastModNarrow: count(dvrange//lastMod_skipper 1293868800000 1296547200000)
 DVRangeLastModNarrow: count(dvrange//lastMod_skipper 1309478400000 1312156800000)
@@ -169,20 +169,20 @@ DVRangeLastModWide: count(dvrange//lastMod_skipper 1104566400000 1262332800000)
 DVRangeLastModWide: count(dvrange//lastMod_skipper 1136102400000 1293868800000)
 DVRangeLastModWide: count(dvrange//lastMod_skipper 1167638400000 1325404800000)
 DVRangeLastModWide: count(dvrange//lastMod_skipper 1199174400000 1356998400000)
-# dayOfYear_skipper: int 1-366, medium cardinality — narrow range (~30 days)
+# dayOfYear_skipper: narrow 30-day range
 DVRangeDayOfYearNarrow: count(dvrange//dayOfYear_skipper 60 90)
 DVRangeDayOfYearNarrow: count(dvrange//dayOfYear_skipper 150 180)
 DVRangeDayOfYearNarrow: count(dvrange//dayOfYear_skipper 200 230)
 DVRangeDayOfYearNarrow: count(dvrange//dayOfYear_skipper 300 330)
 DVRangeDayOfYearNarrow: count(dvrange//dayOfYear_skipper 1 30)
-# dayOfYear_skipper: wide range (~6 months)
+# dayOfYear_skipper: wide 6-month range
 DVRangeDayOfYearWide: count(dvrange//dayOfYear_skipper 1 183)
 DVRangeDayOfYearWide: count(dvrange//dayOfYear_skipper 100 283)
 DVRangeDayOfYearWide: count(dvrange//dayOfYear_skipper 183 366)
 DVRangeDayOfYearWide: count(dvrange//dayOfYear_skipper 50 233)
 DVRangeDayOfYearWide: count(dvrange//dayOfYear_skipper 120 303)
 
-# Doc values range as filter on TermQuery (real-world pattern: term match + date range filter)
+# DV range as filter on TermQuery
 TermWithDVRangeLastMod: 0 +dvRangeFilter=lastMod_skipper,1293868800000,1325404800000 # freq=708472
 TermWithDVRangeLastMod: names +dvRangeFilter=lastMod_skipper,1293868800000,1325404800000 # freq=402762
 TermWithDVRangeLastMod: nbsp +dvRangeFilter=lastMod_skipper,1293868800000,1325404800000 # freq=492778

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -156,6 +156,44 @@ TermDayOfYearSortSkipper: dayofyearskippersort//nbsp # freq=492778
 TermDayOfYearSortSkipper: dayofyearskippersort//part # freq=588644
 TermDayOfYearSortSkipper: dayofyearskippersort//st # freq=306811
 
+# Doc values range queries using skip index (count-only, measuring pure DV filtering speed)
+# lastMod_skipper: epoch millis, high cardinality — narrow 1-month range
+DVRangeLastModNarrow: count(dvrange//lastMod_skipper 1330588800000 1333263600000)
+DVRangeLastModNarrow: count(dvrange//lastMod_skipper 1293868800000 1296547200000)
+DVRangeLastModNarrow: count(dvrange//lastMod_skipper 1309478400000 1312156800000)
+DVRangeLastModNarrow: count(dvrange//lastMod_skipper 1317427200000 1320105600000)
+DVRangeLastModNarrow: count(dvrange//lastMod_skipper 1262332800000 1264924800000)
+# lastMod_skipper: wide 4-year range
+DVRangeLastModWide: count(dvrange//lastMod_skipper 1199174400000 1325404800000)
+DVRangeLastModWide: count(dvrange//lastMod_skipper 1104566400000 1262332800000)
+DVRangeLastModWide: count(dvrange//lastMod_skipper 1136102400000 1293868800000)
+DVRangeLastModWide: count(dvrange//lastMod_skipper 1167638400000 1325404800000)
+DVRangeLastModWide: count(dvrange//lastMod_skipper 1199174400000 1356998400000)
+# dayOfYear_skipper: int 1-366, medium cardinality — narrow range (~30 days)
+DVRangeDayOfYearNarrow: count(dvrange//dayOfYear_skipper 60 90)
+DVRangeDayOfYearNarrow: count(dvrange//dayOfYear_skipper 150 180)
+DVRangeDayOfYearNarrow: count(dvrange//dayOfYear_skipper 200 230)
+DVRangeDayOfYearNarrow: count(dvrange//dayOfYear_skipper 300 330)
+DVRangeDayOfYearNarrow: count(dvrange//dayOfYear_skipper 1 30)
+# dayOfYear_skipper: wide range (~6 months)
+DVRangeDayOfYearWide: count(dvrange//dayOfYear_skipper 1 183)
+DVRangeDayOfYearWide: count(dvrange//dayOfYear_skipper 100 283)
+DVRangeDayOfYearWide: count(dvrange//dayOfYear_skipper 183 366)
+DVRangeDayOfYearWide: count(dvrange//dayOfYear_skipper 50 233)
+DVRangeDayOfYearWide: count(dvrange//dayOfYear_skipper 120 303)
+
+# Doc values range as filter on TermQuery (real-world pattern: term match + date range filter)
+TermWithDVRangeLastMod: 0 +dvRangeFilter=lastMod_skipper,1293868800000,1325404800000 # freq=708472
+TermWithDVRangeLastMod: names +dvRangeFilter=lastMod_skipper,1293868800000,1325404800000 # freq=402762
+TermWithDVRangeLastMod: nbsp +dvRangeFilter=lastMod_skipper,1293868800000,1325404800000 # freq=492778
+TermWithDVRangeLastMod: part +dvRangeFilter=lastMod_skipper,1293868800000,1325404800000 # freq=588644
+TermWithDVRangeLastMod: st +dvRangeFilter=lastMod_skipper,1293868800000,1325404800000 # freq=306811
+TermWithDVRangeDayOfYear: 0 +dvRangeFilter=dayOfYear_skipper,60,180 # freq=708472
+TermWithDVRangeDayOfYear: names +dvRangeFilter=dayOfYear_skipper,60,180 # freq=402762
+TermWithDVRangeDayOfYear: nbsp +dvRangeFilter=dayOfYear_skipper,60,180 # freq=492778
+TermWithDVRangeDayOfYear: part +dvRangeFilter=dayOfYear_skipper,60,180 # freq=588644
+TermWithDVRangeDayOfYear: st +dvRangeFilter=dayOfYear_skipper,60,180 # freq=306811
+
 TermGroup100: group100//0 # freq=708472
 TermGroup100: group100//names # freq=402762
 TermGroup100: group100//nbsp # freq=492778


### PR DESCRIPTION
There has been a lot of interesting work going on making range filter queries faster with doc values. Ideally, range filtering works best with BKD as it can quickly filter out the irrelevant branches and give the desired docs in specific range. Also lucene has IndexOrDocValuesQuery which decides based on cost, on what path to choose.

This PR tries to add benchmarks for range filtering case by using doc values only. I feel it would be useful to track this separately considering the work that has been going in lucene around this area, and we can catch any regressions if they were introduced?

I have added single field filter queries using doc values(skip index enabled) and with different cases - narrow and wide.
Also with some real world pattern like: `find documents matching a term AND within a date range`. Tests interaction of inverted index + DV skip index.`

Related issue- https://github.com/mikemccand/luceneutil/issues/549. Though this was focussed on multi field range filter usecase, for now this PR only covers single field.


Let me know if adding this makes sense.

