### PR TITLE
Add `+searchAfter` task modifier and searchAfter benchmark coverage (#306)

### DIFF
--- a/src/main/perf/SearchTask.java
+++ b/src/main/perf/SearchTask.java
@@ -591,9 +591,9 @@ final class SearchTask extends Task {
       if (topN != otherSearchTask.topN) {
         return false;
       }
-      if (java.util.Objects.equals(
-              after == null ? null : java.util.Arrays.asList(after.fields),
-              otherSearchTask.after == null ? null : java.util.Arrays.asList(otherSearchTask.after.fields))
+      if (java.util.Objects.deepEquals(
+              after == null ? null : after.fields,
+              otherSearchTask.after == null ? null : otherSearchTask.after.fields)
           == false) {
         return false;
       }

--- a/src/main/perf/SearchTask.java
+++ b/src/main/perf/SearchTask.java
@@ -79,6 +79,8 @@ final class SearchTask extends Task {
   private final String category;
   private final Query q;
   private final Sort s;
+  // Non-null enables searchAfter (deep pagination) benchmarking; only valid when s != null.
+  private final FieldDoc after;
   private final String group;
   private final int topN;
   private final boolean singlePassGroup;
@@ -100,11 +102,14 @@ final class SearchTask extends Task {
   private List<TaskParser.TaskBuilder.FacetTask> facetRequests;
   private String vectorField;
 
-  public SearchTask(String category, boolean isCountOnly, Query q, Sort s, String group, int topN,
+  public SearchTask(String category, boolean isCountOnly, Query q, Sort s, FieldDoc after, String group, int topN,
                     boolean doHilite, boolean doStoredLoads, List<TaskParser.TaskBuilder.FacetTask> facetRequests,
                     String vectorField, boolean doDrillSideways) {
     this.category = category;
     this.isCountOnly = isCountOnly;
+    if (after != null && s == null) {
+      throw new IllegalArgumentException("searchAfter requires a sort");
+    }
     if (isCountOnly) {
       // some attempt at catching mistakes!
       if (s != null) {
@@ -125,6 +130,7 @@ final class SearchTask extends Task {
     }
     this.q = q;
     this.s = s;
+    this.after = after;
     if (group != null && group.startsWith("groupblock")) {
       this.group = "groupblock";
       this.singlePassGroup = group.equals("groupblock1pass");
@@ -145,9 +151,9 @@ final class SearchTask extends Task {
   @Override
   public Task clone() {
     if (singlePassGroup) {
-      return new SearchTask(category, isCountOnly, q, s, "groupblock1pass", topN, doHilite, doStoredLoads, facetRequests, vectorField, doDrillSideways);
+      return new SearchTask(category, isCountOnly, q, s, after, "groupblock1pass", topN, doHilite, doStoredLoads, facetRequests, vectorField, doDrillSideways);
     } else {
-      return new SearchTask(category, isCountOnly, q, s, group, topN, doHilite, doStoredLoads, facetRequests, vectorField, doDrillSideways);
+      return new SearchTask(category, isCountOnly, q, s, after, group, topN, doHilite, doStoredLoads, facetRequests, vectorField, doDrillSideways);
     }
   }
 
@@ -346,7 +352,13 @@ final class SearchTask extends Task {
         }
       } else {
         // yes sort
-        hits = searcher.search(q, topN, s);
+        if (after != null) {
+          // searchAfter (deep pagination): exercises the dynamic-pruning skip path with a known top
+          // value but no bottom until the queue fills. See GITHUB#13313 / the #13856 regression.
+          hits = searcher.searchAfter(after, q, topN, s);
+        } else {
+          hits = searcher.search(q, topN, s);
+        }
         if (doHilite) {
           hilite(hits, state, searcher, q);
         }
@@ -579,6 +591,12 @@ final class SearchTask extends Task {
       if (topN != otherSearchTask.topN) {
         return false;
       }
+      if (java.util.Objects.equals(
+              after == null ? null : java.util.Arrays.asList(after.fields),
+              otherSearchTask.after == null ? null : java.util.Arrays.asList(otherSearchTask.after.fields))
+          == false) {
+        return false;
+      }
 
       if (group != null && !group.equals(otherSearchTask.group)) {
         return false;
@@ -605,6 +623,9 @@ final class SearchTask extends Task {
     int hashCode = q.hashCode();
     if (s != null) {
       hashCode ^= s.hashCode();
+    }
+    if (after != null) {
+      hashCode ^= java.util.Arrays.hashCode(after.fields);
     }
     if (group != null) {
       hashCode ^= group.hashCode();

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -60,6 +60,7 @@ import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedSetSelector;
@@ -159,6 +160,9 @@ class TaskParser implements Closeable {
   private final static Pattern countOnlyPattern = Pattern.compile("count\\((.*?)\\)");
   private final static Pattern minShouldMatchPattern = Pattern.compile(" \\+minShouldMatch=(\\d+)($| )");
   private final static Pattern constantScorePattern = Pattern.compile(" \\+constantScore($| )");
+  // +searchAfter=<long>: run the sort as a deep-pagination searchAfter with this value as the
+  // `after` sort value (GITHUB#13313). Only meaningful together with a single-field numeric sort.
+  private final static Pattern searchAfterPattern = Pattern.compile(" \\+searchAfter=(-?\\d+)($| )");
   // pattern: taskName term1 term2 term3 term4 +combinedFields=field1^1.0,field2,field3^2.0
   // this pattern doesn't handle all variations of floating numbers, such as .9 , but should be good enough for perf test query parsing purpose
   private final static Pattern combinedFieldsPattern = Pattern.compile(" \\+combinedFields=((\\p{Alnum}+(\\^\\d+.\\d)?,)+\\p{Alnum}+(\\^\\d+.\\d)?)");
@@ -232,6 +236,7 @@ class TaskParser implements Closeable {
     String text;
     boolean doDrillSideways, doHilite, doStoredLoadsTask;
     Sort sort;
+    Long searchAfterValue; // non-null when +searchAfter=<long> was given
     String group;
 
     // this is only set when pulling pre-computed embeddings from file:
@@ -270,6 +275,7 @@ class TaskParser implements Closeable {
       List<String> drillDowns = parseDrillDowns();
       doStoredLoadsTask = TaskParser.this.doStoredLoads;
       parseHilite();
+      searchAfterValue = parseSearchAfter();
       String[] taskAndType = parseTaskType(text);
       String taskType = taskAndType[0];
       text = taskAndType[1];
@@ -280,7 +286,27 @@ class TaskParser implements Closeable {
       Query query = buildQuery(taskType, text, msm);
       Query query2 = applyDrillDowns(query, drillDowns);
       Query query3 = applyFilter(query2, filter);
-      return new SearchTask(category, isCountOnly, query3, sort, group, topN, doHilite, doStoredLoadsTask, facets, null, doDrillSideways);
+      FieldDoc after = buildSearchAfter();
+      return new SearchTask(category, isCountOnly, query3, sort, after, group, topN, doHilite, doStoredLoadsTask, facets, null, doDrillSideways);
+    }
+
+    // Build the `after` FieldDoc for +searchAfter. Only single-field numeric sorts are supported;
+    // the value is boxed as the type the sort's comparator expects (Long/Integer).
+    FieldDoc buildSearchAfter() {
+      if (searchAfterValue == null) {
+        return null;
+      }
+      if (sort == null || sort.getSort().length != 1) {
+        throw new IllegalArgumentException("+searchAfter requires a single-field sort; got: " + sort);
+      }
+      SortField sf = sort.getSort()[0];
+      Object value = switch (sf.getType()) {
+        case LONG -> searchAfterValue;
+        case INT -> Math.toIntExact(searchAfterValue);
+        default -> throw new IllegalArgumentException(
+            "+searchAfter only supports INT/LONG sorts; got: " + sf.getType());
+      };
+      return new FieldDoc(Integer.MAX_VALUE, Float.NaN, new Object[] {value});
     }
 
     String[] parseTaskType(String line) {
@@ -376,6 +402,19 @@ class TaskParser implements Closeable {
         text = (text.substring(0, m2.start(0)) + text.substring(m2.end(0), text.length())).trim();
       }
       return minShouldMatch;
+    }
+
+    Long parseSearchAfter() throws ParseException {
+      final Matcher m = searchAfterPattern.matcher(text);
+      if (m.find()) {
+        long value = Long.parseLong(m.group(1));
+        text = (text.substring(0, m.start(0)) + " " + text.substring(m.end(0), text.length())).trim();
+        if (m.find()) {
+          throw new ParseException("+searchAfter appears more than once in task: " + text);
+        }
+        return value;
+      }
+      return null;
     }
 
     boolean parseConstantScore() throws ParseException {

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -311,7 +311,10 @@ class TaskParser implements Closeable {
         default -> throw new IllegalArgumentException(
             "+searchAfter only supports INT/LONG sorts; got: " + type);
       };
-      return new FieldDoc(Integer.MAX_VALUE, Float.NaN, new Object[] {value});
+      // after.doc must be a real docid: IndexSearcher rejects after.doc >= reader.maxDoc(). Under a
+      // sort it only breaks ties among documents whose sort value equals the `after` value, so 0
+      // means "every tied document is still competitive" -- the deepest page for a given value.
+      return new FieldDoc(0, Float.NaN, new Object[] {value});
     }
 
     String[] parseTaskType(String line) {

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -63,6 +63,7 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSelector;
+import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.TermQuery;
 
@@ -301,11 +302,14 @@ class TaskParser implements Closeable {
         throw new IllegalArgumentException("+searchAfter requires a single-field sort; got: " + sort);
       }
       SortField sf = sort.getSort()[0];
-      Object value = switch (sf.getType()) {
+      // A SortedNumericSortField reports Type.CUSTOM; its element type is on getNumericType().
+      SortField.Type type =
+          sf instanceof SortedNumericSortField snsf ? snsf.getNumericType() : sf.getType();
+      Object value = switch (type) {
         case LONG -> searchAfterValue;
         case INT -> Math.toIntExact(searchAfterValue);
         default -> throw new IllegalArgumentException(
-            "+searchAfter only supports INT/LONG sorts; got: " + sf.getType());
+            "+searchAfter only supports INT/LONG sorts; got: " + type);
       };
       return new FieldDoc(Integer.MAX_VALUE, Float.NaN, new Object[] {value});
     }

--- a/src/main/perf/TaskParser.java
+++ b/src/main/perf/TaskParser.java
@@ -161,7 +161,8 @@ class TaskParser implements Closeable {
   private final static Pattern minShouldMatchPattern = Pattern.compile(" \\+minShouldMatch=(\\d+)($| )");
   private final static Pattern constantScorePattern = Pattern.compile(" \\+constantScore($| )");
   // +searchAfter=<long>: run the sort as a deep-pagination searchAfter with this value as the
-  // `after` sort value (GITHUB#13313). Only meaningful together with a single-field numeric sort.
+  // `after` sort value (GITHUB#13313). We have only implemented the single-valued numeric case here
+  // (Lucene's searchAfter can handle any sort type).
   private final static Pattern searchAfterPattern = Pattern.compile(" \\+searchAfter=(-?\\d+)($| )");
   // pattern: taskName term1 term2 term3 term4 +combinedFields=field1^1.0,field2,field3^2.0
   // this pattern doesn't handle all variations of floating numbers, such as .9 , but should be good enough for perf test query parsing purpose

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -1804,6 +1804,8 @@ def writeIndexHTML(searchChartData, days, timeStampString):
 
   w("<br><br><b>Sorting with searchAfter / deep pagination (on TermQuery):</b>")
   writeOneLine(w, done, "TermDayOfYearSortSearchAfter", "Day of year (int, medium cardinality, searchAfter)")
+  writeOneLine(w, done, "TermDateTimeSortSearchAfter", "Date/time (long, high cardinality, skewed, searchAfter)")
+  writeOneLine(w, done, "TermDateTimeSortSkipperSearchAfter", "Date/time (long, high cardinality, skewed, skipper, searchAfter)")
 
   w("<br><br><b>Sorting with doc value skippers (on TermQuery):</b>")
   writeOneLine(w, done, "TermDTSortSkipper", "Date/time (long, high cardinality, skipper)")

--- a/src/python/nightlyBench.py
+++ b/src/python/nightlyBench.py
@@ -1802,6 +1802,9 @@ def writeIndexHTML(searchChartData, days, timeStampString):
   writeOneLine(w, done, "TermMonthSort", "Month (string, low cardinality)")
   writeOneLine(w, done, "TermDayOfYearSort", "Day of year (int, medium cardinality)")
 
+  w("<br><br><b>Sorting with searchAfter / deep pagination (on TermQuery):</b>")
+  writeOneLine(w, done, "TermDayOfYearSortSearchAfter", "Day of year (int, medium cardinality, searchAfter)")
+
   w("<br><br><b>Sorting with doc value skippers (on TermQuery):</b>")
   writeOneLine(w, done, "TermDTSortSkipper", "Date/time (long, high cardinality, skipper)")
   writeOneLine(w, done, "TermTitleSortSkipper", "Title (string, high cardinality, skipper)")

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -114,6 +114,19 @@ TermDateTimeSort: lastmodndvsort//nbsp # freq=492778
 TermDateTimeSort: lastmodndvsort//part # freq=588644
 TermDateTimeSort: lastmodndvsort//st # freq=306811
 
+# searchAfter (deep pagination) variant of the lastMod sort. Unlike dayOfYear's uniform 1..366,
+# lastMod is the article revision timestamp and is heavily skewed towards the end of the corpus:
+# enumerated over all 33,332,620 docs of enwiki-20120502, the range is 2002-11-05..2012-05-03 with
+# p50=2012-02-11 and p90=1335623810000 (2012-04-28). 16 equal-width buckets put 68% of the docs in
+# the last one, so a round date much before 2010 would skip almost nothing. p90 is used here as the
+# analogue of dayOfYear's 330/366, keeping a real competitive tail.
+# REGENERATE these values when the corpus is upgraded -- they are specific to enwiki-20120502.
+TermDateTimeSortSearchAfter: lastmodndvsort//0 +searchAfter=1335623810000 # freq=708472
+TermDateTimeSortSearchAfter: lastmodndvsort//names +searchAfter=1335623810000 # freq=402762
+TermDateTimeSortSearchAfter: lastmodndvsort//nbsp +searchAfter=1335623810000 # freq=492778
+TermDateTimeSortSearchAfter: lastmodndvsort//part +searchAfter=1335623810000 # freq=588644
+TermDateTimeSortSearchAfter: lastmodndvsort//st +searchAfter=1335623810000 # freq=306811
+
 TermTitleSort: titledvsort//0 # freq=708472
 TermTitleSort: titledvsort//names # freq=402762
 TermTitleSort: titledvsort//nbsp # freq=492778
@@ -147,6 +160,14 @@ TermDateTimeSortSkipper: lastmodskippersort//names # freq=402762
 TermDateTimeSortSkipper: lastmodskippersort//nbsp # freq=492778
 TermDateTimeSortSkipper: lastmodskippersort//part # freq=588644
 TermDateTimeSortSkipper: lastmodskippersort//st # freq=306811
+
+# Same searchAfter variant against the skip-index encoding, so a pruning change that helps one
+# encoding and not the other is visible. Same p90 value and the same regeneration note.
+TermDateTimeSortSkipperSearchAfter: lastmodskippersort//0 +searchAfter=1335623810000 # freq=708472
+TermDateTimeSortSkipperSearchAfter: lastmodskippersort//names +searchAfter=1335623810000 # freq=402762
+TermDateTimeSortSkipperSearchAfter: lastmodskippersort//nbsp +searchAfter=1335623810000 # freq=492778
+TermDateTimeSortSkipperSearchAfter: lastmodskippersort//part +searchAfter=1335623810000 # freq=588644
+TermDateTimeSortSkipperSearchAfter: lastmodskippersort//st +searchAfter=1335623810000 # freq=306811
 
 TermTitleSortSkipper: titleskippersort//0 # freq=708472
 TermTitleSortSkipper: titleskippersort//names # freq=402762

--- a/tasks/wikinightly.tasks
+++ b/tasks/wikinightly.tasks
@@ -132,6 +132,16 @@ TermDayOfYearSort: dayofyeardvsort//nbsp # freq=492778
 TermDayOfYearSort: dayofyeardvsort//part # freq=588644
 TermDayOfYearSort: dayofyeardvsort//st # freq=306811
 
+# searchAfter (deep pagination) variant of the dayOfYear sort. dayOfYear is 1..366, so
+# +searchAfter=330 asks for the tail of the range: the non-competitive prefix should be
+# skipped via dynamic pruning rather than fully collected. This is the coverage that was
+# missing when apache/lucene#13221 caused the apache/lucene#13856 searchAfter regression.
+TermDayOfYearSortSearchAfter: dayofyeardvsort//0 +searchAfter=330 # freq=708472
+TermDayOfYearSortSearchAfter: dayofyeardvsort//names +searchAfter=330 # freq=402762
+TermDayOfYearSortSearchAfter: dayofyeardvsort//nbsp +searchAfter=330 # freq=492778
+TermDayOfYearSortSearchAfter: dayofyeardvsort//part +searchAfter=330 # freq=588644
+TermDayOfYearSortSearchAfter: dayofyeardvsort//st +searchAfter=330 # freq=306811
+
 TermDateTimeSortSkipper: lastmodskippersort//0 # freq=708472
 TermDateTimeSortSkipper: lastmodskippersort//names # freq=402762
 TermDateTimeSortSkipper: lastmodskippersort//nbsp # freq=492778


### PR DESCRIPTION
Adds `searchAfter` (deep pagination) coverage to the search benchmarks, closing #306.

Today every sort task runs `searcher.search(q, topN, sort)`; there's no `searchAfter` path. That's the blind spot #306 tracks — it's the spinoff from the Lucene 10.0 search-after regression (apache/lucene#13856), where a dynamic-pruning change (apache/lucene#13221) caused a ~10x slowdown on mostly-sorted data that no benchy caught, and was reverted (apache/lucene#13971). This adds the missing signal.

**What it does**

A `+searchAfter=<long>` task modifier, parsed and stripped like the existing `+minShouldMatch` / `+constantScore` directives:

```
TermDayOfYearSortSearchAfter: dayofyeardvsort//st +searchAfter=330
```

- `TaskParser` parses the modifier and builds a `FieldDoc` from the value. Supported for single-field int/long sorts (the numeric dynamic-pruning path); it throws for anything else.
- `SearchTask` threads the `FieldDoc` through and calls `searcher.searchAfter(after, q, topN, sort)` when set, else the existing `search(q, topN, sort)`. It's folded into `equals()`/`hashCode()` so cross-run result verification and task de-duplication stay correct.

**Tasks**

Adds a `TermDayOfYearSortSearchAfter` category (5 queries, respecting the per-category cap from #226) to `wikinightly.tasks`, sorting on `dayOfYear` (int, 1..366) with `+searchAfter=330` — the tail of the range, so the non-competitive prefix is exercised by dynamic pruning rather than fully collected.

**A couple of things I wasn't sure about — happy to adjust:**

1. I added one `writeOneLine(...)` in `nightlyBench.py` to display the new category. #583 (`+constantScore`) didn't touch that file, so I kept this as its own final commit — happy to drop it if the report populates another way.
2. I used `dayOfYear` because its range is easy to reason about. `lastMod` (long, msec) is closer to the mostly-sorted timeseries shape from #13856 — I can add a `lastMod` variant too if you'd prefer that (or as well). I wasn't sure of a good deep `after` value for it without seeing the data distribution.

**Testing**

Compiles against current Lucene main; `ruff check --preview` on the changed Python adds no new findings; the `validate_nightly_task_count` cap check passes for the new category; and the task line parses (modifier stripped, sort type preserved). I haven't run it through a full nightly against a real wikimedium index yet — that "first light" is where the interesting part is, so I'd love to see what it shows once it runs.
