### PR TITLE
Fix "File name too long" problem

### DIFF
--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -18,7 +18,6 @@
 import glob
 import hashlib
 import os
-import platform
 import random
 import subprocess
 import time
@@ -273,13 +272,15 @@ class Index:
     name.append("nd%gM" % (self.numDocs / 1000000.0))
     full_name = ".".join(name)
 
-    # On macOS, truncate if the name is too long for the 255-byte filename limit.
-    # Keep a prefix and append a short hash of the full name so it remains unique.
-    if platform.system() == "Darwin":
-      max_len = 200
-      if len(full_name) > max_len:
-        name_hash = hashlib.sha256(full_name.encode()).hexdigest()[:12]
-        full_name = full_name[:max_len] + "." + name_hash
+    # Truncate if the name is too long for the 255-byte filename limit.
+    # The JFR filename typically adds ~34 chars ("bench-index-baseline_vs_patch-" + ".jfr"),
+    # so the index name (including hash suffix) must stay under 255 - 34 = 221 chars.
+    max_name_len = 221
+    hash_len = 5
+    max_prefix = max_name_len - hash_len
+    if len(full_name) > max_name_len:
+      name_hash = hashlib.sha256(full_name.encode()).hexdigest()[:hash_len]
+      full_name = full_name[:max_prefix] + name_hash
 
     return full_name
 


### PR DESCRIPTION
Follow-up to #576.

The filename-too-long problem not only exists on MacOS, but also exists on Linux. When indexing with facet, the index folder name as well as the jfr filename exceeds the limit. Error message:

```
[0.411s][error][jfr,startup] Could not start recording, not able to write to file /local/home/xuzh/workspace/logs/baseline_vs_patch/2026.07.23.14.16.52/bench-index-baseline_vs_patch-wikimediumall.fork_lucene.candidate.facets.taxonomy:Date.taxonomy:Month.taxonomy:DayOfYear.sortedset:Date.sortedset:Month.sortedset:DayOfYear.taxonomy:RandomLabel.sortedset:RandomLabel.Lucene90.Lucene104.dvfields.nd33.3326M.jfr. /local/home/zhangxuv/workspace/logs/baseline_vs_patch/2026.07.23.14.16.52/bench-index-baseline_vs_patch-wikimediumall.fork_lucene.candidate.facets.taxonomy:Date.taxonomy:Month.taxonomy:DayOfYear.sortedset:Date.sortedset:Month.sortedset:DayOfYear.taxonomy:RandomLabel.sortedset:RandomLabel.Lucene90.Lucene104.dvfields.nd33.3326M.jfr: File name too long
Error occurred during initialization of VM
Failure when starting JFR on_create_vm_3
```

Validate on linux and mac:
```
~ touch "$(python3 -c "print('a' * 255)")"
~ touch "$(python3 -c "print('a' * 256)")"
touch: cannot touch ‘aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa’: File name too long
```