### PR TITLE
Gracefully skip search benchmark when waitForCommit=False

### DIFF
--- a/src/python/competition.py
+++ b/src/python/competition.py
@@ -558,6 +558,12 @@ class Competition:
       print("Removing old JFR %s..." % fileName)
       os.remove(fileName)
 
+    # If any competitor's index uses waitForCommit=False, the indexer calls rollback() instead of
+    # commit(), so no segments file is written and that index cannot be searched.  Since the search
+    # benchmark needs both indices to compare, skip search but still run indexing.
+    noCommitIndices = [idx.getName() for idx in self.indices if not idx.waitForCommit]
+    canSearch = self.benchSearch and len(noCommitIndices) == 0
+
     base.tasksFile = base.index.dataSource.tasksFile
     challenger.tasksFile = challenger.index.dataSource.tasksFile
 
@@ -567,14 +573,25 @@ class Competition:
       challenger,
       coldRun=self.cold,
       doCharts=self.printCharts,
-      search=self.benchSearch,
+      search=canSearch,
       index=self.benchIndex,
       verifyScores=self.verifyScores,
       verifyCounts=self.verifyCounts,
       taskPatterns=(self.onlyTaskPatterns, self.notTaskPatterns),
       requireOverlap=self.requireOverlap,
       randomSeed=self.randomSeed,
+      skipReport=not canSearch,
     )
+
+    if not canSearch:
+      print()
+      print("WARNING: search benchmark was skipped because the following indices use waitForCommit=False")
+      print("         (no segments file is written — the indexer calls rollback instead of commit):")
+      for name in noCommitIndices:
+        print(f"           - {name}")
+      print("         Set waitForCommit=True to enable search benchmarking.")
+      print()
+
     return self
 
   def clearCompetitors(self):

--- a/src/python/searchBench.py
+++ b/src/python/searchBench.py
@@ -29,7 +29,7 @@ PYTHON_MAJOR_VER = sys.version_info.major
 osName = common.osName
 
 
-def run(id, base, challenger, coldRun=False, doCharts=False, search=False, index=False, verifyScores=True, verifyCounts=True, taskPatterns=None, randomSeed=None, requireOverlap=1.0):
+def run(id, base, challenger, coldRun=False, doCharts=False, search=False, index=False, verifyScores=True, verifyCounts=True, taskPatterns=None, randomSeed=None, requireOverlap=1.0, skipReport=False):
   competitors = [challenger, base]
 
   if randomSeed is None:
@@ -192,7 +192,7 @@ def run(id, base, challenger, coldRun=False, doCharts=False, search=False, index
         print(f"\n{mode.upper()} merged search profile for {c.name}:")
         print(c.getAggregateProfilerResult(id, mode, stackSize=12)[0][1])
 
-  else:
+  elif not skipReport:
     results = {}
     for c in competitors:
       results[c] = r.getSearchLogFiles(id, c)


### PR DESCRIPTION

When waitForCommit=False, the Indexer calls rollback() instead of commit(), so no segments_* file is written to disk, the search benchmark fails with below error:
```
Exception in thread "main" org.apache.lucene.index.IndexNotFoundException: no segments* file found in MMapDirectory@/local/home/xuzh/workspace/indices/wikimedium10k.fork_lucene.candidate.facets.taxonomy:Date.taxonomy:Month.taxonomy:DayOfYear.sortedset:Date.sortedset:Month.sortedset:DayOfYear.taxonomy:RandomLabel.sortedset:RandomLabel.Lucene90.Lucene104.dvfields.nd0.01M/index lockFactory=org.apache.lucene.store.NativeFSLockFactory@6e9319f: files: [write.lock]
	at org.apache.lucene.index.SegmentInfos$FindSegmentsFile.run(SegmentInfos.java:822)
	at org.apache.lucene.index.SegmentInfos$FindSegmentsFile.run(SegmentInfos.java:778)
	at org.apache.lucene.index.SegmentInfos.readLatestCommit(SegmentInfos.java:561)
	at org.apache.lucene.index.DirectoryReader.listCommits(DirectoryReader.java:449)
	at perf.PerfUtils.findCommitPoint(PerfUtils.java:41)
	at perf.SearchPerfTest._main(SearchPerfTest.java:533)
	at perf.SearchPerfTest.main(SearchPerfTest.java:145)
Traceback (most recent call last):
  File "/local/home/xuzh/workspace/luceneutil_fork/src/python/localrun.py", line 93, in <module>
    comp.benchmark("baseline_vs_patch")
  File "/local/home/xuzh/workspace/luceneutil_fork/src/python/competition.py", line 564, in benchmark
    searchBench.run(
  File "/local/home/xuzh/workspace/luceneutil_fork/src/python/searchBench.py", line 172, in run
    logFile = r.runSimpleSearchBench(iter, id, c, coldRun, seed, staticSeed, filter=None, taskPatterns=taskPatterns)
  File "/local/home/xuzh/workspace/luceneutil_fork/src/python/benchUtil.py", line 1324, in runSimpleSearchBench
    raise RuntimeError("SearchPerfTest failed; see log %s.stdout" % logFile)
RuntimeError: SearchPerfTest failed; see log /local/home/xuzh/workspace/logs/baseline_vs_patch.my_modified_version.0.stdout
```

This PR gracefully skips search while still allowing indexing to run fully for both baseline and candidate. So after this PR, it shows something like below:
```
WARNING: search benchmark was skipped because the following indices use waitForCommit=False
         (no segments file is written — the indexer calls rollback instead of commit):
           - wikimedium10k.lucene.facets.taxonomy:Date.taxonomy:Month.taxonomy:DayOfYear.sortedset:Date.sortedset:Month.sortedset:DayOfYear.taxonomy:RandomLabel.sortedset:RandomLabel.Lucene90.Lucene104.dvfields.nd0.01M
           - wikimedium10k.fork_lucene.candidate.facets.taxonomy:Date.taxonomy:Month.taxonomy:DayOfYear.sortedset:Date.sortedset:Month.sortedset:DayOfYear.taxonomy:RandomLabel.sortedset:RandomLabel.Lucene90.Lucene104.dvfields.nd0.01M
         Set waitForCommit=True to enable search benchmarking.
```


The background is that I wanted to benchmark pure indexing throughput, the cost of repeated flushes without interference of merges and/or a final commit. To achieve this, I configured `localrun.py` with, waitForMerges=False, waitForCommit=False, mergePolicy="NoMergePolicy".

```

  index = comp.newIndex(
    args.baseline,
    sourceData,
	facets=(
	  ("taxonomy:Date", "Date"),
	  ("taxonomy:Month", "Month"),
	  ("taxonomy:DayOfYear", "DayOfYear"),
	  ("sortedset:Date", "Date"),
	  ("sortedset:Month", "Month"),
	  ("sortedset:DayOfYear", "DayOfYear"),
	  ("taxonomy:RandomLabel", "RandomLabel"),
	  ("sortedset:RandomLabel", "RandomLabel"),
	),
	postingsFormat="Lucene104",
	idFieldPostingsFormat="Lucene104",
	directory="MMapDirectory",
	ramBufferMB=2048,
	waitForMerges=False,
	waitForCommit=False,
	grouping=False,
	verbose=True,
	mergePolicy="NoMergePolicy",
	useCMS=False,
  )

  # create a competitor named baseline with sources in the ../trunk folder
  comp.competitor("baseline", args.baseline, index=index, searchConcurrency=args.searchConcurrency)

  # use the same index as baseline unless --reindex was passed.
  # create a competitor named my_modified_version (or provided candidate name) with sources in the ../patch folder
  # if --reindex flag is not used, luceneutil will automatically use the index from the base competitor for searching
  # while the codec that is used for running this competitor is taken from this competitor.
  candidate_index = index
  if args.reindex:
    candidate_index = comp.newIndex(
      args.candidate,
      sourceData,
      # addDVFields=True,
      extraNamePart="candidate",
      facets=(
        ("taxonomy:Date", "Date"),
        ("taxonomy:Month", "Month"),
        ("taxonomy:DayOfYear", "DayOfYear"),
        ("sortedset:Date", "Date"),
        ("sortedset:Month", "Month"),
        ("sortedset:DayOfYear", "DayOfYear"),
        ("taxonomy:RandomLabel", "RandomLabel"),
        ("sortedset:RandomLabel", "RandomLabel"),
      ),
      postingsFormat="Lucene104",
      idFieldPostingsFormat="Lucene104",
      directory="MMapDirectory",
      ramBufferMB=2048,
      waitForMerges=False,
      waitForCommit=False,
      grouping=False,
      verbose=True,
      mergePolicy="NoMergePolicy",
      useCMS=False,
    )
  comp.competitor("my_modified_version", args.candidate, index=candidate_index, searchConcurrency=args.searchConcurrency)

  # start the benchmark - this can take long depending on your index and machines
  comp.benchmark("baseline_vs_patch")
```
