### PR TITLE
Fix exact NN key for `filterStrategy = query-time-pre-filter`

### DIFF
--- a/src/main/knn/KnnGraphTester.java
+++ b/src/main/knn/KnnGraphTester.java
@@ -1052,9 +1052,9 @@ public class KnnGraphTester implements FormatterLogger {
   }
 
   // static so we are forced to pass in all things that are volatile wrt indexing (if they change, it requires reindexing)
-  private static String formatExactNNKey(boolean parentJoin, FilterStrategy filterStrategy, Float filterSelectivity,
-                                         Long randomSeed, Path docPath, Path queryVectorsPath, int numDocs, String metric,
-                                         int numQueryVectors, int queryStartIndex, SearchType searchType, int topK, float resultSimilarity) {
+  private static String formatExactNNKey(boolean parentJoin, Float filterSelectivity, Long randomSeed, Path docPath,
+                                         Path queryVectorsPath, int numDocs, String metric, int numQueryVectors,
+                                         int queryStartIndex, SearchType searchType, int topK, float resultSimilarity) {
     List<String> suffix = new ArrayList<>();
     suffix.add(metric);
 
@@ -1074,8 +1074,7 @@ public class KnnGraphTester implements FormatterLogger {
       suffix.add("parentJoin");
     }
 
-    if (filterStrategy == FilterStrategy.INDEX_TIME_FILTER) {
-      suffix.add(filterStrategy.toString());
+    if (filterSelectivity != null) {
       suffix.add(filterSelectivity.toString());
       suffix.add(String.valueOf(randomSeed));
     }
@@ -1756,8 +1755,7 @@ public class KnnGraphTester implements FormatterLogger {
                              Path queryPath, int queryStartIndex,
                              String metric) throws IOException, InterruptedException {
 
-    String exactNNKey = formatExactNNKey(parentJoin,
-                                         filterStrategy, filterSelectivity, randomSeed, docPath, queryPath, numDocs, metric,
+    String exactNNKey = formatExactNNKey(parentJoin, filterSelectivity, randomSeed, docPath, queryPath, numDocs, metric,
                                          numQueryVectors, queryStartIndex, searchType, topK, resultSimilarity);
 
     log("exact nn key = %s\n", exactNNKey);


### PR DESCRIPTION
### TL;DR

This PR fixes the baseline exact NN used for `filterStrategy = query-time-pre-filter`.

### Description

Fix exact NN key to **always** include `filterSelectivity` and `seed` (and **not** `filterStrategy` dependent).

A bit of history: the `index-time-filter` option was added in #468 to create an explicit HNSW graph for a subset of documents (selected by `filterSelectivity`).

At the time, the exact NN key (correctly) [included](https://github.com/kaivalnp/luceneutil/blob/9fabbfd939c3a8ae51c5e1f689941168302437b0/src/main/knn/KnnGraphTester.java#L1134-L1135) `filterSelectivity` and `seed` (see `filterSelectivity == null ? 0 : Objects.hash(filterSelectivity, randomSeed)` clause).

In a later [refactor](https://github.com/mikemccand/luceneutil/commit/1cc34623ee474edd071d4c6f0c9b074612cea274) - the key was made explicit, and started mirroring the [index key](https://github.com/kaivalnp/luceneutil/blob/77c92659bb19d82f83d467f5fda0889b607c9540/src/main/knn/KnnGraphTester.java#L987). This introduced a bug because [an index is different for different `filterSelectivity` / `seed` when `index-time-filter` is used, but **not** for `query-time-pre-filter`](https://github.com/kaivalnp/luceneutil/blob/77c92659bb19d82f83d467f5fda0889b607c9540/src/main/knn/KnnGraphTester.java#L1009-L1011).

As a consequence, an exact NN result is created by the _first_ run of `query-time-pre-filter`, and is silently re-used by further runs, even when they have a different `resultSimilarity` / `seed` (i.e. different filtered document set).

### Benchmarks

`main`

```
visited  filterSelectivity  recall  latency(ms)  netCPU  avgCpuCount
   4446               0.90   0.998        1.199   1.198        0.999
   3902               0.50   0.545        0.940   0.939        0.999
    913               0.10   0.104        0.175   0.174        0.995
```

This PR (re-uses built index from `main`)

```
visited  filterSelectivity  recall  latency(ms)  netCPU  avgCpuCount
   4446               0.90   0.998        1.231   1.230        0.999
   3902               0.50   0.998        0.955   0.954        0.999
    913               0.10   1.000        0.166   0.165        0.995
```